### PR TITLE
Integrate splitting for saturn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "tools/m2c"]
 	path = tools/m2c
 	url = https://github.com/matt-kempster/m2c.git
+[submodule "tools/saturn-splitter"]
+	path = tools/saturn-splitter
+	url = https://github.com/sozud/saturn-splitter.git

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ GOPATH			:= $(HOME)/go
 ASPATCH			:= $(GOPATH)/bin/aspatch
 SOTNDISK		:= $(GOPATH)/bin/sotn-disk
 GFXSTAGE		:= $(PYTHON) $(TOOLS_DIR)/gfxstage.py
+SATURN_SPLITTER_DIR := $(TOOLS_DIR)/saturn-splitter
+SATURN_SPLITTER_APP := $(SATURN_SPLITTER_DIR)/rust-dis/target/release/rust-dis
 
 define list_src_files
 	$(foreach dir,$(ASM_DIR)/$(1),$(wildcard $(dir)/**.s))
@@ -248,6 +250,10 @@ extract_tt_%: $(SPLAT_APP)
 	$(SPLAT) $(CONFIG_DIR)/splat.$(VERSION).tt_$*.yaml
 $(CONFIG_DIR)/generated.$(VERSION).symbols.%.txt:
 
+extract_saturn: $(SATURN_SPLITTER_APP)
+	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/game.prg.yaml
+	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/t_bat.prg.yaml
+
 context:
 	$(M2CTX) $(SOURCE)
 	@echo ctx.c has been updated.
@@ -321,6 +327,11 @@ $(ASPATCH): $(GO)
 	$(GO) install github.com/xeeynamo/sotn-decomp/tools/aspatch@latest
 $(SOTNDISK): $(GO)
 	$(GO) install github.com/xeeynamo/sotn-decomp/tools/sotn-disk@latest
+
+$(SATURN_SPLITTER_APP):
+	git submodule init $(SATURN_SPLITTER_DIR)
+	git submodule update $(SATURN_SPLITTER_DIR)
+	cd $(SATURN_SPLITTER_DIR)/rust-dis && cargo build --release
 
 $(BUILD_DIR)/%.s.o: %.s
 	$(AS) $(AS_FLAGS) -o $@ $<

--- a/config/saturn/game.prg.yaml
+++ b/config/saturn/game.prg.yaml
@@ -1,0 +1,19 @@
+options:
+  target_path:  disks/saturn/GAME.PRG
+  asm_path:     asm/saturn/game
+  src_path:     src/saturn/game
+segments:
+  - name: game
+    type: code
+    start: 0x00000000
+    vram:  0x06066000
+    subalign: 2
+    subsegments:
+      - start: 0x0
+        type: data
+        file: 40
+        end: 0x3F
+      - start: 0x40
+        type: c
+        file: 40
+        end: 0x2008B

--- a/config/saturn/t_bat.prg.yaml
+++ b/config/saturn/t_bat.prg.yaml
@@ -1,0 +1,23 @@
+options:
+  target_path:  disks/saturn/T_BAT.PRG
+  asm_path:     asm/saturn/t_bat
+  src_path:     src/saturn/t_bat
+segments:
+  - name: t_bat
+    type: code
+    start: 0x00000000
+    vram:  0x060CF000
+    subalign: 2
+    subsegments:
+      - start: 0x0
+        type: data
+        file: 60
+        end: 0x5F
+      - start: 0x60
+        type: c
+        file: 60
+        end: 0x2857
+      - start: 0x2858
+        type: data
+        file: 60
+        end: 0x7000


### PR DESCRIPTION
This PR does some initial integration work for splitting the Saturn version. It adds T_BAT.PRG (Bat overlay) and GAME.PRG (similar to DRA.BIN). These are extracted to asm/saturn/* and src/saturn/*. Right now there's no attempt to compile. I haven't been able to figure out the issues with sotn-disk so this requires pre-extracted files in disks/saturn. Something like this is able to do it:

```
bchunk saturn.bin saturn.cue saturn.iso
7z x saturn.iso 
```

The Saturn version has the code split up differently so I think putting it in a separate folder to begin with makes sense. For example the Random function is in GAME.PRG rather than in the stage overlays. There's also an Alucard overlay rather than it being included in GAME.PRG. See here for some comparisons: https://github.com/Xeeynamo/sotn-decomp/wiki/Saturn-Matching

I didn't attempt to install Rust as part of the project setup like with Go.