### PR TITLE
Create Saturn asm directories by type

### DIFF
--- a/src/saturn/game.c
+++ b/src/saturn/game.c
@@ -1,81 +1,81 @@
 #include "inc_asm.h"
 #include "sattypes.h"
-INCLUDE_ASM("asm/saturn/game", d6066000, d_06066000);
-INCLUDE_ASM("asm/saturn/game", f6066040, func_06066040);
-INCLUDE_ASM("asm/saturn/game", f60661BC, func_060661BC);
-INCLUDE_ASM("asm/saturn/game", f6066330, func_06066330);
-INCLUDE_ASM("asm/saturn/game", f6066400, func_06066400);
-INCLUDE_ASM("asm/saturn/game", f60664E0, func_060664E0);
-INCLUDE_ASM("asm/saturn/game", f60665BC, func_060665BC);
-INCLUDE_ASM("asm/saturn/game", f60666A4, func_060666A4);
-INCLUDE_ASM("asm/saturn/game", f6066854, func_06066854);
-INCLUDE_ASM("asm/saturn/game", f60668D4, func_060668D4);
-INCLUDE_ASM("asm/saturn/game", f6066B30, func_06066B30);
-INCLUDE_ASM("asm/saturn/game", f6066B74, func_06066B74);
-INCLUDE_ASM("asm/saturn/game", f6066CE0, func_06066CE0);
-INCLUDE_ASM("asm/saturn/game", f6066FE0, func_06066FE0);
-INCLUDE_ASM("asm/saturn/game", f6067090, func_06067090);
-INCLUDE_ASM("asm/saturn/game", f60674B8, func_060674B8);
-INCLUDE_ASM("asm/saturn/game", f6067958, func_06067958);
-INCLUDE_ASM("asm/saturn/game", d606797C, d_0606797C);
-INCLUDE_ASM("asm/saturn/game", f6067A04, func_06067A04);
-INCLUDE_ASM("asm/saturn/game", f606B6F8, func_0606B6F8);
-INCLUDE_ASM("asm/saturn/game", f606B760, func_0606B760);
-INCLUDE_ASM("asm/saturn/game", f606BB4C, func_0606BB4C);
-INCLUDE_ASM("asm/saturn/game", f606BEE4, func_0606BEE4);
-INCLUDE_ASM("asm/saturn/game", f606C064, func_0606C064);
-INCLUDE_ASM("asm/saturn/game", f606C088, func_0606C088);
-INCLUDE_ASM("asm/saturn/game", f606C160, func_0606C160);
-INCLUDE_ASM("asm/saturn/game", f606C3E4, func_0606C3E4);
-INCLUDE_ASM("asm/saturn/game", f606C504, func_0606C504);
-INCLUDE_ASM("asm/saturn/game", f606C594, func_0606C594);
-INCLUDE_ASM("asm/saturn/game", f606C774, func_0606C774);
-INCLUDE_ASM("asm/saturn/game", f606CA10, func_0606CA10);
-INCLUDE_ASM("asm/saturn/game", f606D058, func_0606D058);
-INCLUDE_ASM("asm/saturn/game", f606D2D0, func_0606D2D0);
-INCLUDE_ASM("asm/saturn/game", f606D358, func_0606D358);
-INCLUDE_ASM("asm/saturn/game", f606D3FC, func_0606D3FC);
-INCLUDE_ASM("asm/saturn/game", f606D554, func_0606D554);
-INCLUDE_ASM("asm/saturn/game", f606D5FC, func_0606D5FC);
-INCLUDE_ASM("asm/saturn/game", f606D6DC, func_0606D6DC);
-INCLUDE_ASM("asm/saturn/game", f606D798, func_0606D798);
-INCLUDE_ASM("asm/saturn/game", f606D804, func_0606D804);
-INCLUDE_ASM("asm/saturn/game", f606D880, func_0606D880);
-INCLUDE_ASM("asm/saturn/game", f606DAE8, func_0606DAE8);
-INCLUDE_ASM("asm/saturn/game", f606DC8C, func_0606DC8C);
-INCLUDE_ASM("asm/saturn/game", f606DCF0, func_0606DCF0);
-INCLUDE_ASM("asm/saturn/game", f606DF2C, func_0606DF2C);
-INCLUDE_ASM("asm/saturn/game", f606DFA0, func_0606DFA0);
-INCLUDE_ASM("asm/saturn/game", f606E020, func_0606E020);
-INCLUDE_ASM("asm/saturn/game", f606E074, func_0606E074);
-INCLUDE_ASM("asm/saturn/game", f606E0D0, func_0606E0D0);
-INCLUDE_ASM("asm/saturn/game", f606EE28, func_0606EE28);
-INCLUDE_ASM("asm/saturn/game", f606EEF8, func_0606EEF8);
-INCLUDE_ASM("asm/saturn/game", f606F01C, func_0606F01C);
-INCLUDE_ASM("asm/saturn/game", f606F14C, func_0606F14C);
-INCLUDE_ASM("asm/saturn/game", f606F1C8, func_0606F1C8);
-INCLUDE_ASM("asm/saturn/game", f606F21C, func_0606F21C);
-INCLUDE_ASM("asm/saturn/game", f606F2C0, func_0606F2C0);
-INCLUDE_ASM("asm/saturn/game", f606F328, func_0606F328);
-INCLUDE_ASM("asm/saturn/game", f606F348, func_0606F348);
-INCLUDE_ASM("asm/saturn/game", f606F378, func_0606F378);
-INCLUDE_ASM("asm/saturn/game", f606F3D8, func_0606F3D8);
-INCLUDE_ASM("asm/saturn/game", f606F3F8, func_0606F3F8);
-INCLUDE_ASM("asm/saturn/game", f606F418, func_0606F418);
-INCLUDE_ASM("asm/saturn/game", f606F448, func_0606F448);
-INCLUDE_ASM("asm/saturn/game", f606F4C4, func_0606F4C4);
-INCLUDE_ASM("asm/saturn/game", f606F59C, func_0606F59C);
-INCLUDE_ASM("asm/saturn/game", f606F65C, func_0606F65C);
-INCLUDE_ASM("asm/saturn/game", f606F760, func_0606F760);
-INCLUDE_ASM("asm/saturn/game", f606F798, func_0606F798);
-INCLUDE_ASM("asm/saturn/game", f606F800, func_0606F800);
-INCLUDE_ASM("asm/saturn/game", f606F884, func_0606F884);
-INCLUDE_ASM("asm/saturn/game", f606F8A8, func_0606F8A8);
-INCLUDE_ASM("asm/saturn/game", f606FA30, func_0606FA30);
-INCLUDE_ASM("asm/saturn/game", f606FC60, func_0606FC60);
-INCLUDE_ASM("asm/saturn/game", f606FC80, func_0606FC80);
-INCLUDE_ASM("asm/saturn/game", f606FE60, func_0606FE60);
-INCLUDE_ASM("asm/saturn/game", f606FFA0, func_0606FFA0);
+INCLUDE_ASM("asm/saturn/game/data", d6066000, d_06066000);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066040, func_06066040);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60661BC, func_060661BC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066330, func_06066330);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066400, func_06066400);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60664E0, func_060664E0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60665BC, func_060665BC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60666A4, func_060666A4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066854, func_06066854);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60668D4, func_060668D4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066B30, func_06066B30);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066B74, func_06066B74);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066CE0, func_06066CE0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6066FE0, func_06066FE0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6067090, func_06067090);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60674B8, func_060674B8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6067958, func_06067958);
+INCLUDE_ASM("asm/saturn/game/data", d606797C, d_0606797C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6067A04, func_06067A04);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606B6F8, func_0606B6F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606B760, func_0606B760);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606BB4C, func_0606BB4C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606BEE4, func_0606BEE4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C064, func_0606C064);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C088, func_0606C088);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C160, func_0606C160);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C3E4, func_0606C3E4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C504, func_0606C504);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C594, func_0606C594);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606C774, func_0606C774);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606CA10, func_0606CA10);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D058, func_0606D058);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D2D0, func_0606D2D0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D358, func_0606D358);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D3FC, func_0606D3FC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D554, func_0606D554);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D5FC, func_0606D5FC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D6DC, func_0606D6DC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D798, func_0606D798);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D804, func_0606D804);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606D880, func_0606D880);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606DAE8, func_0606DAE8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606DC8C, func_0606DC8C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606DCF0, func_0606DCF0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606DF2C, func_0606DF2C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606DFA0, func_0606DFA0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606E020, func_0606E020);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606E074, func_0606E074);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606E0D0, func_0606E0D0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606EE28, func_0606EE28);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606EEF8, func_0606EEF8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F01C, func_0606F01C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F14C, func_0606F14C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F1C8, func_0606F1C8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F21C, func_0606F21C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F2C0, func_0606F2C0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F328, func_0606F328);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F348, func_0606F348);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F378, func_0606F378);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F3D8, func_0606F3D8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F3F8, func_0606F3F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F418, func_0606F418);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F448, func_0606F448);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F4C4, func_0606F4C4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F59C, func_0606F59C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F65C, func_0606F65C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F760, func_0606F760);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F798, func_0606F798);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F800, func_0606F800);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F884, func_0606F884);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606F8A8, func_0606F8A8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FA30, func_0606FA30);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FC60, func_0606FC60);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FC80, func_0606FC80);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FE60, func_0606FE60);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FFA0, func_0606FFA0);
 
 extern s32 DAT_06086380;
 void func_0606FFC8(void) {
@@ -84,76 +84,76 @@ void func_0606FFC8(void) {
     }
 }
 
