### PR TITLE
Document zombie spawner entity

### DIFF
--- a/config/symbols.us.stno3.txt
+++ b/config/symbols.us.stno3.txt
@@ -130,4 +130,4 @@ EntityBoneScimitar = 0x801D5AAC;
 EntityBoneScimitarParts = 0x801D615C;
 EntityBat = 0x801D6264;
 EntityZombie = 0x801D64B0;
-EntityUnkId4D = 0x801D6710;
+EntityZombieSpawner = 0x801D6710;

--- a/config/symbols.us.stnp3.txt
+++ b/config/symbols.us.stnp3.txt
@@ -80,6 +80,6 @@ EntityBoneScimitar = 0x801C91C4;
 EntityBoneScimitarParts = 0x801C9874;
 EntityBat = 0x801C997C;
 EntityZombie = 0x801C9BC8;
-EntityZombieExplosion = 0x801C9E28;
+EntityZombieSpawner = 0x801C9E28;
 EntityBloodSplatter = 0x801C9F98;
 EntityBloodyZombie = 0x801CA654;

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -77,7 +77,13 @@ void EntityZombie(Entity* self) {
 
 const u32 rodataPadding_377CC[] = {0, 0};
 
-void EntityUnkId4D(Entity* self) {
+// The zombie spawner is created inside the first room of the castle.
+// It is responsible for spawning the "floor zombies" that rise up
+// from the ground and swarm Alucard.
+// Every 32 to 95 frames, it will alternate spawning a zombie
+// on the right side or left side of the screen.
+// The exact position a zombie is spawned in is also randomized.
+void EntityZombieSpawner(Entity* self) {
     s32 distCameraEntity;
     Entity* newEntity;
     s32 rnd;
@@ -104,6 +110,8 @@ void EntityUnkId4D(Entity* self) {
                 newEntity->posY.i.hi -= 48;
                 self->ext.generic.unk88.unk ^= 1;
 
+                // Zombies are prevented from spawning too close to the
+                // edges of the room.
                 distCameraEntity = g_Camera.posX.i.hi + newEntity->posX.i.hi;
                 if ((distCameraEntity < (g_CurrentRoom.x + 128)) ||
                     ((g_CurrentRoom.width - 128) < distCameraEntity)) {

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -75,7 +75,13 @@ void EntityZombie(Entity* self) {
     }
 }
 
-void EntityZombieExplosion(Entity* self) {
+// The zombie spawner is created inside the first room of the castle.
+// It is responsible for spawning the "floor zombies" that rise up
+// from the ground and swarm Alucard.
+// Every 32 to 95 frames, it will alternate spawning a zombie
+// on the right side or left side of the screen.
+// The exact position a zombie is spawned in is also randomized.
+void EntityZombieSpawner(Entity* self) {
     s32 distCameraEntity;
     Entity* newEntity;
     s32 rnd;
@@ -102,6 +108,8 @@ void EntityZombieExplosion(Entity* self) {
                 newEntity->posY.i.hi -= 48;
                 self->ext.generic.unk88.unk ^= 1;
 
+                // Zombies are prevented from spawning too close to the
+                // edges of the room.
                 distCameraEntity = g_Camera.posX.i.hi + newEntity->posX.i.hi;
                 if ((distCameraEntity < (g_CurrentRoom.x + 128)) ||
                     ((g_CurrentRoom.width - 128) < distCameraEntity)) {


### PR DESCRIPTION
Renamed `EntityUnkId4D` and `EntityZombieExplosion` to EntityZombieSpawner.
Describes how the zombie spawner behaves.