### PR TITLE
Match MAD duplicates of CreateEntityWhenIn functions

### DIFF
--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -262,7 +262,7 @@ void CreateEntityWhenInVerticalRange(LayoutObject* layoutObj) {
     s16 posY;
     Entity* entity;
 
-    posY = g_Camera_posY_i_hi;
+    posY = g_Camera.posY.i.hi;
     yClose = posY - 0x40;
     yFar = posY + 0x120;
     if (yClose < 0) {
@@ -300,7 +300,7 @@ void CreateEntityWhenInHorizontalRange(LayoutObject* layoutObj) {
     s16 posX;
     Entity* entity;
 
-    posX = g_Camera_posX_i_hi;
+    posX = g_Camera.posX.i.hi;
     xClose = posX - 0x40;
     xFar = posX + 0x140;
     if (xClose < 0) {

--- a/src/st/mad/mad.h
+++ b/src/st/mad/mad.h
@@ -67,7 +67,5 @@ extern u8 g_eBreakableHitboxes[];
 extern u8 g_eBreakableExplosionTypes[];
 extern u16 g_eBreakableanimSets[];
 extern u8 g_eBreakableBlendModes[];
-extern u16 g_Camera_posX_i_hi;
-extern u16 g_Camera_posY_i_hi;
 
 #endif


### PR DESCRIPTION
There are numerous duplicates of the `CreateEntityWhenInVerticalRange` and `CreateEntityWhenInHorizontalRange` functions. This pull request matches the duplicates identified in overlay MAD:

- MAD  - `func_80190608` - Previously matching; renamed to `CreateEntityWhenInVerticalRange`
- MAD  - `func_80190720` - Renamed to `CreateEntityWhenInHorizontalRange`