-INCLUDE_ASM("asm/saturn/game", f606FFE4, func_0606FFE4);
-INCLUDE_ASM("asm/saturn/game", f607003C, func_0607003C);
-INCLUDE_ASM("asm/saturn/game", f60703DC, func_060703DC);
-INCLUDE_ASM("asm/saturn/game", f6070410, func_06070410);
-INCLUDE_ASM("asm/saturn/game", f6070540, func_06070540);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f606FFE4, func_0606FFE4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607003C, func_0607003C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60703DC, func_060703DC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070410, func_06070410);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070540, func_06070540);
 
 extern s32 DAT_060861B0[];
 s32 func_06070568(s32 pos) { DAT_060861B0[pos] = 0; }
 
-INCLUDE_ASM("asm/saturn/game", f6070580, func_06070580);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070580, func_06070580);
 
 s32 func_060705A0(s32 pos) { DAT_060861B0[pos] = 0x1000; }
 
 s32 func_060705B8(s32 pos) { return DAT_060861B0[pos]; }
 
-INCLUDE_ASM("asm/saturn/game", f60705CC, func_060705CC);
-INCLUDE_ASM("asm/saturn/game", f60707F0, func_060707F0);
-INCLUDE_ASM("asm/saturn/game", f6070820, func_06070820);
-INCLUDE_ASM("asm/saturn/game", f6070938, func_06070938);
-INCLUDE_ASM("asm/saturn/game", f6070988, func_06070988);
-INCLUDE_ASM("asm/saturn/game", d6070A60, d_06070A60);
-INCLUDE_ASM("asm/saturn/game", f6071C3C, func_06071C3C);
-INCLUDE_ASM("asm/saturn/game", f60720F4, func_060720F4);
-INCLUDE_ASM("asm/saturn/game", f60726A8, func_060726A8);
-INCLUDE_ASM("asm/saturn/game", f60727DC, func_060727DC);
-INCLUDE_ASM("asm/saturn/game", f607284C, func_0607284C);
-INCLUDE_ASM("asm/saturn/game", d60728B4, d_060728B4);
-INCLUDE_ASM("asm/saturn/game", f6072BCC, func_06072BCC);
-INCLUDE_ASM("asm/saturn/game", f6072C04, func_06072C04);
-INCLUDE_ASM("asm/saturn/game", f6072C94, func_06072C94);
-INCLUDE_ASM("asm/saturn/game", f60731C0, func_060731C0);
-INCLUDE_ASM("asm/saturn/game", f6073280, func_06073280);
-INCLUDE_ASM("asm/saturn/game", f60732E4, func_060732E4);
-INCLUDE_ASM("asm/saturn/game", f60733A4, func_060733A4);
-INCLUDE_ASM("asm/saturn/game", f607356C, func_0607356C);
-INCLUDE_ASM("asm/saturn/game", f60735A4, func_060735A4);
-INCLUDE_ASM("asm/saturn/game", f607360C, func_0607360C);
-INCLUDE_ASM("asm/saturn/game", f607369C, func_0607369C);
-INCLUDE_ASM("asm/saturn/game", f60736D4, func_060736D4);
-INCLUDE_ASM("asm/saturn/game", f607371C, func_0607371C);
-INCLUDE_ASM("asm/saturn/game", f6073740, func_06073740);
-INCLUDE_ASM("asm/saturn/game", f6073770, func_06073770);
-INCLUDE_ASM("asm/saturn/game", f60737A0, func_060737A0);
-INCLUDE_ASM("asm/saturn/game", f6073E58, func_06073E58);
-INCLUDE_ASM("asm/saturn/game", f6073EEC, func_06073EEC);
-INCLUDE_ASM("asm/saturn/game", f6073FEC, func_06073FEC);
-INCLUDE_ASM("asm/saturn/game", f6074048, func_06074048);
-INCLUDE_ASM("asm/saturn/game", f6074068, func_06074068);
-INCLUDE_ASM("asm/saturn/game", f60740F8, func_060740F8);
-INCLUDE_ASM("asm/saturn/game", f6074278, func_06074278);
-INCLUDE_ASM("asm/saturn/game", f60743B8, func_060743B8);
-INCLUDE_ASM("asm/saturn/game", f6074470, func_06074470);
-INCLUDE_ASM("asm/saturn/game", f60744F8, func_060744F8);
-INCLUDE_ASM("asm/saturn/game", f60745A0, func_060745A0);
-INCLUDE_ASM("asm/saturn/game", f6074698, func_06074698);
-INCLUDE_ASM("asm/saturn/game", f6074700, func_06074700);
-INCLUDE_ASM("asm/saturn/game", f6074724, func_06074724);
-INCLUDE_ASM("asm/saturn/game", f6074964, func_06074964);
-INCLUDE_ASM("asm/saturn/game", f60749F8, func_060749F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60705CC, func_060705CC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60707F0, func_060707F0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070820, func_06070820);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070938, func_06070938);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6070988, func_06070988);
+INCLUDE_ASM("asm/saturn/game/data", d6070A60, d_06070A60);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6071C3C, func_06071C3C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60720F4, func_060720F4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60726A8, func_060726A8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60727DC, func_060727DC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607284C, func_0607284C);
+INCLUDE_ASM("asm/saturn/game/data", d60728B4, d_060728B4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6072BCC, func_06072BCC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6072C04, func_06072C04);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6072C94, func_06072C94);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60731C0, func_060731C0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073280, func_06073280);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60732E4, func_060732E4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60733A4, func_060733A4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607356C, func_0607356C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60735A4, func_060735A4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607360C, func_0607360C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607369C, func_0607369C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60736D4, func_060736D4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607371C, func_0607371C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073740, func_06073740);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073770, func_06073770);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60737A0, func_060737A0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073E58, func_06073E58);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073EEC, func_06073EEC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6073FEC, func_06073FEC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074048, func_06074048);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074068, func_06074068);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60740F8, func_060740F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074278, func_06074278);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60743B8, func_060743B8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074470, func_06074470);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60744F8, func_060744F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60745A0, func_060745A0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074698, func_06074698);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074700, func_06074700);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074724, func_06074724);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074964, func_06074964);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60749F8, func_060749F8);
 
 extern s32 DAT_06085c70;
 s32* func_06074A98(void) { return &DAT_06085c70; }
 
