### PR TITLE
Match duplicates of RWRP func_8018C04C

### DIFF
--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -128,7 +128,14 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C0F0);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C1EC);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C300);
+void func_8018C300(s16 arg0) {
+    while (true) {
+        if ((D_80195A34->posY != 0xFFFE) && ((s32)D_80195A34->posY >= arg0)) {
+            break;
+        }
+        D_80195A34++;
+    }
+}
 
 void func_8018C34C(s16 arg0) {
     while (true) {

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -112,7 +112,14 @@ void CreateEntityWhenInHorizontalRange(LayoutObject* layoutObj) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_8018C04C);
+void func_8018C04C(s16 arg0) {
+    while (true) {
+        if ((D_80195A30->posX != 0xFFFE) && (((s32)D_80195A30->posX >= arg0))) {
+            break;
+        }
+        D_80195A30++;
+    }
+}
 
 void func_8018C098(s16 arg0) {
     while (true) {

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -862,9 +862,16 @@ INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3478);
 void func_801B3574(s16);
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3574);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", func_801B3688);
-
 extern LayoutObject* D_801C00A4;
+void func_801B3688(s16 arg0) {
+    while (true) {
+        if ((D_801C00A4->posY != 0xFFFE) && ((s32)D_801C00A4->posY >= arg0)) {
+            break;
+        }
+        D_801C00A4++;
+    }
+}
+
 void func_801B36D4(s16 arg0) {
     while (true) {
         if ((D_801C00A4->posY != 0xFFFF) &&


### PR DESCRIPTION
This pull request matches the following functions, which are all duplicates of previously decompiled functions:

- RWRP - `func_8018C04C`
- RWRP - `func_8018C300`
- ST0 - `func_801B3688`