### PR TITLE
Match duplicates of EntityRoomForeground

### DIFF
--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -751,7 +751,30 @@ void EntityEnemyBlood(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", EntityUnkId08);
+extern u16 D_80180458;
+extern ObjInit2 D_8018125C[];
+void EntityUnkId08(Entity* entity) {
+    ObjInit2* objInit;
+
+    objInit = &D_8018125C[entity->subId];
+    if (entity->step == 0) {
+        InitializeEntity(&D_80180458);
+        entity->animSet = objInit->animSet;
+        entity->zPriority = objInit->zPriority;
+        entity->unk5A = objInit->unk4.s;
+        entity->palette = objInit->palette;
+        entity->unk19 = objInit->unk8;
+        entity->blendMode = objInit->blendMode;
+        if (objInit->unkC != 0) {
+            entity->flags = objInit->unkC;
+        }
+        if (entity->subId >= 5) {
+            entity->unk1E = 0x800;
+            entity->unk19 = (u8)(entity->unk19 | 4);
+        }
+    }
+    func_80194394(objInit->unk10, entity);
+}
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_8019BBA4);
 

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -247,7 +247,30 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80194590);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80194924);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80194DD4);
+extern u16 D_80180494[];
+extern ObjInit2 D_80181134[];
+void func_80194DD4(Entity* entity) {
+    ObjInit2* objInit;
+
+    objInit = &D_80181134[entity->subId];
+    if (entity->step == 0) {
+        func_8018E290(D_80180494);
+        entity->animSet = objInit->animSet;
+        entity->zPriority = objInit->zPriority;
+        entity->unk5A = objInit->unk4.s;
+        entity->palette = objInit->palette;
+        entity->unk19 = objInit->unk8;
+        entity->blendMode = objInit->blendMode;
+        if (objInit->unkC != 0) {
+            entity->flags = objInit->unkC;
+        }
+        if (entity->subId >= 5) {
+            entity->unk1E = 0x800;
+            entity->unk19 = (u8)(entity->unk19 | 4);
+        }
+    }
+    func_8018D6B0(objInit->unk10, entity);
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80194EC0);
 


### PR DESCRIPTION
Match the following functions, which are all duplicates of EntityRoomForeground found in other areas:

- CEN - EntityUnkId08
- RWRP - func_80194DD4