### PR TITLE
Match func 8018ef78

### DIFF
--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -167,7 +167,7 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EE84);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EF28);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EF78);
+void func_8018EF78(void) { func_8018D580(g_CurrentEntity); }
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EFA0);
 

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -972,7 +972,7 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B615C);
 
 void func_801B61D4(void) {}
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B61DC);
+void func_801B61DC(void) { DestroyEntity(g_CurrentEntity); }
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B6204);
 

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -976,7 +976,7 @@ void func_801B61DC(void) { DestroyEntity(g_CurrentEntity); }
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B6204);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B6314);
+void func_801B6314(void) { DestroyEntity(g_CurrentEntity); }
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B633C);
 


### PR DESCRIPTION
Match the following functions, which are all duplicates of previously decompiled functions:
- RWRP - func_8018EF78
- ST0  - func_801B61DC
- ST0  - func_801B6314