### PR TITLE
DrawMenuStr now decompiled

### DIFF
--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -423,8 +423,43 @@ void DrawMenuChar(u8 ch, int x, int y, MenuContext* context) {
                   0x196, 0x1E, 1, 0);
 }
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/5298C", DrawMenuStr);
-// DECOMP_ME_WIP DrawMenuStr https://decomp.me/scratch/S4Dzb
+void DrawMenuStr(const u8* str, s32 x, s32 y, MenuContext* context) {
+    const int ChWidth = 8;
+    const int ChHeight = 8;
+    u8 ch;
+    s32 xcopy;
+    s32 ycopy;
+
+    s32 s4 = D_8013784C;
+
+    D_80137614 = 0;
+    while (1) {
+        xcopy = x;
+        ycopy = y;
+        ch = *str++;
+        if (*str == 0xC0 && *(str + 1) == 0xD2) {
+            D_8013784C = 2;
+            str += 2;
+        } else
+            D_8013784C = s4;
+
+        if (ch == 0xFF) {
+            ch = *str++;
+            if (ch == 0) {
+                break;
+            }
+            if (ch != 0xFF) {
+                xcopy -= ChWidth;
+                ycopy -= ChHeight;
+                x -= ChWidth;
+            }
+        }
+        DrawMenuChar(ch, xcopy, ycopy, context);
+        x += ChWidth;
+    }
+    D_80137614 = 1;
+    func_800F53D4(0x1E, context->unk18 + 2);
+}
 
 void DrawMenuInt(s32 digit, s32 x, s32 y, MenuContext* context) {
     do {

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -659,7 +659,7 @@ void func_800FF7B8(s32 arg0);
 void func_800F98AC(s32 arg0, s32 arg1);
 void func_800F99B8(s32 arg0, s32 arg1, s32 arg2);
 void DrawMenuChar(u8 ch, int x, int y, MenuContext* context);
-void DrawMenuStr(const char* str, s32 x, s32 y, MenuContext* context);
+void DrawMenuStr(const u8* str, s32 x, s32 y, MenuContext* context);
 void DrawMenuInt(s32 value, s32 x, s32 y, MenuContext*);
 void DrawSettingsReverseCloak(MenuContext* context);
 void DrawSettingsSound(MenuContext* context);


### PR DESCRIPTION
This is a function which writes strings on the menu screens. Xeeynamo had previously started a scratch for this, but I got it to be matching. Code is ugly, but functional. Submitting this now as an operational function; myself or others may make the logic more straightforward in future.

No real changes outside the function itself; no new externs needed. Had to change the function signature to use u8 instead of char in order to get it to match.

As always, happy to make any requested changes in formatting or similar.

Thanks a bunch!

Before submitting this PR, please make sure:

- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
