### PR TITLE
Match func 80195714

### DIFF
--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -541,7 +541,23 @@ INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80195318);
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_8019565C);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80195714);
+void func_80195714(void) {
+    s32 temp_v1;
+    s32 temp_v1_2;
+
+    if (g_CurrentEntity->accelerationY >= 0) {
+        temp_v1 = g_CurrentEntity->unk88.S16.unk0 + g_CurrentEntity->unk84.unk;
+        g_CurrentEntity->unk84.unk = temp_v1;
+        g_CurrentEntity->accelerationX = temp_v1;
+        if ((temp_v1 == 0x10000) || (temp_v1 == -0x10000)) {
+            g_CurrentEntity->unk88.S16.unk0 = -(s16) (u16) g_CurrentEntity->unk88.S16.unk0;
+        }
+    }
+    temp_v1_2 = g_CurrentEntity->accelerationY;
+    if (temp_v1_2 < 0x4000) {
+        g_CurrentEntity->accelerationY = temp_v1_2 + 0x2000;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_80195798);
 

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -543,19 +543,22 @@ INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", func_8019565C);
 
 void func_80195714(void) {
     s32 temp_v1;
-    s32 temp_v1_2;
+    Entity* entity;
 
-    if (g_CurrentEntity->accelerationY >= 0) {
-        temp_v1 = g_CurrentEntity->unk88.S16.unk0 + g_CurrentEntity->unk84.unk;
-        g_CurrentEntity->unk84.unk = temp_v1;
-        g_CurrentEntity->accelerationX = temp_v1;
-        if ((temp_v1 == 0x10000) || (temp_v1 == -0x10000)) {
-            g_CurrentEntity->unk88.S16.unk0 = -(s16) (u16) g_CurrentEntity->unk88.S16.unk0;
+    entity = g_CurrentEntity;
+    if (entity->accelerationY >= 0) {
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
+        entity->accelerationX = temp_v1;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
         }
+        entity = g_CurrentEntity;
     }
-    temp_v1_2 = g_CurrentEntity->accelerationY;
-    if (temp_v1_2 < 0x4000) {
-        g_CurrentEntity->accelerationY = temp_v1_2 + 0x2000;
+    NOP;
+
+    if (entity->accelerationY < 0x00004000) {
+        entity->accelerationY += 0x2000;
     }
 }
 

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -892,30 +892,26 @@ void ReplaceBreakableWithItemDrop(Entity* self) {
     self->step = 0;
 }
 
-// This function matches with PSYQ4.0 GCC 2.7.2 with -02 Optimization flag
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/mad/nonmatchings/D8C8", func_8019344C);
-#else
 void func_8019344C(void) {
     s32 temp_v1;
-    Entity* entity = g_CurrentEntity;
+    Entity* entity;
 
+    entity = g_CurrentEntity;
     if (entity->accelerationY >= 0) {
-        temp_v1 = entity->unk88 + entity->unk84.value;
-        entity->unk84.value = temp_v1;
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
         entity->accelerationX = temp_v1;
-
-        if ((temp_v1 == 0x10000) || (temp_v1 == -0x10000)) {
-            entity->unk88 = -entity->unk88;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
         }
         entity = g_CurrentEntity;
     }
+    NOP;
 
     if (entity->accelerationY < 0x00004000) {
         entity->accelerationY += 0x2000;
     }
 }
-#endif
 
 void func_801934D0(u16 arg0) {
     Collider res;

--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -1019,26 +1019,26 @@ void ReplaceBreakableWithItemDrop(Entity* self) {
     self->step = 0;
 }
 
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", func_801C6114);
-#else
-// matches with gcc 2.6.0 + aspsx 2.34
 void func_801C6114(void) {
     s32 temp_v1;
+    Entity* entity;
 
-    if (g_CurrentEntity->accelerationY >= 0) {
-        temp_v1 = g_CurrentEntity->unk88.S16.unk0 + g_CurrentEntity->unk84.unk;
-        g_CurrentEntity->unk84.unk = temp_v1;
-        g_CurrentEntity->accelerationX = temp_v1;
-        if ((temp_v1 == 0x10000) || (temp_v1 == -0x10000)) {
-            g_CurrentEntity->unk88.S16.unk0 = -g_CurrentEntity->unk88.S16.unk0;
+    entity = g_CurrentEntity;
+    if (entity->accelerationY >= 0) {
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
+        entity->accelerationX = temp_v1;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
         }
+        entity = g_CurrentEntity;
     }
-    if (g_CurrentEntity->accelerationY < 0x4000) {
-        g_CurrentEntity->accelerationY += 0x2000;
+    NOP;
+
+    if (entity->accelerationY < 0x00004000) {
+        entity->accelerationY += 0x2000;
     }
 }
-#endif
 
 void func_801C6198(u16 arg0) {
     Collider res;

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -1683,7 +1683,26 @@ void ReplaceBreakableWithItemDrop(Entity* self) {
     self->step = 0;
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BD984);
+void func_801BD984(void) {
+    s32 temp_v1;
+    Entity* entity;
+
+    entity = g_CurrentEntity;
+    if (entity->accelerationY >= 0) {
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
+        entity->accelerationX = temp_v1;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
+        }
+        entity = g_CurrentEntity;
+    }
+    NOP;
+
+    if (entity->accelerationY < 0x00004000) {
+        entity->accelerationY += 0x2000;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801BDA08);
 

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -2290,26 +2290,26 @@ void ReplaceBreakableWithItemDrop(Entity* self) {
     self->step = 0;
 }
 
-// aspatch skips a nop, ASPSX
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", func_801BDD9C);
-#else
 void func_801BDD9C(void) {
-    if (g_CurrentEntity->accelerationY >= 0) {
-        g_CurrentEntity->unk84.unk += g_CurrentEntity->unk88.S16.unk0;
-        g_CurrentEntity->accelerationX = g_CurrentEntity->unk84.unk;
+    s32 temp_v1;
+    Entity* entity;
 
-        if ((g_CurrentEntity->accelerationX == 0x10000) ||
-            (g_CurrentEntity->accelerationX == -0x10000)) {
-            g_CurrentEntity->unk88.U16.unk0 = -g_CurrentEntity->unk88.U16.unk0;
+    entity = g_CurrentEntity;
+    if (entity->accelerationY >= 0) {
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
+        entity->accelerationX = temp_v1;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
         }
+        entity = g_CurrentEntity;
     }
+    NOP;
 
-    if (g_CurrentEntity->accelerationY < 0x4000) {
-        g_CurrentEntity->accelerationY += 0x2000;
+    if (entity->accelerationY < 0x00004000) {
+        entity->accelerationY += 0x2000;
     }
 }
-#endif
 
 void func_801BDE20(u16 arg0) {
     Collider res;

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -238,7 +238,26 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E634);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018E978);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EA30);
+void func_8018EA30(void) {
+    s32 temp_v1;
+    Entity* entity;
+
+    entity = g_CurrentEntity;
+    if (entity->accelerationY >= 0) {
+        temp_v1 = entity->unk88.S16.unk0 + entity->unk84.unk;
+        entity->unk84.unk = temp_v1;
+        entity->accelerationX = temp_v1;
+        if (temp_v1 == 0x10000 || temp_v1 == -0x10000) {
+            entity->unk88.S16.unk0 = -entity->unk88.S16.unk0;
+        }
+        entity = g_CurrentEntity;
+    }
+    NOP;
+
+    if (entity->accelerationY < 0x00004000) {
+        entity->accelerationY += 0x2000;
+    }
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018EAB4);
 


### PR DESCRIPTION
This pull request matches the following functions, which are all duplicates of previously decompiled functions:

- CEN  - `func_80195714`
- NO3  - `func_801C6114` - Previously non-matching
- NP3  - `func_801BD984`
- NZ0  - `func_801BDD9C` - Previously non-matching
- RWRP - `func_8018EA30`
- MAD  - `func_8019344C` - Previously non-matching
