### PR TITLE
Fix to makefile to properly create the  directory before cp'ing into it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ format:
 check:
 	sha1sum --check config/check.$(VERSION).sha
 expected: check
+	mkdir -p expected
 	rm -rf expected/build
 	cp -r build expected/
 


### PR DESCRIPTION
Solves the issue mentioned in discord - When you `cp` into expected, and expected does not exist, the CONTENTS of build get copied into the newly-created `expected` directory. This PR solves this by running `mkdir -p expected` first (-p causes mkdir to not error if `expected` already exists). Then, when `cp` runs, `expected` will always exist, thus `build` properly gets copied into it.