### PR TITLE
Match func_801AC084

### DIFF
--- a/src/st/sel/2C048.c
+++ b/src/st/sel/2C048.c
@@ -34,10 +34,7 @@ void SetupFileChoose(void) {
     g_MemCardSelectorY = 0;
 }
 
-#ifndef NON_EQUIVALENT
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/2C048", func_801AC084);
-#else
-// Those arrays are weird. They do not store s32 but they are used as such.
+// These arrays are weird. They do not store s32 but they are used as such.
 extern s32 D_80180068[];
 extern s32 D_80180088[];
 extern s32 D_801800A8[];
@@ -46,24 +43,22 @@ extern s32 D_801800E8[];
 extern s32 D_80180108[];
 
 void func_801AC084(s32 arg0, s32 ypos) {
-    POLY_GT4* poly = &g_PrimBuf[D_801BAF18[arg0].unk0];
+    Primitive* prim = &g_PrimBuf[D_801BAF18[arg0].unk0];
     s32 i;
-
     for (i = 0; i < 8; i++) {
-        poly->x0 = D_80180068[i] + 0x68;
-        poly->y0 = D_80180088[i] + 0x58 + ypos;
-        poly->u0 = D_801800A8[i];
-        poly->v0 = D_801800C8[i];
-        poly->u1 = D_801800E8[i];
-        poly->tpage = 0xC;
-        poly->clut = 0x200;
-        poly->pad2 = 0x11;
-        poly->pad3 = 8;
-        poly->v1 = D_80180108[i];
-        poly = (POLY_GT4*)poly->tag;
+        prim->x0 = LOH(D_80180068[i]) + 0x68;
+        prim->y0 = LOH(D_80180088[i]) + 0x58 + ypos;
+        prim->u0 = LOBU(D_801800A8[i]);
+        prim->v0 = LOBU(D_801800C8[i]);
+        prim->u1 = LOBU(D_801800E8[i]);
+        prim->v1 = LOBU(D_80180108[i]);
+        prim->tpage = 0xC;
+        prim->clut = 0x200;
+        prim->priority = 0x11;
+        prim->blendMode = 8;
+        prim = prim->next;
     }
 }
-#endif
 
 INCLUDE_ASM("asm/us/st/sel/nonmatchings/2C048", func_801AC174);
 


### PR DESCRIPTION
This function was previously marked as NON_EQUIVALENT. The `LOH(x)` and `LOBU(x)` hacks were used to make it match.
Special props to @sonicdcer and @Xeeynamo for all their help.