### PR TITLE
Match CEN and DRE duplicates of CreateEntityWhenIn functions

### DIFF
--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -141,7 +141,43 @@ void func_80192B00(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80192C18);
+void func_80192C18(LayoutObject* layoutObj) {
+    s16 xClose;
+    s16 xFar;
+    s16 posX;
+    Entity* entity;
+
+    posX = g_Camera_posX_i_hi;
+    xClose = posX - 0x40;
+    xFar = posX + 0x140;
+    if (xClose < 0) {
+        xClose = 0;
+    }
+
+    posX = layoutObj->posX;
+    if (posX < xClose) {
+        return;
+    }
+
+    if (xFar < posX) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            func_80192A3C(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        func_80192A3C(entity, layoutObj);
+        break;
+    }
+}
 
 void func_80192D30(s16 arg0) {
     while (1) {

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -103,7 +103,43 @@ INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", EntityNumericDamage);
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80192A3C);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80192B00);
+void func_80192B00(LayoutObject* layoutObj) {
+    s16 yClose;
+    s16 yFar;
+    s16 posY;
+    Entity* entity;
+
+    posY = g_Camera_posY_i_hi;
+    yClose = posY - 0x40;
+    yFar = posY + 0x120;
+    if (yClose < 0) {
+        yClose = 0;
+    }
+
+    posY = layoutObj->posY;
+    if (posY < yClose) {
+        return;
+    }
+
+    if (yFar < posY) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            func_80192A3C(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        func_80192A3C(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80192C18);
 

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -25,5 +25,6 @@ extern s16 D_8019D38A;
 extern s8 D_8019D38E;
 extern s8 D_8019D38F;
 void func_80192A3C(Entity*, LayoutObject*);
+extern u16 g_Camera_posX_i_hi;
 extern u16 g_Camera_posY_i_hi;
 #endif

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -24,4 +24,6 @@ extern s16 D_8019D386;
 extern s16 D_8019D38A;
 extern s8 D_8019D38E;
 extern s8 D_8019D38F;
+void func_80192A3C(Entity*, LayoutObject*);
+extern u16 g_Camera_posY_i_hi;
 #endif

--- a/src/st/dre/14214.c
+++ b/src/st/dre/14214.c
@@ -358,7 +358,43 @@ void func_80198C44(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/14214", func_80198D5C);
+void func_80198D5C(LayoutObject* layoutObj) {
+    s16 xClose;
+    s16 xFar;
+    s16 posX;
+    Entity* entity;
+
+    posX = g_Camera_posX_i_hi;
+    xClose = posX - 0x40;
+    xFar = posX + 0x140;
+    if (xClose < 0) {
+        xClose = 0;
+    }
+
+    posX = layoutObj->posX;
+    if (posX < xClose) {
+        return;
+    }
+
+    if (xFar < posX) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 void func_80198E74(s16 arg0) {
     while (1) {

--- a/src/st/dre/14214.c
+++ b/src/st/dre/14214.c
@@ -320,7 +320,43 @@ void CreateEntityFromLayout(Entity* entity, LayoutObject* initDesc) {
     entity->unk68 = (initDesc->objectId >> 0xA) & 7;
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/14214", func_80198C44);
+void func_80198C44(LayoutObject* layoutObj) {
+    s16 yClose;
+    s16 yFar;
+    s16 posY;
+    Entity* entity;
+
+    posY = g_Camera_posY_i_hi;
+    yClose = posY - 0x40;
+    yFar = posY + 0x120;
+    if (yClose < 0) {
+        yClose = 0;
+    }
+
+    posY = layoutObj->posY;
+    if (posY < yClose) {
+        return;
+    }
+
+    if (yFar < posY) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/dre/nonmatchings/14214", func_80198D5C);
 

--- a/src/st/dre/dre.h
+++ b/src/st/dre/dre.h
@@ -62,4 +62,5 @@ extern s16 D_801A3F14;
 extern s16 D_801A3F16;
 extern s32 D_801A3F18;
 extern u16 D_801A3F8C[];
+extern u16 g_Camera_posX_i_hi;
 extern u16 g_Camera_posY_i_hi;

--- a/src/st/dre/dre.h
+++ b/src/st/dre/dre.h
@@ -62,3 +62,4 @@ extern s16 D_801A3F14;
 extern s16 D_801A3F16;
 extern s32 D_801A3F18;
 extern u16 D_801A3F8C[];
+extern u16 g_Camera_posY_i_hi;


### PR DESCRIPTION
There are numerous duplicates of the `CreateEntityWhenInVerticalRange` and `CreateEntityWhenInHorizontalRange` functions. This pull request matches the duplicates identified in overlay CEN and DRE:

- CEN  - func_80192B00
- CEN  - func_80192C18
- DRE  - func_80198C44
- DRE  - func_80198D5C