-INCLUDE_ASM("asm/saturn/game", f6074AA8, func_06074AA8);
-INCLUDE_ASM("asm/saturn/game", f6074BF4, func_06074BF4);
-INCLUDE_ASM("asm/saturn/game", f6074C28, func_06074C28);
-INCLUDE_ASM("asm/saturn/game", f6074CC8, func_06074CC8);
-INCLUDE_ASM("asm/saturn/game", f6075838, func_06075838);
-INCLUDE_ASM("asm/saturn/game", f6075D24, func_06075D24);
-INCLUDE_ASM("asm/saturn/game", f60766DC, func_060766DC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074AA8, func_06074AA8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074BF4, func_06074BF4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074C28, func_06074C28);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6074CC8, func_06074CC8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6075838, func_06075838);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6075D24, func_06075D24);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60766DC, func_060766DC);
 
 struct Unk_060860D8 {
     u8 pad[0x23];
@@ -163,48 +163,48 @@ struct Unk_060860D8 {
 extern struct Unk_060860D8 DAT_060860D8;
 s32 func_06076718(void) { return DAT_060860D8.unk24 == 0x15; }
 
-INCLUDE_ASM("asm/saturn/game", f607672C, func_0607672C);
-INCLUDE_ASM("asm/saturn/game", f6076A04, func_06076A04);
-INCLUDE_ASM("asm/saturn/game", f6077148, func_06077148);
-INCLUDE_ASM("asm/saturn/game", f607718C, func_0607718C);
-INCLUDE_ASM("asm/saturn/game", f60771B0, func_060771B0);
-INCLUDE_ASM("asm/saturn/game", f60771D4, func_060771D4);
-INCLUDE_ASM("asm/saturn/game", f6077260, func_06077260);
-INCLUDE_ASM("asm/saturn/game", f6077354, func_06077354);
-INCLUDE_ASM("asm/saturn/game", f6077764, func_06077764);
-INCLUDE_ASM("asm/saturn/game", f6077B20, func_06077B20);
-INCLUDE_ASM("asm/saturn/game", f6077D88, func_06077D88);
-INCLUDE_ASM("asm/saturn/game", f6078120, func_06078120);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607672C, func_0607672C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6076A04, func_06076A04);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077148, func_06077148);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607718C, func_0607718C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60771B0, func_060771B0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60771D4, func_060771D4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077260, func_06077260);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077354, func_06077354);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077764, func_06077764);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077B20, func_06077B20);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6077D88, func_06077D88);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078120, func_06078120);
 
 extern s32 DAT_00292000;
 
 s32* func_060784A8(void) { return &DAT_00292000; }
 
