### PR TITLE
Match func_801bafec

### DIFF
--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -121,8 +121,10 @@ void func_80192D30(s16 arg0) {
 
 void func_80192D7C(s16 arg0) {
     while (true) {
-        if (((D_8019C764->posX != 0xFFFF) &&
-             ((arg0 >= D_8019C764->posX) || (D_8019C764->posX == 0xFFFE)))) {
+        if (
+            ((D_8019C764->posX != 0xFFFF) &&
+            ((arg0 >= D_8019C764->posX) || (D_8019C764->posX == 0xFFFE)))
+        ) {
             break;
         }
         D_8019C764--;
@@ -145,8 +147,10 @@ void func_80192FE4(s16 arg0) {
 
 void func_80193030(s16 arg0) {
     while (true) {
-        if (((D_8019C768->posY != 0xFFFF) &&
-             ((arg0 >= D_8019C768->posY) || (!(D_8019C768->posY != 0xFFFE))))) {
+        if (
+            (D_8019C768->posY != 0xFFFF) &&
+            ((arg0 >= D_8019C768->posY) || !(D_8019C768->posY != 0xFFFE))
+        ) {
             break;
         }
         D_8019C768--;

--- a/src/st/dre/14214.c
+++ b/src/st/dre/14214.c
@@ -335,12 +335,12 @@ void func_80198E74(s16 arg0) {
 }
 
 void func_80198EC0(s16 arg0) {
-    while (1) {
-        if (D_801A32C4->posX != 0xFFFF) {
-            if ((arg0 >= (s32)D_801A32C4->posX) ||
-                (D_801A32C4->posX == 0xFFFE)) {
-                break;
-            }
+    while (true) {
+        if (
+            (D_801A32C4->posX != 0xFFFF) &&
+            ((arg0 >= (s32)D_801A32C4->posX) || (D_801A32C4->posX == 0xFFFE))
+        ) {
+            break;
         }
         D_801A32C4--;
     }
@@ -361,12 +361,12 @@ void func_80199128(s16 arg0) {
 }
 
 void func_80199174(s16 arg0) {
-    while (1) {
-        if (D_801A32C8->posY != 0xFFFF) {
-            if (((s32)arg0 >= D_801A32C8->posY) ||
-                (D_801A32C8->posY == 0xFFFE)) {
-                break;
-            }
+    while (true) {
+        if (
+            (D_801A32C8->posY != 0xFFFF) &&
+            (((s32)arg0 >= D_801A32C8->posY) || (D_801A32C8->posY == 0xFFFE))
+        ) {
+            break;
         }
         D_801A32C8--;
     }

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -376,16 +376,15 @@ loop_1:
     }
 }
 
-void func_80190884(s32 arg0) {
-    s32 a2, a3;
-    a3 = 0xFFFF;
-    arg0 = (s16)arg0;
-    a2 = 0xFFFE;
-loop_1:
-    if ((D_801997D8->posX == a3) ||
-        ((arg0 < D_801997D8->posX) && (D_801997D8->posX != a2))) {
+void func_80190884(s16 arg0) {
+    while (true) {
+        if (
+            (D_801997D8->posX != 0xFFFF) &&
+            ((arg0 >= (s32)D_801997D8->posX) || (D_801997D8->posX == 0xFFFE))
+        ) {
+            break;
+        }
         D_801997D8--;
-        goto loop_1;
     }
 }
 
@@ -428,12 +427,13 @@ loop_1:
 
 void func_80190B24(s16 arg0) {
     while (true) {
-        if (D_801997DC->posY == 0xFFFF)
-            D_801997DC--;
-        else if (arg0 >= (s32)D_801997DC->posY || D_801997DC->posY == 0xFFFE)
+        if (
+            (D_801997DC->posY != 0xFFFF) &&
+            ((arg0 >= D_801997DC->posY || D_801997DC->posY == 0xFFFE))
+        ) {
             break;
-        else
-            D_801997DC--;
+        }
+        D_801997DC--;
     }
 }
 

--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -424,8 +424,10 @@ void func_801C3730(s16 arg0) {
 
 void func_801C377C(s16 arg0) {
     while (true) {
-        if ((D_801D7110->posX == (u16)~0) ||
-            ((arg0 < D_801D7110->posX) && (D_801D7110->posX != (u16)~1))) {
+        if (
+            (D_801D7110->posX == (u16)~0) ||
+            ((arg0 < D_801D7110->posX) && (D_801D7110->posX != (u16)~1))
+        ) {
             D_801D7110--;
         } else {
             break;

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -989,7 +989,18 @@ INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAE88);
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAFA0);
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAFEC);
+extern LayoutObject* D_801D2768;
+
+void func_801BAFEC(s16 arg0) {
+    while (true) {
+        if ((D_801D2768->posX != 0xFFFF) &&
+            ((arg0 >= D_801D2768->posX) || (D_801D2768->posX == 0xFFFE))
+        ) {
+            break;
+        }
+        D_801D2768--;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BB044);
 

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -992,7 +992,8 @@ INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAFA0);
 extern LayoutObject* D_801D2768;
 void func_801BAFEC(s16 arg0) {
     while (true) {
-        if ((D_801D2768->posX != 0xFFFF) &&
+        if (
+            (D_801D2768->posX != 0xFFFF) &&
             ((arg0 >= D_801D2768->posX) || (D_801D2768->posX == 0xFFFE))
         ) {
             break;
@@ -1017,7 +1018,8 @@ void func_801BB254(s16 arg0) {
 extern LayoutObject* D_801D276C;
 void func_801BB2A0(s16 arg0) {
     while (true) {
-        if ((D_801D276C->posY != 0xFFFF) &&
+        if (
+            (D_801D276C->posY != 0xFFFF) &&
             ((arg0 >= D_801D276C->posY) || (D_801D276C->posY == 0xFFFE))
         ) {
             break;

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -990,7 +990,6 @@ INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAE88);
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAFA0);
 
 extern LayoutObject* D_801D2768;
-
 void func_801BAFEC(s16 arg0) {
     while (true) {
         if ((D_801D2768->posX != 0xFFFF) &&
@@ -1015,7 +1014,17 @@ void func_801BB254(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BB2A0);
+extern LayoutObject* D_801D276C;
+void func_801BB2A0(s16 arg0) {
+    while (true) {
+        if ((D_801D276C->posY != 0xFFFF) &&
+            ((arg0 >= D_801D276C->posY) || (D_801D276C->posY == 0xFFFE))
+        ) {
+            break;
+        }
+        D_801D276C--;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BB2F8);
 

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -1320,8 +1320,10 @@ void func_801BB3B8(s16 arg0) {
 
 void func_801BB404(s16 arg0) {
     while (true) {
-        if (!(D_801CAA74->posX == 0xFFFF) &&
-            (((s32)arg0 >= D_801CAA74->posX) || (D_801CAA74->posX == 0xFFFE))) {
+        if (
+            !(D_801CAA74->posX == 0xFFFF) &&
+            (((s32)arg0 >= D_801CAA74->posX) || (D_801CAA74->posX == 0xFFFE))
+        ) {
             break;
         }
         D_801CAA74--;

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -55,7 +55,17 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C1EC);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C300);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C34C);
+extern LayoutObject* D_80195A34;
+void func_8018C34C(s16 arg0) {
+    while (true) {
+        if ((D_80195A34->posY != 0xFFFF) &&
+            ((arg0 >= D_80195A34->posY) || (D_80195A34->posY == 0xFFFE))
+        ) {
+            break;
+        }
+        D_80195A34--;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C3A4);
 

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -37,7 +37,17 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018BF34);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C04C);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C098);
+extern LayoutObject* D_80195A30;
+void func_8018C098(s16 arg0) {
+    while (true) {
+        if ((D_80195A30->posX != 0xFFFF) &&
+            ((arg0 >= D_80195A30->posX) || (D_80195A30->posX == 0xFFFE))
+        ) {
+            break;
+        }
+        D_80195A30--;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C0F0);
 

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -40,7 +40,8 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C04C);
 extern LayoutObject* D_80195A30;
 void func_8018C098(s16 arg0) {
     while (true) {
-        if ((D_80195A30->posX != 0xFFFF) &&
+        if (
+            (D_80195A30->posX != 0xFFFF) &&
             ((arg0 >= D_80195A30->posX) || (D_80195A30->posX == 0xFFFE))
         ) {
             break;
@@ -58,7 +59,8 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C300);
 extern LayoutObject* D_80195A34;
 void func_8018C34C(s16 arg0) {
     while (true) {
-        if ((D_80195A34->posY != 0xFFFF) &&
+        if (
+            (D_80195A34->posY != 0xFFFF) &&
             ((arg0 >= D_80195A34->posY) || (D_80195A34->posY == 0xFFFE))
         ) {
             break;

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -831,7 +831,17 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3574);
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3688);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B36D4);
+extern LayoutObject* D_801C00A4;
+void func_801B36D4(s16 arg0) {
+    while (true) {
+        if ((D_801C00A4->posY != 0xFFFF) &&
+            ((arg0 >= D_801C00A4->posY) || (D_801C00A4->posY == 0xFFFE))
+        ) {
+            break;
+        }
+        D_801C00A4--;
+    }
+}
 
 void func_801B372C(s16);
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B372C);

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -811,7 +811,17 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B32BC);
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B33D4);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3420);
+extern LayoutObject* D_801C00A0;
+void func_801B3420(s16 arg0) {
+    while (true) {
+        if ((D_801C00A0->posX != 0xFFFF) &&
+            ((arg0 >= D_801C00A0->posX) || (D_801C00A0->posX == 0xFFFE))
+        ) {
+            break;
+        }
+        D_801C00A0--;
+    }
+}
 
 void func_801B3478(s16);
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3478);

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -814,7 +814,8 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B33D4);
 extern LayoutObject* D_801C00A0;
 void func_801B3420(s16 arg0) {
     while (true) {
-        if ((D_801C00A0->posX != 0xFFFF) &&
+        if (
+            (D_801C00A0->posX != 0xFFFF) &&
             ((arg0 >= D_801C00A0->posX) || (D_801C00A0->posX == 0xFFFE))
         ) {
             break;
@@ -834,7 +835,8 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3688);
 extern LayoutObject* D_801C00A4;
 void func_801B36D4(s16 arg0) {
     while (true) {
-        if ((D_801C00A4->posY != 0xFFFF) &&
+        if (
+            (D_801C00A4->posY != 0xFFFF) &&
             ((arg0 >= D_801C00A4->posY) || (D_801C00A4->posY == 0xFFFE))
         ) {
             break;


### PR DESCRIPTION
Match the following functions, which are all duplicates of previously matched functions:

```
- NP3 - func_801BAFEC
- NP3 - func_801BB2A0
- ST0 - func_801B3420
- ST0 - func_801B36D4
- RWRP - func_8018C098
- RWRP - func_8018C34C
```

Other matching duplicates have also been refactored and/or reformatted.
