### PR TITLE
Match NO3, NP3, and RWRP duplicates of CreateEntityWhenIn functions

### DIFF
--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -409,7 +409,43 @@ void CreateEntityFromLayout(Entity* entity, LayoutObject* initDesc) {
     entity->unk68 = (initDesc->objectId >> 0xA) & 7;
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", func_801C3500);
+void func_801C3500(LayoutObject* layoutObj) {
+    s16 yClose;
+    s16 yFar;
+    s16 posY;
+    Entity* entity;
+
+    posY = g_Camera_posY_i_hi;
+    yClose = posY - 0x40;
+    yFar = posY + 0x120;
+    if (yClose < 0) {
+        yClose = 0;
+    }
+
+    posY = layoutObj->posY;
+    if (posY < yClose) {
+        return;
+    }
+
+    if (yFar < posY) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", func_801C3618);
 

--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -447,7 +447,43 @@ void func_801C3500(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", func_801C3618);
+void func_801C3618(LayoutObject* layoutObj) {
+    s16 xClose;
+    s16 xFar;
+    s16 posX;
+    Entity* entity;
+
+    posX = g_Camera_posX_i_hi;
+    xClose = posX - 0x40;
+    xFar = posX + 0x140;
+    if (xClose < 0) {
+        xClose = 0;
+    }
+
+    posX = layoutObj->posX;
+    if (posX < xClose) {
+        return;
+    }
+
+    if (xFar < posX) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 void func_801C3730(s16 arg0) {
     while (true) {

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -98,4 +98,5 @@ extern s32 D_801D7D64;
 extern u16 D_801D7DD8[];
 extern LayoutObject* g_pStObjLayout[];
 extern PfnEntityUpdate PfnEntityUpdates[];
+extern u16 g_Camera_posX_i_hi;
 extern u16 g_Camera_posY_i_hi;

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -98,3 +98,4 @@ extern s32 D_801D7D64;
 extern u16 D_801D7DD8[];
 extern LayoutObject* g_pStObjLayout[];
 extern PfnEntityUpdate PfnEntityUpdates[];
+extern u16 g_Camera_posY_i_hi;

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -1267,7 +1267,43 @@ void func_801BAD70(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAE88);
+void func_801BAE88(LayoutObject* layoutObj) {
+    s16 xClose;
+    s16 xFar;
+    s16 posX;
+    Entity* entity;
+
+    posX = g_Camera_posX_i_hi;
+    xClose = posX - 0x40;
+    xFar = posX + 0x140;
+    if (xClose < 0) {
+        xClose = 0;
+    }
+
+    posX = layoutObj->posX;
+    if (posX < xClose) {
+        return;
+    }
+
+    if (xFar < posX) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAFA0);
 

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -1229,7 +1229,43 @@ void CreateEntityFromLayout(Entity* entity, LayoutObject* initDesc) {
     entity->unk68 = (initDesc->objectId >> 0xA) & 7;
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAD70);
+void func_801BAD70(LayoutObject* layoutObj) {
+    s16 yClose;
+    s16 yFar;
+    s16 posY;
+    Entity* entity;
+
+    posY = g_Camera_posY_i_hi;
+    yClose = posY - 0x40;
+    yFar = posY + 0x120;
+    if (yClose < 0) {
+        yClose = 0;
+    }
+
+    posY = layoutObj->posY;
+    if (posY < yClose) {
+        return;
+    }
+
+    if (yFar < posY) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            CreateEntityFromLayout(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        CreateEntityFromLayout(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BAE88);
 

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -85,4 +85,5 @@ extern s32 D_801826A4;
 extern PfnEntityUpdate PfnEntityUpdates[];
 LayoutObject* D_801D276C;
 extern u16 D_801D33F4[];
+extern u16 g_Camera_posX_i_hi;
 extern u16 g_Camera_posY_i_hi;

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -85,3 +85,4 @@ extern s32 D_801826A4;
 extern PfnEntityUpdate PfnEntityUpdates[];
 LayoutObject* D_801D276C;
 extern u16 D_801D33F4[];
+extern u16 g_Camera_posY_i_hi;

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -28,7 +28,43 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018B6B4);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018BD58);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018BE1C);
+void func_8018BE1C(LayoutObject* layoutObj) {
+    s16 yClose;
+    s16 yFar;
+    s16 posY;
+    Entity* entity;
+
+    posY = g_Camera_posY_i_hi;
+    yClose = posY - 0x40;
+    yFar = posY + 0x120;
+    if (yClose < 0) {
+        yClose = 0;
+    }
+
+    posY = layoutObj->posY;
+    if (posY < yClose) {
+        return;
+    }
+
+    if (yFar < posY) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            func_8018BD58(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        func_8018BD58(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018BF34);
 

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -66,7 +66,43 @@ void func_8018BE1C(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018BF34);
+void func_8018BF34(LayoutObject* layoutObj) {
+    s16 xClose;
+    s16 xFar;
+    s16 posX;
+    Entity* entity;
+
+    posX = g_Camera_posX_i_hi;
+    xClose = posX - 0x40;
+    xFar = posX + 0x140;
+    if (xClose < 0) {
+        xClose = 0;
+    }
+
+    posX = layoutObj->posX;
+    if (posX < xClose) {
+        return;
+    }
+
+    if (xFar < posX) {
+        return;
+    }
+
+    switch (layoutObj->objectId & 0xE000) {
+    case 0x0:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        if (entity->objectId == 0) {
+            func_8018BD58(entity, layoutObj);
+        }
+        break;
+    case 0x8000:
+        break;
+    case 0xA000:
+        entity = &D_800762D8[(u8)layoutObj->objectRoomIndex];
+        func_8018BD58(entity, layoutObj);
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C04C);
 

--- a/src/st/rwrp/rwrp.h
+++ b/src/st/rwrp/rwrp.h
@@ -10,4 +10,6 @@ extern s16 D_80180A94[];
 extern ObjInit2 D_80181134[];
 extern LayoutObject* D_80195A30;
 extern LayoutObject* D_80195A34;
+void func_8018BD58(Entity*, LayoutObject*);
+extern u16 g_Camera_posY_i_hi;
 #endif

--- a/src/st/rwrp/rwrp.h
+++ b/src/st/rwrp/rwrp.h
@@ -11,5 +11,6 @@ extern ObjInit2 D_80181134[];
 extern LayoutObject* D_80195A30;
 extern LayoutObject* D_80195A34;
 void func_8018BD58(Entity*, LayoutObject*);
+extern u16 g_Camera_posX_i_hi;
 extern u16 g_Camera_posY_i_hi;
 #endif


### PR DESCRIPTION
There are numerous duplicates of the `CreateEntityWhenInVerticalRange` and `CreateEntityWhenInHorizontalRange` functions. This pull request matches the duplicates identified in overlays NO3, NP3, and RWRP:

- NO3  - func_801C3500
- NO3  - func_801C3618
- NP3  - func_801BAD70
- NP3  - func_801BAE88
- RWRP - func_8018BE1C
- RWRP - func_8018BF34