-INCLUDE_ASM("asm/saturn/game", f60784B8, func_060784B8);
-INCLUDE_ASM("asm/saturn/game", f6078550, func_06078550);
-INCLUDE_ASM("asm/saturn/game", f6078604, func_06078604);
-INCLUDE_ASM("asm/saturn/game", f6078684, func_06078684);
-INCLUDE_ASM("asm/saturn/game", f607872C, func_0607872C);
-INCLUDE_ASM("asm/saturn/game", f6078748, func_06078748);
-INCLUDE_ASM("asm/saturn/game", f60787C8, func_060787C8);
-INCLUDE_ASM("asm/saturn/game", f6078920, func_06078920);
-INCLUDE_ASM("asm/saturn/game", f60789C4, func_060789C4);
-INCLUDE_ASM("asm/saturn/game", f6078D58, func_06078D58);
-INCLUDE_ASM("asm/saturn/game", f6078E80, func_06078E80);
-INCLUDE_ASM("asm/saturn/game", f6078F58, func_06078F58);
-INCLUDE_ASM("asm/saturn/game", f6079008, func_06079008);
-INCLUDE_ASM("asm/saturn/game", f60790B4, func_060790B4);
-INCLUDE_ASM("asm/saturn/game", f6079208, func_06079208);
-INCLUDE_ASM("asm/saturn/game", f60792B8, func_060792B8);
-INCLUDE_ASM("asm/saturn/game", f6079424, func_06079424);
-INCLUDE_ASM("asm/saturn/game", f6079580, func_06079580);
-INCLUDE_ASM("asm/saturn/game", f6079670, func_06079670);
-INCLUDE_ASM("asm/saturn/game", f607973C, func_0607973C);
-INCLUDE_ASM("asm/saturn/game", f60797FC, func_060797FC);
-INCLUDE_ASM("asm/saturn/game", f6079958, func_06079958);
-INCLUDE_ASM("asm/saturn/game", f6079A2C, func_06079A2C);
-INCLUDE_ASM("asm/saturn/game", f6079AF0, func_06079AF0);
-INCLUDE_ASM("asm/saturn/game", f6079B74, func_06079B74);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60784B8, func_060784B8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078550, func_06078550);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078604, func_06078604);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078684, func_06078684);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607872C, func_0607872C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078748, func_06078748);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60787C8, func_060787C8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078920, func_06078920);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60789C4, func_060789C4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078D58, func_06078D58);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078E80, func_06078E80);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6078F58, func_06078F58);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079008, func_06079008);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60790B4, func_060790B4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079208, func_06079208);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60792B8, func_060792B8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079424, func_06079424);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079580, func_06079580);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079670, func_06079670);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607973C, func_0607973C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f60797FC, func_060797FC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079958, func_06079958);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079A2C, func_06079A2C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079AF0, func_06079AF0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079B74, func_06079B74);
 
 void func_06079B9C(s32* param_1) {
     param_1[1] += param_1[3];
@@ -227,56 +227,56 @@ void func_06079BCC(s32* param_1) {
     }
 }
 
-INCLUDE_ASM("asm/saturn/game", f6079BE4, func_06079BE4);
-INCLUDE_ASM("asm/saturn/game", f6079C04, func_06079C04);
-INCLUDE_ASM("asm/saturn/game", f6079DEC, func_06079DEC);
-INCLUDE_ASM("asm/saturn/game", f6079F60, func_06079F60);
-INCLUDE_ASM("asm/saturn/game", f607A030, func_0607A030);
-INCLUDE_ASM("asm/saturn/game", f607A118, func_0607A118);
-INCLUDE_ASM("asm/saturn/game", f607A1C8, func_0607A1C8);
-INCLUDE_ASM("asm/saturn/game", f607A290, func_0607A290);
-INCLUDE_ASM("asm/saturn/game", f607A608, func_0607A608);
-INCLUDE_ASM("asm/saturn/game", f607A88C, func_0607A88C);
-INCLUDE_ASM("asm/saturn/game", f607A994, func_0607A994);
-INCLUDE_ASM("asm/saturn/game", f607A9F8, func_0607A9F8);
-INCLUDE_ASM("asm/saturn/game", f607AA1C, func_0607AA1C);
-INCLUDE_ASM("asm/saturn/game", f607AA40, func_0607AA40);
-INCLUDE_ASM("asm/saturn/game", f607AA74, func_0607AA74);
-INCLUDE_ASM("asm/saturn/game", f607AAA4, func_0607AAA4);
-INCLUDE_ASM("asm/saturn/game", f607AACC, func_0607AACC);
-INCLUDE_ASM("asm/saturn/game", f607AAF4, func_0607AAF4);
-INCLUDE_ASM("asm/saturn/game", f607AB1C, func_0607AB1C);
-INCLUDE_ASM("asm/saturn/game", f607AB4C, func_0607AB4C);
-INCLUDE_ASM("asm/saturn/game", f607AB84, func_0607AB84);
-INCLUDE_ASM("asm/saturn/game", f607ABBC, func_0607ABBC);
-INCLUDE_ASM("asm/saturn/game", f607ABF4, func_0607ABF4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079BE4, func_06079BE4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079C04, func_06079C04);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079DEC, func_06079DEC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f6079F60, func_06079F60);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A030, func_0607A030);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A118, func_0607A118);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A1C8, func_0607A1C8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A290, func_0607A290);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A608, func_0607A608);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A88C, func_0607A88C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A994, func_0607A994);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607A9F8, func_0607A9F8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AA1C, func_0607AA1C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AA40, func_0607AA40);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AA74, func_0607AA74);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AAA4, func_0607AAA4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AACC, func_0607AACC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AAF4, func_0607AAF4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AB1C, func_0607AB1C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AB4C, func_0607AB4C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AB84, func_0607AB84);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607ABBC, func_0607ABBC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607ABF4, func_0607ABF4);
 
 extern u8 DAT_06099811;
 u8 func_0607AC2C(void) { return DAT_06099811; }
 
