### PR TITLE
Add scratch scraping to function_finder

### DIFF
--- a/tools/function_finder.py
+++ b/tools/function_finder.py
@@ -4,6 +4,41 @@
 from pathlib import Path
 from tabulate import tabulate
 import os
+import requests
+import json
+import time
+import concurrent.futures
+
+# search for scratches with the name on decomp.me
+def find_scratches(name):
+    # avoid hitting server too hard
+    time.sleep(1)
+
+    scratches = json.loads(requests.get(f"https://decomp.me/api/scratch?search={name}").text)
+
+    best_result = None
+    best_percent = 0
+
+    for result in scratches['results']:
+        # seems to give approximate matches, skip these
+        if result['name'] != name:
+            continue
+        if result['platform'] != 'ps1':
+            continue
+
+        score = result['score']
+        max_score = result['max_score']
+        percent = (max_score - score) / max_score
+
+        if percent > best_percent:
+            best_percent = percent
+            best_result = result
+        percent = round(percent,3)
+
+    if best_result:
+        return [f"https://decomp.me{best_result['url']}", round(best_percent,3)]
+
+    return None
 
 # look in asm files, read in the text and check for branches and jump tables
 def get_asm_files(asm_path):
@@ -78,6 +113,18 @@ def get_c_files(c_path):
                 files.append([path, func_name.strip(), address.strip()])
     return files
 
+def find_wip(o):
+    if o[4] == "":
+        name = o[0]
+        # look for a WIP on decomp.me
+        function_name = os.path.basename(name).split('.')[0]
+        result = find_scratches(function_name)
+
+        if result:
+            return f"{result[0]} (Scraped {result[1]})"
+
+    return ""
+
 if __name__ == '__main__':
     asm_files = get_asm_files('asm/us')
     c_files = get_c_files('src')
@@ -110,6 +157,17 @@ if __name__ == '__main__':
                 wip = c_file[2]
 
         output.append([str(name).replace("asm/", ""), length, branches, jump_table, wip])
+
+    # we are mostly waiting on IO so run in parallel
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [executor.submit(find_wip, o) for o in output]
+        results = [f.result() for f in futures]
+
+    # Update output with the results
+    for i, o in enumerate(output):
+        # keep the in-source results as definitive
+        if o[4] == "":
+            o[4] = results[i]
 
     headers = ['Filename', 'Length', 'Branches', 'Jtbl', 'Decomp.me WIP']
     print(tabulate(output, headers=headers))

--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -9,5 +9,6 @@ python-Levenshtein
 cxxfilt
 mapfile-parser>=1.1.3<2.0.0
 tabulate
+requests
 
 -r n64splat/requirements.txt


### PR DESCRIPTION
This adds the ability to scrape decomp.me for functions. We just look for ps1 and the same function name so collisions are possible. The in-source entries are considered definitive and scraped entries are labeled in the output so that it's known they may be less reliable. There's many scratches that we don't have labeled in the source so this should help avoid duplicated effort.

Here's an example of the output:

https://gist.github.com/sozud/2fa067f9434a326020f09f8fe6a2e75d