### PR TITLE
Entity refactor proposal 1

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -380,6 +380,62 @@ typedef struct Entity {
     } unkB8;
 } Entity; // size = 0xBC
 
+typedef struct EntityBase {
+    /* 0x00 */ f32 posX;
+    /* 0x04 */ f32 posY;
+    /* 0x08 */ s32 accelerationX;
+    /* 0x0C */ s32 accelerationY;
+    /* 0x10 */ u16 unk10;
+    /* 0x12 */ s16 unk12;
+    /* 0x14 */ u16 facing;
+    /* 0x16 */ u16 palette;
+    /* 0x18 */ s8 blendMode;
+    /* 0x19 */ u8 unk19;
+    /* 0x1A */ s16 unk1A;
+    /* 0x1C */ s16 unk1C;
+    /* 0x1E */ s16 unk1E; // poly rotation angle
+    /* 0x20 */ s16 unk20; // poly / rotation origin x
+    /* 0x22 */ s16 unk22; // poly / rotation origin y
+    /* 0x24 */ u16 zPriority;
+    /* 0x26 */ u16 objectId;
+    /* 0x28 */ PfnEntityUpdate pfnUpdate;
+    /* 0x2C */ u16 step;
+    /* 0x2E */ u16 unk2E; // pl_step_s
+    /* 0x30 */ u16 subId;
+    /* 0x32 */ u16 objectRoomIndex;
+    /* 0x34 */ s32 flags;
+    /* 0x38 */ s16 unk38;
+    /* 0x3A */ s16 enemyId;
+    /* 0x3C */ u16 unk3C; // hitbox state
+    /* 0x3E */ s16 hitPoints;
+    /* 0x40 */ s16 attack;
+    /* 0x42 */ s16 attackElement;
+    /* 0x44 */ u16 unk44;
+    /* 0x46 */ u8 hitboxWidth;
+    /* 0x47 */ u8 hitboxHeight;
+    /* 0x48 */ u8 unk48; // 1 = took hit
+    /* 0x49 */ u8 unk49; // invincibility frames
+    /* 0x4A */ s16 unk4A;
+    /* 0x4C */ AnimationFrame* unk4C;
+    /* 0x50 */ u16 animFrameIdx;
+    /* 0x52 */ s16 animFrameDuration;
+    /* 0x54 */ s16 animSet;
+    /* 0x56 */ s16 animCurFrame;
+    /* 0x58 */ s16 unk58;
+    /* 0x5A */ s16 unk5A;
+    /* 0x5C */ s32 unk5C;
+    /* 0x60 */ s32 unk60;
+    /* 0x64 */ s32 firstPolygonIndex;
+    /* 0x68 */ s16 unk68;
+    /* 0x6A */ u16 unk6A;
+    /* 0x6C */ u8 unk6C;
+    /* 0x6D */ s8 unk6D;
+    /* 0x6E */ s16 unk6E;
+    /* 0x70 */ s32 unk70;
+    /* 0x74 */ s32 unk74;
+    /* 0x78 */ s32 unk78;
+} EntityBase; // size = 0xBC
+
 typedef struct {
     /* 0x00 */ u16 animSet;
     /* 0x02 */ u16 zPriority;

--- a/include/objects.h
+++ b/include/objects.h
@@ -67,6 +67,24 @@ typedef enum {
     /* 0x15 */ ENTITY_15 = 0x15
 } SotnEntityIds;
 
+typedef struct {
+    EntityBase base;
+    u16 timer;
+    s16 unk7E;
+    u8 unk80;
+    s8 unk81;
+    s16 unk82;
+    s16 unk84;
+    s16 unk86;
+    s16 unk88;
+    s16 unk8A;
+    s16 unk8C;
+    s16 unk8E;
+    s16 unk90;
+    s16 unk92;
+    s16 unk94;
+} ETEquipItemDrop;
+
 void EntityBreakable(Entity*);
 void EntityExplosion(Entity*);
 void EntityPrizeDrop(Entity*);
@@ -76,7 +94,7 @@ void EntityIntenseExplosion(Entity*);
 void EntityAbsorbOrb(Entity*);
 void EntityRoomForeground(Entity*);
 void EntityStageNamePopup(Entity*);
-void EntityEquipItemDrop(Entity*);
+void EntityEquipItemDrop(ETEquipItemDrop*);
 void EntityRelicOrb(Entity*);
 #ifndef MAD_H
 void EntityHeartDrop(Entity*);

--- a/src/st/wrp/D020.c
+++ b/src/st/wrp/D020.c
@@ -285,8 +285,8 @@ void func_8018D990(Entity* arg0, s32 renderFlags) {
 
 extern u16 D_80194728[];
 
-void EntityEquipItemDrop(Entity* self) {
-    u16 itemId = self->subId & 0x7FFF;
+void EntityEquipItemDrop(ETEquipItemDrop* self) {
+    u16 itemId = self->base.subId & 0x7FFF;
     s32 firstPolygonIndex;
     Collider collider;
     POLY_GT4* poly;
@@ -302,26 +302,27 @@ void EntityEquipItemDrop(Entity* self) {
     s16 temp_a0;
     s32* unk;
 
-    if (((self->step - 2) < 3U) && (self->unk48 != 0)) {
-        self->step = 5;
+    if (((self->base.step - 2) < 3U) && (self->base.unk48 != 0)) {
+        self->base.step = 5;
     }
 
-    switch (self->step) {
+    switch (self->base.step) {
     case 0:
         if (g_CurrentPlayableCharacter != PLAYER_ALUCARD) {
-            self->pfnUpdate = EntityPrizeDrop;
-            self->subId = 0;
-            self->objectId = 3;
+            self->base.pfnUpdate = EntityPrizeDrop;
+            self->base.subId = 0;
+            self->base.objectId = 3;
             func_8018C240(0);
             EntityPrizeDrop(self);
             return;
         }
         InitializeEntity(D_8018044C);
-        self->unk7C.s = 0;
+        self->timer = 0;
         break;
 
     case 1:
-        g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi, &collider, 0);
+        g_api.CheckCollision(self->base.posX.i.hi, self->base.posY.i.hi,
+                             &collider, 0);
 
         if (!(collider.unk0 & 7)) {
             for (index = 0; index < 32; index++) {
@@ -335,8 +336,8 @@ void EntityEquipItemDrop(Entity* self) {
                 return;
             }
 
-            if (LOH(self->unk94) != 0) {
-                temp_a0 = LOH(self->unk94);
+            if (self->unk94 != 0) {
+                temp_a0 = self->unk94;
                 temp_a0--;
                 D_8003BF9C[temp_a0 >> 3] |= 1 << (temp_a0 & 7);
             }
@@ -347,10 +348,10 @@ void EntityEquipItemDrop(Entity* self) {
                 return;
             }
 
-            self->flags |= FLAG_FREE_POLYGONS;
-            self->firstPolygonIndex = firstPolygonIndex;
+            self->base.flags |= FLAG_FREE_POLYGONS;
+            self->base.firstPolygonIndex = firstPolygonIndex;
             D_80194728[index] = 0x1E0;
-            self->unk8C.modeU16.unk0 = index;
+            self->unk8C = index;
 
             if (itemId < 169) {
                 g_api.func_800EB534(g_api.D_800A4B04[itemId].icon,
@@ -382,33 +383,33 @@ void EntityEquipItemDrop(Entity* self) {
             poly->pad2 = 0x80;
             poly->pad3 = 6;
 
-            self->unk7C.s = 128;
-            self->step++;
+            self->timer = 128;
+            self->base.step++;
             break;
         }
         DestroyEntity(self);
         break;
 
     case 2:
-        if (self->accelerationY < 0) {
-            g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi - 7,
+        if (self->base.accelerationY < 0) {
+            g_api.CheckCollision(self->base.posX.i.hi, self->base.posY.i.hi - 7,
                                  &collider, 0);
             if (collider.unk0 & 5) {
-                self->accelerationY = 0;
+                self->base.accelerationY = 0;
             }
         }
 
         MoveEntity();
 
-        g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi + 7, &collider,
-                             0);
+        g_api.CheckCollision(self->base.posX.i.hi, self->base.posY.i.hi + 7,
+                             &collider, 0);
 
-        if ((collider.unk0 & 5) && (self->accelerationY > 0)) {
-            self->accelerationX = 0;
-            self->accelerationY = 0;
-            self->posY.i.hi += collider.unk18;
-            self->unk80.modeS8.unk0 = 240;
-            self->step++;
+        if ((collider.unk0 & 5) && (self->base.accelerationY > 0)) {
+            self->base.accelerationX = 0;
+            self->base.accelerationY = 0;
+            self->base.posY.i.hi += collider.unk18;
+            self->unk80 = 240;
+            self->base.step++;
         } else {
             FallEntity();
         }
@@ -418,21 +419,21 @@ void EntityEquipItemDrop(Entity* self) {
 
     case 3:
         func_8018CB34(1);
-        if (!(self->subId & 0x8000)) {
-            if (!(--self->unk80.modeS8.unk0 & 255)) {
-                self->unk80.modeS8.unk0 = 0x50;
-                self->step++;
+        if (!(self->base.subId & 0x8000)) {
+            if (!(--self->unk80 & 255)) {
+                self->unk80 = 0x50;
+                self->base.step++;
             }
         } else {
-            D_80194728[self->unk8C.modeS16.unk0] = 0x10;
+            D_80194728[self->unk8C] = 0x10;
         }
         break;
 
     case 4:
         func_8018CB34(1);
-        if (self->unk80.modeS8.unk0 += 255) {
-            poly = &g_PrimBuf[self->firstPolygonIndex];
-            if (self->unk80.modeS8.unk0 & 2) {
+        if (self->unk80 += 255) {
+            poly = &g_PrimBuf[self->base.firstPolygonIndex];
+            if (self->unk80 & 2) {
                 poly->pad3 = 8;
             } else {
                 poly->pad3 = 2;
@@ -465,11 +466,11 @@ void EntityEquipItemDrop(Entity* self) {
         break;
     }
 
-    if (self->step >= 2) {
-        if (self->unk7C.u != 0) {
-            self->unk7C.u--;
+    if (self->base.step >= 2) {
+        if (self->timer != 0) {
+            self->timer--;
         }
-        func_8018D990(self, self->unk7C.u);
+        func_8018D990(self, self->timer);
     }
 }
 


### PR DESCRIPTION
## What I like

* Each entity will have meaningful fields to work with.
* Structure clear and code clean
* Structures can be self-contained into dedicated entity C files
* It's good to introduce it ASAP to avoid to refactor too much later on
* You can just search `} ET` to find all the custom entity structures

## What I do not like

* I had to fire asm-differ as the function was initially not matching
* Some structures have to be defined globally (eg. in objects.h)
* We will have a lot of mixed old and new code and it will take time to adapt everything
* Duplicate `Entity` and `EntityBase` until we replace every single function
* `EntityBase` is not `0xBC` big, so we have to create a `EntityEmpty` to use in functions such as `AllocEntity`
* Fields are not always consecutive, so you often need padding in the entity struct (eg. from 0x81 to 0x8B is unused)
* IMHO the biggest elephant in the room: `self->base` everywhere. This will get annoying pretty fast.