-INCLUDE_ASM("asm/saturn/game", f607AC40, func_0607AC40);
-INCLUDE_ASM("asm/saturn/game", f607AE48, func_0607AE48);
-INCLUDE_ASM("asm/saturn/game", f607AECC, func_0607AECC);
-INCLUDE_ASM("asm/saturn/game", f607AF0C, func_0607AF0C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AC40, func_0607AC40);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AE48, func_0607AE48);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AECC, func_0607AECC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AF0C, func_0607AF0C);
 
 extern s16 DAT_06085e86[];
 s32 func_0607AF28(u8 pos) { return DAT_06085e86[pos]; }
 
-INCLUDE_ASM("asm/saturn/game", f607AF3C, func_0607AF3C);
-INCLUDE_ASM("asm/saturn/game", f607AF68, func_0607AF68);
-INCLUDE_ASM("asm/saturn/game", f607AF94, func_0607AF94);
-INCLUDE_ASM("asm/saturn/game", f607AFD8, func_0607AFD8);
-INCLUDE_ASM("asm/saturn/game", f607B014, func_0607B014);
-INCLUDE_ASM("asm/saturn/game", f607B04C, func_0607B04C);
-INCLUDE_ASM("asm/saturn/game", f607B0AC, func_0607B0AC);
-INCLUDE_ASM("asm/saturn/game", f607B0D0, func_0607B0D0);
-INCLUDE_ASM("asm/saturn/game", f607B104, func_0607B104);
-INCLUDE_ASM("asm/saturn/game", f607B134, func_0607B134);
-INCLUDE_ASM("asm/saturn/game", f607B184, func_0607B184);
-INCLUDE_ASM("asm/saturn/game", f607B1C8, func_0607B1C8);
-INCLUDE_ASM("asm/saturn/game", f607B218, func_0607B218);
-INCLUDE_ASM("asm/saturn/game", f607B240, func_0607B240);
-INCLUDE_ASM("asm/saturn/game", f607B264, func_0607B264);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AF3C, func_0607AF3C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AF68, func_0607AF68);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AF94, func_0607AF94);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607AFD8, func_0607AFD8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B014, func_0607B014);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B04C, func_0607B04C);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B0AC, func_0607B0AC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B0D0, func_0607B0D0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B104, func_0607B104);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B134, func_0607B134);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B184, func_0607B184);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B1C8, func_0607B1C8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B218, func_0607B218);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B240, func_0607B240);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B264, func_0607B264);
 
 extern u32 g_randomNext;
 
@@ -286,11 +286,11 @@ s32 Random(void) {
     return g_randomNext >> 0x18;
 }
 
-INCLUDE_ASM("asm/saturn/game", f607B318, func_0607B318);
-INCLUDE_ASM("asm/saturn/game", f607B374, func_0607B374);
-INCLUDE_ASM("asm/saturn/game", f607B3D0, func_0607B3D0);
-INCLUDE_ASM("asm/saturn/game", f607B448, func_0607B448);
-INCLUDE_ASM("asm/saturn/game", f607B4B8, func_0607B4B8);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B318, func_0607B318);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B374, func_0607B374);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B3D0, func_0607B3D0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B448, func_0607B448);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B4B8, func_0607B4B8);
 
 void func_0607B604(s32* param_1) {
     s32* temp = *param_1;
@@ -298,12 +298,12 @@ void func_0607B604(s32* param_1) {
     temp[0x18 / 4] = param_1[2];
 }
 
-INCLUDE_ASM("asm/saturn/game", f607B618, func_0607B618);
-INCLUDE_ASM("asm/saturn/game", f607B674, func_0607B674);
-INCLUDE_ASM("asm/saturn/game", f607B714, func_0607B714);
-INCLUDE_ASM("asm/saturn/game", f607B7B4, func_0607B7B4);
-INCLUDE_ASM("asm/saturn/game", f607BE38, func_0607BE38);
-INCLUDE_ASM("asm/saturn/game", f607BED0, func_0607BED0);
-INCLUDE_ASM("asm/saturn/game", f607C054, func_0607C054);
-INCLUDE_ASM("asm/saturn/game", f607C0A0, func_0607C0A0);
-INCLUDE_ASM("asm/saturn/game", f607C0BC, func_0607C0BC);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B618, func_0607B618);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B674, func_0607B674);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B714, func_0607B714);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607B7B4, func_0607B7B4);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607BE38, func_0607BE38);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607BED0, func_0607BED0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607C054, func_0607C054);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607C0A0, func_0607C0A0);
+INCLUDE_ASM("asm/saturn/game/f_nonmat", f607C0BC, func_0607C0BC);

--- a/src/saturn/stage_02.c
+++ b/src/saturn/stage_02.c
@@ -3,51 +3,51 @@
 
 // Alchemy Laboratory
 
