### PR TITLE
Matching decomp of DRA func_80117D3C

### DIFF
--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -1576,7 +1576,25 @@ void func_8012CB0C(void) {
     PLAYER.step_s = 7;
 }
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_8012CB4C);
+void func_8012CB4C(void) {
+    PLAYER.step_s = 2;
+    if ((PLAYER.facing != 0 && g_Player.padPressed & PAD_RIGHT) ||
+        (PLAYER.facing == 0 && g_Player.padPressed & PAD_LEFT)) {
+        func_8010DA48(0xE1);
+        D_800B0914 = 0;
+        D_8013842C = 0;
+        return;
+    }
+    if (D_8013842C != 0) {
+        func_8010DA48(0xE2);
+        D_800B0914 = 2;
+        AccelerateX(0x20000);
+        return;
+    }
+    func_8010DA48(0xE0);
+    D_800B0914 = 1;
+    D_8013842C = 0xC;
+}
 
 void func_8012CC30(s32 arg0) {
     if (arg0 == 0) {

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -1584,16 +1584,16 @@ void func_8012CB4C(void) {
         D_800B0914 = 0;
         D_8013842C = 0;
         return;
-    }
-    if (D_8013842C != 0) {
+    } else if (D_8013842C != 0) {
         func_8010DA48(0xE2);
         D_800B0914 = 2;
         AccelerateX(0x20000);
         return;
+    } else {
+        func_8010DA48(0xE0);
+        D_800B0914 = 1;
+        D_8013842C = 0xC;
     }
-    func_8010DA48(0xE0);
-    D_800B0914 = 1;
-    D_8013842C = 0xC;
 }
 
 void func_8012CC30(s32 arg0) {

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -180,7 +180,19 @@ INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_801177A0);
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_80117AC0);
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_80117D3C);
+s32 func_80117D3C(void) {
+    if (PLAYER.step_s != 0) {
+        if ((D_8009744C != 0) || (g_Player.padTapped & PAD_L1) ||
+            (func_800FEEA4(1, 1) < 0) ||
+            ((func_800FE3A8(8) == false) &&
+             ((D_80138004 == 0) || (--D_80138004 == 0)))) {
+            func_8010E27C();
+            SetPlayerStep(0xE);
+            return 1;
+        }
+    }
+    return 0;
+}
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_80117DEC);
 

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -476,6 +476,7 @@ extern u8 D_80138044;
 extern u8 D_80138048;
 extern s32 D_8013808C;
 extern s32 D_8013841C;
+extern s32 D_8013842C;
 extern s32 D_80138430;
 extern s32 D_80138438;
 extern s32 D_80138440;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -822,5 +822,6 @@ bool func_80133950(void);
 void func_80133FCC(void);
 void func_8013415C(void);
 void func_801361F8(void);
+extern s32 D_80138004;
 
 #endif


### PR DESCRIPTION
Another function working! This one was 99% done by Sozud, I just recognized a problem in the conditionals that was causing it to use an extra register.

Seems to be something related to the mist-form, since it checks for pressing the controller's L1 button. Will try to decompile some of the functions called by this one.

Co-authored  by: @sozud 

- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
