### PR TITLE
Working decomp of func_8012CB4C

### DIFF
--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -1576,7 +1576,25 @@ void func_8012CB0C(void) {
     PLAYER.step_s = 7;
 }
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_8012CB4C);
+void func_8012CB4C(void) {
+    PLAYER.step_s = 2;
+    if ((PLAYER.facing != 0 && g_Player.padPressed & PAD_RIGHT) ||
+        (PLAYER.facing == 0 && g_Player.padPressed & PAD_LEFT)) {
+        func_8010DA48(0xE1);
+        D_800B0914 = 0;
+        D_8013842C = 0;
+        return;
+    }
+    if (D_8013842C != 0) {
+        func_8010DA48(0xE2);
+        D_800B0914 = 2;
+        AccelerateX(0x20000);
+        return;
+    }
+    func_8010DA48(0xE0);
+    D_800B0914 = 1;
+    D_8013842C = 0xC;
+}
 
 void func_8012CC30(s32 arg0) {
     if (arg0 == 0) {

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -476,6 +476,7 @@ extern u8 D_80138044;
 extern u8 D_80138048;
 extern s32 D_8013808C;
 extern s32 D_8013841C;
+extern s32 D_8013842C;
 extern s32 D_80138430;
 extern s32 D_80138438;
 extern s32 D_80138440;


### PR DESCRIPTION
Short and simple function, but took a bit to get rid of the goto's :)

This seems to be the input handler that handles moving the player left and right in response to the left and right controller inputs. We also add a new variable, D_8013842C. Its purpose is unclear; I will next attempt to decompile some of the other functions using that variable.

Thank you, and please let me know if anything is amiss! I think at this point I know how to submit appropriate PRs, but am more than happy to be corrected.


- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