-INCLUDE_ASM("asm/saturn/stage_02", d60DC000, d_060DC000);
-INCLUDE_ASM("asm/saturn/stage_02", f60DC040, func_060DC040);
-INCLUDE_ASM("asm/saturn/stage_02", f60DC460, func_060DC460);
-INCLUDE_ASM("asm/saturn/stage_02", f60DC4EC, func_060DC4EC);
-INCLUDE_ASM("asm/saturn/stage_02", f60DC510, func_060DC510);
-INCLUDE_ASM("asm/saturn/stage_02", f60DC7B4, func_060DC7B4);
-INCLUDE_ASM("asm/saturn/stage_02", f60DCA54, func_060DCA54);
-INCLUDE_ASM("asm/saturn/stage_02", f60DCCD4, func_060DCCD4);
-INCLUDE_ASM("asm/saturn/stage_02", f60DCFA4, func_060DCFA4);
-INCLUDE_ASM("asm/saturn/stage_02", f60DD20C, func_060DD20C);
-INCLUDE_ASM("asm/saturn/stage_02", f60DD3E8, func_060DD3E8);
-INCLUDE_ASM("asm/saturn/stage_02", f60DD690, func_060DD690);
-INCLUDE_ASM("asm/saturn/stage_02", f60DD790, func_060DD790);
-INCLUDE_ASM("asm/saturn/stage_02", f60DD8D8, func_060DD8D8);
-INCLUDE_ASM("asm/saturn/stage_02", f60DDB80, func_060DDB80);
-INCLUDE_ASM("asm/saturn/stage_02", f60DDE40, func_060DDE40);
-INCLUDE_ASM("asm/saturn/stage_02", f60DDF64, func_060DDF64);
-INCLUDE_ASM("asm/saturn/stage_02", f60DE178, func_060DE178);
-INCLUDE_ASM("asm/saturn/stage_02", f60DE2B0, func_060DE2B0);
-INCLUDE_ASM("asm/saturn/stage_02", f60DE348, func_060DE348);
-INCLUDE_ASM("asm/saturn/stage_02", f60DE6CC, func_060DE6CC);
-INCLUDE_ASM("asm/saturn/stage_02", f60DE970, func_060DE970);
-INCLUDE_ASM("asm/saturn/stage_02", f60DEE20, func_060DEE20);
-INCLUDE_ASM("asm/saturn/stage_02", f60DF264, func_060DF264);
-INCLUDE_ASM("asm/saturn/stage_02", f60DF3B8, func_060DF3B8);
-INCLUDE_ASM("asm/saturn/stage_02", f60DF52C, func_060DF52C);
-INCLUDE_ASM("asm/saturn/stage_02", f60DF664, func_060DF664);
-INCLUDE_ASM("asm/saturn/stage_02", f60DF798, func_060DF798);
-INCLUDE_ASM("asm/saturn/stage_02", f60DFAE4, func_060DFAE4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0304, func_060E0304);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0684, func_060E0684);
-INCLUDE_ASM("asm/saturn/stage_02", f60E08B0, func_060E08B0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E08E4, func_060E08E4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E093C, func_060E093C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0AF0, func_060E0AF0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0B24, func_060E0B24);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0B7C, func_060E0B7C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E0DC8, func_060E0DC8);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60DC000, d_060DC000);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DC040, func_060DC040);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DC460, func_060DC460);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DC4EC, func_060DC4EC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DC510, func_060DC510);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DC7B4, func_060DC7B4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DCA54, func_060DCA54);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DCCD4, func_060DCCD4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DCFA4, func_060DCFA4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DD20C, func_060DD20C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DD3E8, func_060DD3E8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DD690, func_060DD690);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DD790, func_060DD790);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DD8D8, func_060DD8D8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DDB80, func_060DDB80);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DDE40, func_060DDE40);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DDF64, func_060DDF64);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DE178, func_060DE178);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DE2B0, func_060DE2B0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DE348, func_060DE348);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DE6CC, func_060DE6CC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DE970, func_060DE970);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DEE20, func_060DEE20);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DF264, func_060DF264);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DF3B8, func_060DF3B8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DF52C, func_060DF52C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DF664, func_060DF664);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DF798, func_060DF798);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60DFAE4, func_060DFAE4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0304, func_060E0304);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0684, func_060E0684);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E08B0, func_060E08B0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E08E4, func_060E08E4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E093C, func_060E093C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0AF0, func_060E0AF0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0B24, func_060E0B24);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0B7C, func_060E0B7C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0DC8, func_060E0DC8);
 void f60E0F58() {}
 void f60E0F64() {}
-INCLUDE_ASM("asm/saturn/stage_02", f60E0F70, func_060E0F70);
-INCLUDE_ASM("asm/saturn/stage_02", f60E1A00, func_060E1A00);
-INCLUDE_ASM("asm/saturn/stage_02", f60E1C08, func_060E1C08);
-INCLUDE_ASM("asm/saturn/stage_02", f60E1CA8, func_060E1CA8);
-INCLUDE_ASM("asm/saturn/stage_02", f60E1D48, func_060E1D48);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E0F70, func_060E0F70);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E1A00, func_060E1A00);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E1C08, func_060E1C08);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E1CA8, func_060E1CA8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E1D48, func_060E1D48);
 
 struct Unk {
     u8 pad[0x38];
@@ -65,16 +65,16 @@ void func_060e1ff8(s32 param_1) {
     DAT_060e2014.unk_38 = 1;
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E2018, func_060E2018);
-INCLUDE_ASM("asm/saturn/stage_02", f60E21B8, func_060E21B8);
-INCLUDE_ASM("asm/saturn/stage_02", f60E22FC, func_060E22FC);
-INCLUDE_ASM("asm/saturn/stage_02", f60E2420, func_060E2420);
-INCLUDE_ASM("asm/saturn/stage_02", f60E2898, func_060E2898);
-INCLUDE_ASM("asm/saturn/stage_02", f60E29A4, func_060E29A4);
-INCLUDE_ASM("asm/saturn/stage_02", d60E2A80, d_060E2A80);
-INCLUDE_ASM("asm/saturn/stage_02", d60E32DC, d_060E32DC);
-INCLUDE_ASM("asm/saturn/stage_02", d60E47A4, d_060E47A4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E4908, func_060E4908);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E2018, func_060E2018);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E21B8, func_060E21B8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E22FC, func_060E22FC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E2420, func_060E2420);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E2898, func_060E2898);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E29A4, func_060E29A4);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60E2A80, d_060E2A80);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60E32DC, d_060E32DC);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60E47A4, d_060E47A4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E4908, func_060E4908);
 
 typedef struct Entity {
     s16 temp;
@@ -129,25 +129,25 @@ s32 func_801BBC3C(Entity* e) {
     return 1;
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E4FD0, func_060E4FD0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5388, func_060E5388);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5410, func_060E5410);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5AE4, func_060E5AE4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5C4C, func_060E5C4C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5DB4, func_060E5DB4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E5EA0, func_060E5EA0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E600C, func_060E600C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E6140, func_060E6140);
-INCLUDE_ASM("asm/saturn/stage_02", f60E625C, func_060E625C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E633C, func_060E633C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E6628, func_060E6628);
-INCLUDE_ASM("asm/saturn/stage_02", f60E6B00, func_060E6B00);
-INCLUDE_ASM("asm/saturn/stage_02", f60E6C0C, func_060E6C0C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E7014, func_060E7014);
-INCLUDE_ASM("asm/saturn/stage_02", f60E73CC, func_060E73CC);
-INCLUDE_ASM("asm/saturn/stage_02", f60E7508, func_060E7508);
-INCLUDE_ASM("asm/saturn/stage_02", f60E81D4, func_060E81D4);
-INCLUDE_ASM("asm/saturn/stage_02", f60E82EC, func_060E82EC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E4FD0, func_060E4FD0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5388, func_060E5388);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5410, func_060E5410);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5AE4, func_060E5AE4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5C4C, func_060E5C4C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5DB4, func_060E5DB4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E5EA0, func_060E5EA0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E600C, func_060E600C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E6140, func_060E6140);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E625C, func_060E625C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E633C, func_060E633C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E6628, func_060E6628);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E6B00, func_060E6B00);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E6C0C, func_060E6C0C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E7014, func_060E7014);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E73CC, func_060E73CC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E7508, func_060E7508);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E81D4, func_060E81D4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E82EC, func_060E82EC);
 
 s32 arr_0605C140[];
 
