### PR TITLE
Decompile func_8018e1c0

### DIFF
--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -126,7 +126,12 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E118);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E160);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E1C0);
+void func_8018E1C0(s32 arg0) {
+    g_CurrentEntity->step = arg0 & 0xFF;
+    g_CurrentEntity->unk2E = 0;
+    g_CurrentEntity->animFrameIdx = 0;
+    g_CurrentEntity->animFrameDuration = 0;
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E1E0);
 


### PR DESCRIPTION
This function is a duplicate of func_80194EA4 in CEN, along with several others.