### PR TITLE
Fix GitHub pipeline

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install requirements
         run: sudo apt-get install gcc-mipsel-linux-gnu

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install requirements
         run: sudo apt-get install gcc-mipsel-linux-gnu

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
       - name: Install requirements
         run: sudo apt-get install gcc-mipsel-linux-gnu
-      - name: Downgrade binutils
-        run: |
-          curl -L -o binutils-mipsel-linux-gnu_2.35.2-2cross2_amd64.deb http://ftp.de.debian.org/debian/pool/main/b/binutils-mipsen/binutils-mipsel-linux-gnu_2.35.2-2cross2_amd64.deb
-          sudo dpkg -i binutils-mipsel-linux-gnu_2.35.2-2cross2_amd64.deb
-          rm binutils-mipsel-linux-gnu_2.35.2-2cross2_amd64.deb
       - name: Clone main repository
         uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ update-dependencies: require-tools $(M2CTX_APP) $(M2C_APP)
 $(SPLAT_APP):
 	git submodule init $(SPLAT_DIR)
 	git submodule update $(SPLAT_DIR)
-	pip3 install -r $(SPLAT_DIR)/requirements.txt
+	pip3 install -r $(TOOLS_DIR)/requirements-python.txt
 $(ASMDIFFER_APP):
 	git submodule init $(ASMDIFFER_DIR)
 	git submodule update $(ASMDIFFER_DIR)

--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -1,4 +1,3 @@
--r n64splat/requirements.txt
 pre-commit
 black
 pycparser
@@ -8,3 +7,16 @@ intervaltree
 colorama
 python-Levenshtein
 cxxfilt
+
+# Temporarily commenting this one as spimdiasm 1.9.1 is broken
+# -r n64splat/requirements.txt
+PyYAML
+pylibyaml
+tqdm
+intervaltree
+colorama
+spimdisasm==1.9.0
+rabbitizer>=1.4.0
+pygfxd
+n64img>=0.1.2
+# Remove all of this once 1.9.2 or later fixes the problem


### PR DESCRIPTION
Creates a workaround to force using spimdisasm 1.9.0 as 1.9.1 currently breaks the repo