@@ -157,8 +157,8 @@ void func_060e8330(void) {
     arr_0605C140[0xF1] = 1;
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E8350, func_060E8350);
-INCLUDE_ASM("asm/saturn/stage_02", f60E837C, func_060E837C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E8350, func_060E8350);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E837C, func_060E837C);
 
 void func_060E87D0(s32, s32);
 void func_060E8990(s32, s32, s32);
@@ -170,9 +170,9 @@ void func_060E8780(s32 param_1, s32 param_2, s32 param_3, s32 param_4) {
     func_060E8ADC(param_1, param_2, param_4);
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E87D0, func_060E87D0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E8990, func_060E8990);
-INCLUDE_ASM("asm/saturn/stage_02", f60E8ADC, func_060E8ADC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E87D0, func_060E87D0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E8990, func_060E8990);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E8ADC, func_060E8ADC);
 
 void func_060E8E1C(s32, s32);
 void func_060E8EEC(s32, s32, s32);
@@ -182,11 +182,11 @@ void func_060E8DE0(s32 arg0, s32 arg1, s32 arg2) {
     func_060E8EEC(arg0, arg1, arg2);
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E8E1C, func_060E8E1C);
-INCLUDE_ASM("asm/saturn/stage_02", f60E8EEC, func_060E8EEC);
-INCLUDE_ASM("asm/saturn/stage_02", f60E9058, func_060E9058);
-INCLUDE_ASM("asm/saturn/stage_02", f60E9220, func_060E9220);
-INCLUDE_ASM("asm/saturn/stage_02", f60E9270, func_060E9270);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E8E1C, func_060E8E1C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E8EEC, func_060E8EEC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E9058, func_060E9058);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E9220, func_060E9220);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E9270, func_060E9270);
 
 // dupe of func_060e97c4
 void func_060E92A8(u16** param_1) {
@@ -203,8 +203,8 @@ void func_060E92A8(u16** param_1) {
 const u16 pad_060e92d4 = 0xAAAA;
 const u16 pad_060e92d6 = 0xAAAB;
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E92D8, func_060E92D8);
-INCLUDE_ASM("asm/saturn/stage_02", f60E9770, func_060E9770);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E92D8, func_060E92D8);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E9770, func_060E9770);
 
 // seems to saturn-only. param_1 is probably a struct?
 void func_060e97c4(u16** param_1) {
@@ -217,10 +217,10 @@ void func_060e97c4(u16** param_1) {
     }
 }
 
-INCLUDE_ASM("asm/saturn/stage_02", f60E97F0, func_060E97F0);
-INCLUDE_ASM("asm/saturn/stage_02", f60E9828, func_060E9828);
-INCLUDE_ASM("asm/saturn/stage_02", f60EA058, func_060EA058);
-INCLUDE_ASM("asm/saturn/stage_02", f60EA1E0, func_060EA1E0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E97F0, func_060E97F0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60E9828, func_060E9828);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EA058, func_060EA058);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EA1E0, func_060EA1E0);
 
 // dupe of func_060e97c4
 void func_060EA234(u16** param_1) {
@@ -235,21 +235,21 @@ void func_060EA234(u16** param_1) {
 const u16 pad_060EA260 = 0xCCCC;
 const u16 pad_060EA262 = 0xCCCD;
 
-INCLUDE_ASM("asm/saturn/stage_02", f60EA264, func_060EA264);
-INCLUDE_ASM("asm/saturn/stage_02", f60EAC54, func_060EAC54);
-INCLUDE_ASM("asm/saturn/stage_02", f60EACC0, func_060EACC0);
-INCLUDE_ASM("asm/saturn/stage_02", f60EAF2C, func_060EAF2C);
-INCLUDE_ASM("asm/saturn/stage_02", f60EAFAC, func_060EAFAC);
-INCLUDE_ASM("asm/saturn/stage_02", f60EB5C4, func_060EB5C4);
-INCLUDE_ASM("asm/saturn/stage_02", f60EB6E4, func_060EB6E4);
-INCLUDE_ASM("asm/saturn/stage_02", f60EB8D0, func_060EB8D0);
-INCLUDE_ASM("asm/saturn/stage_02", f60EB950, func_060EB950);
-INCLUDE_ASM("asm/saturn/stage_02", f60EB9EC, func_060EB9EC);
-INCLUDE_ASM("asm/saturn/stage_02", f60EBEB0, func_060EBEB0);
-INCLUDE_ASM("asm/saturn/stage_02", f60EC030, func_060EC030);
-INCLUDE_ASM("asm/saturn/stage_02", f60EC1F0, func_060EC1F0);
-INCLUDE_ASM("asm/saturn/stage_02", f60EC240, func_060EC240);
-INCLUDE_ASM("asm/saturn/stage_02", f60EC278, func_060EC278);
-INCLUDE_ASM("asm/saturn/stage_02", f60EC730, func_060EC730);
-INCLUDE_ASM("asm/saturn/stage_02", d60ECA94, d_060ECA94);
-INCLUDE_ASM("asm/saturn/stage_02", d60ECC50, d_060ECC50);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EA264, func_060EA264);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAC54, func_060EAC54);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EACC0, func_060EACC0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAF2C, func_060EAF2C);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAFAC, func_060EAFAC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EB5C4, func_060EB5C4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EB6E4, func_060EB6E4);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EB8D0, func_060EB8D0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EB950, func_060EB950);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EB9EC, func_060EB9EC);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EBEB0, func_060EBEB0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EC030, func_060EC030);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EC1F0, func_060EC1F0);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EC240, func_060EC240);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EC278, func_060EC278);
+INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EC730, func_060EC730);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60ECA94, d_060ECA94);
+INCLUDE_ASM("asm/saturn/stage_02/data", d60ECC50, d_060ECC50);

--- a/src/saturn/t_bat.c
+++ b/src/saturn/t_bat.c
@@ -12,25 +12,25 @@ typedef struct Entity {
     u16 subId;
 } Entity;
 
-INCLUDE_ASM("asm/saturn/t_bat", d60CF000, d_060CF000);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF060, func_060CF060);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF294, func_060CF294);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF2E8, func_060CF2E8);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF410, func_060CF410);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF5F4, func_060CF5F4);
-INCLUDE_ASM("asm/saturn/t_bat", f60CF6B4, func_060CF6B4);
-INCLUDE_ASM("asm/saturn/t_bat", f60CFB00, func_060CFB00);
-INCLUDE_ASM("asm/saturn/t_bat", f60CFC48, func_060CFC48);
-INCLUDE_ASM("asm/saturn/t_bat", f60D0490, func_060D0490);
+INCLUDE_ASM("asm/saturn/t_bat/data", d60CF000, d_060CF000);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF060, func_060CF060);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF294, func_060CF294);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF2E8, func_060CF2E8);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF410, func_060CF410);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF5F4, func_060CF5F4);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF6B4, func_060CF6B4);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CFB00, func_060CFB00);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CFC48, func_060CFC48);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D0490, func_060D0490);
 
 void f60D0938() {}
 void f60D0944() {}
 void f60D0950() {}
 void f60D095C() {}
-INCLUDE_ASM("asm/saturn/t_bat", f60D0968, func_060D0968);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D0968, func_060D0968);
 void f60D0A4C() {}
 void f60D0A58() {}
-INCLUDE_ASM("asm/saturn/t_bat", f60D0A64, func_060D0A64);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D0A64, func_060D0A64);
 void f60D1010() {}
 void f60D101C() {}
 void f60D1028() {}
@@ -49,7 +49,7 @@ void func_80173C2C(Entity* entity) {
     func_0600FFB8(entity); // DestroyEntity
 }
 
-INCLUDE_ASM("asm/saturn/t_bat", f60D1070, func_060D1070);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D1070, func_060D1070);
 
 // PSX: TT_000:func_80173E78
 // SAT: T_BAT:f_021B8 / func_060D11B8
@@ -69,7 +69,7 @@ s32 func_80173E78(s32 arg0, s32 arg1) {
     return arg0;
 }
 
-INCLUDE_ASM("asm/saturn/t_bat", f60D11DC, func_060D11DC);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D11DC, func_060D11DC);
 
 // PSX: func_80173F30
 // SAT: func_060D1224
@@ -80,7 +80,7 @@ s32 func_80173F30(Entity* entity, s16 x, s16 y) {
            0xFFF; // was entity->posY.i.hi
 }
 
-INCLUDE_ASM("asm/saturn/t_bat", f60D125C, func_060D125C);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D125C, func_060D125C);
 
 s32 func_0600F914(s32, s32);
 
@@ -95,10 +95,10 @@ s32 func_80173FE8(Entity* entity, s32 x, s32 y) {
                          diffX); // SquareRoot12
 }
 
-INCLUDE_ASM("asm/saturn/t_bat", f60D12DC, func_060D12DC);
-INCLUDE_ASM("asm/saturn/t_bat", f60D141C, func_060D141C);
-INCLUDE_ASM("asm/saturn/t_bat", f60D1640, func_060D1640);
-INCLUDE_ASM("asm/saturn/t_bat", f60D16D0, func_060D16D0);
-INCLUDE_ASM("asm/saturn/t_bat", f60D1784, func_060D1784);
-INCLUDE_ASM("asm/saturn/t_bat", f60D1808, func_060D1808);
-INCLUDE_ASM("asm/saturn/t_bat", d60D1858, d_060D1858);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D12DC, func_060D12DC);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D141C, func_060D141C);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D1640, func_060D1640);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D16D0, func_060D16D0);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D1784, func_060D1784);
+INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60D1808, func_060D1808);
+INCLUDE_ASM("asm/saturn/t_bat/data", d60D1858, d_060D1858);

--- a/src/saturn/zero.c
+++ b/src/saturn/zero.c
@@ -1,8 +1,8 @@
 #include "inc_asm.h"
-INCLUDE_ASM("asm/saturn/zero", d6004080, d_06004080);
-INCLUDE_ASM("asm/saturn/zero", f600EE88, func_0600EE88);
-INCLUDE_ASM("asm/saturn/zero", d600EFBC, d_0600EFBC);
-INCLUDE_ASM("asm/saturn/zero", f600F914, func_0600F914);
-INCLUDE_ASM("asm/saturn/zero", d600F96C, d_0600F96C);
-INCLUDE_ASM("asm/saturn/zero", f600FFB8, func_0600FFB8);
-INCLUDE_ASM("asm/saturn/zero", d6010008, d_06010008);
+INCLUDE_ASM("asm/saturn/zero/data", d6004080, d_06004080);
+INCLUDE_ASM("asm/saturn/zero/f_nonmat", f600EE88, func_0600EE88);
+INCLUDE_ASM("asm/saturn/zero/data", d600EFBC, d_0600EFBC);
+INCLUDE_ASM("asm/saturn/zero/f_nonmat", f600F914, func_0600F914);
+INCLUDE_ASM("asm/saturn/zero/data", d600F96C, d_0600F96C);
+INCLUDE_ASM("asm/saturn/zero/f_nonmat", f600FFB8, func_0600FFB8);
+INCLUDE_ASM("asm/saturn/zero/data", d6010008, d_06010008);


### PR DESCRIPTION
Previously all the Saturn asm was placed in the same folder. Now there are folders for matching, nonmatching and data. The C files are scanned for the INCLUDE_ASM macro similarly to splat. This makes it easier to keep track of which functions still need to be worked on.