### PR TITLE
Switch ASPATCH to MASPSX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tools/saturn-splitter"]
 	path = tools/saturn-splitter
 	url = https://github.com/sozud/saturn-splitter.git
+[submodule "tools/maspsx"]
+	path = tools/maspsx
+	url = https://github.com/mkst/maspsx.git

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,21 @@
 .SECONDARY:
 
 # Binaries
-VERSION			?= us
+VERSION         ?= us
 MAIN            := main
 DRA             := dra
 
 # Compilers
-CC1PSX			:= ./bin/cc1-psx-26
+CC1PSX          := ./bin/cc1-psx-26
 CROSS           := mipsel-linux-gnu-
 AS              := $(CROSS)as
 CC              := $(CC1PSX)
 LD              := $(CROSS)ld
-CPP				:= $(CROSS)cpp
+CPP             := $(CROSS)cpp
 OBJCOPY         := $(CROSS)objcopy
 AS_FLAGS        += -Iinclude -march=r3000 -mtune=r3000 -no-pad-sections -O1 -G0
-CC_FLAGS        += -mcpu=3000 -quiet -G0 -w -O2 -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -fgnu-linker -mgas -msoft-float
-CPP_FLAGS       += -Iinclude -undef -Wall -lang-c -fno-builtin -gstabs
+CC_FLAGS        += -mcpu=3000 -quiet -G0 -w -O2 -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -fgnu-linker -mgas -msoft-float -gcoff
+CPP_FLAGS       += -Iinclude -undef -Wall -lang-c -fno-builtin
 CPP_FLAGS       += -Dmips -D__GNUC__=2 -D__OPTIMIZE__ -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D_LANGUAGE_C -DLANGUAGE_C -DHACKS
 CPP_FLAGS       += -D_internal_version_$(VERSION)
 
@@ -34,11 +34,11 @@ TOOLS_DIR       := tools
 MAIN_ASM_DIRS   := $(ASM_DIR)/$(MAIN) $(ASM_DIR)/$(MAIN)/psxsdk $(ASM_DIR)/$(MAIN)/data
 MAIN_SRC_DIRS   := $(SRC_DIR)/$(MAIN) $(SRC_DIR)/$(MAIN)/psxsdk
 MAIN_S_FILES    := $(foreach dir,$(MAIN_ASM_DIRS),$(wildcard $(dir)/*.s)) \
-					$(foreach dir,$(MAIN_ASM_DIRS),$(wildcard $(dir)/**/*.s))
+                   $(foreach dir,$(MAIN_ASM_DIRS),$(wildcard $(dir)/**/*.s))
 MAIN_C_FILES    := $(foreach dir,$(MAIN_SRC_DIRS),$(wildcard $(dir)/*.c)) \
-					$(foreach dir,$(MAIN_SRC_DIRS),$(wildcard $(dir)/**/*.c))
+                   $(foreach dir,$(MAIN_SRC_DIRS),$(wildcard $(dir)/**/*.c))
 MAIN_O_FILES    := $(foreach file,$(MAIN_S_FILES),$(BUILD_DIR)/$(file).o) \
-					$(foreach file,$(MAIN_C_FILES),$(BUILD_DIR)/$(file).o)
+                   $(foreach file,$(MAIN_C_FILES),$(BUILD_DIR)/$(file).o)
 MAIN_TARGET     := $(BUILD_DIR)/$(MAIN)
 
 # Tooling
@@ -53,12 +53,13 @@ M2CTX           := $(PYTHON) $(M2CTX_APP)
 M2C_DIR         := $(TOOLS_DIR)/m2c
 M2C_APP         := $(M2C_DIR)/m2c.py
 M2C             := $(PYTHON) $(M2C_APP)
-M2C_ARGS		:= -P 4
-GO				:= $(HOME)/go/bin/go
-GOPATH			:= $(HOME)/go
-ASPATCH			:= $(GOPATH)/bin/aspatch
-SOTNDISK		:= $(GOPATH)/bin/sotn-disk
-GFXSTAGE		:= $(PYTHON) $(TOOLS_DIR)/gfxstage.py
+M2C_ARGS        := -P 4
+GO              := $(HOME)/go/bin/go
+GOPATH          := $(HOME)/go
+ASPATCH         := $(GOPATH)/bin/aspatch
+MASPSX          := $(PYTHON) tools/maspsx/maspsx.py --no-macro-inc --expand-div
+SOTNDISK        := $(GOPATH)/bin/sotn-disk
+GFXSTAGE        := $(PYTHON) $(TOOLS_DIR)/gfxstage.py
 SATURN_SPLITTER_DIR := $(TOOLS_DIR)/saturn-splitter
 SATURN_SPLITTER_APP := $(SATURN_SPLITTER_DIR)/rust-dis/target/release/rust-dis
 
@@ -348,10 +349,10 @@ $(SATURN_SPLITTER_APP):
 $(BUILD_DIR)/%.s.o: %.s
 	$(AS) $(AS_FLAGS) -o $@ $<
 $(BUILD_DIR)/%.c.o: %.c $(ASPATCH) $(CC1PSX)
-	$(CPP) $(CPP_FLAGS) $< | $(CC) $(CC_FLAGS) | $(ASPATCH) | $(AS) $(AS_FLAGS) -o $@
+	$(CPP) $(CPP_FLAGS) $< | $(CC) $(CC_FLAGS) | $(MASPSX) | $(AS) $(AS_FLAGS) -o $@
 
 build_saturn_dosemu_docker_container:
-	docker build -t dosemu:latest -f tools/saturn_toolchain/dosemu_dockerfile . 
+	docker build -t dosemu:latest -f tools/saturn_toolchain/dosemu_dockerfile .
 
 build_saturn_binutils_docker_container:
 	docker build -t binutils-sh-elf:latest -f tools/saturn_toolchain/binutils_dockerfile .

--- a/src/dra/47BB8.c
+++ b/src/dra/47BB8.c
@@ -853,10 +853,6 @@ void func_800EAEEC(void) {
     func_800EAEA4();
 }
 
-// ASPSX jump to 'nop'
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/dra/nonmatchings/47BB8", func_800EAF28);
-#else
 void func_800EAF28(s32 arg0) {
     s32 temp_v1;
     s32 i;
@@ -884,7 +880,6 @@ void func_800EAF28(s32 arg0) {
         }
     }
 }
-#endif
 
 void DecompressWriteNibble(s32 ch) {
     u8 temp = ch;

--- a/src/dra/62D70.c
+++ b/src/dra/62D70.c
@@ -206,12 +206,6 @@ void func_801065F4(s16 startIndex) {
         DestroyEntity(pItem);
 }
 
-// Not jumping into a 'nop'. Matching with PSY-Q 3.5.
-#ifndef NON_MATCHING
-void DrawEntitiesHitbox(s32 blendMode);
-INCLUDE_ASM("asm/us/dra/nonmatchings/62D70", DrawEntitiesHitbox);
-#else
-// DECOMP_ME_WIP DrawEntitiesHitbox https://decomp.me/scratch/QFSeC
 void DrawEntitiesHitbox(s32 blendMode) {
     DR_MODE* drawMode;
     s32 polyCount;
@@ -311,7 +305,6 @@ void DrawEntitiesHitbox(s32 blendMode) {
         g_GpuUsage.drawModes++;
     }
 }
-#endif
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/62D70", func_80106A28);
 

--- a/src/dra/gameover.c
+++ b/src/dra/gameover.c
@@ -89,7 +89,7 @@ void func_800E5498(void) {
     g_GpuUsage.gt4++;
 }
 
-// Jump to 'nop' due to ASPSX missing
+// Jump to 'nop' due to ASPSX missing | needs rodata
 // HD version needs some tweaking at 'Gameover_4'
 #ifndef NON_MATCHING
 #if defined(VERSION_US)

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -589,11 +589,6 @@ void EntityMoveableBox(Entity* self) {
 }
 
 // lever to operate cannon
-// DECOMP_ME_WIP EntityCannonLever https://decomp.me/scratch/7ce8a
-// Matching in PSY-Q 3.5, assembler skips a nop
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", EntityCannonLever);
-#else
 void EntityCannonLever(Entity* self) {
     /** TODO: !FAKE
      * self->ext.generic.unk7C should be a POLY_G4*
@@ -659,18 +654,17 @@ void EntityCannonLever(Entity* self) {
         break;
 
     case 3:
-        D_80180ED0 = 1;
+        D_80180ED0[0] = 1;
         break;
     }
 
-    if (D_8003BE6F != 0) {
+    if (D_8003BE6F[0] != 0) {
         self->unk3C = 0;
     }
     poly = (POLY_GT4*)*(s32*)&self->ext.generic.unk7C.s;
     poly->x0 = self->posX.i.hi - 4;
     poly->y0 = self->posY.i.hi - 20;
 }
-#endif
 
 // cannon for shortcut
 void EntityCannon(Entity* self) {
@@ -907,11 +901,6 @@ INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", func_801B2D08);
 
 INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", func_801B2FD8);
 
-// Aspatch skips a nop. TODO: Fix compiler
-// Matching in decompme: https://decomp.me/scratch/Swhgi
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", EntityFloorSpikes);
-#else
 void EntityFloorSpikes(Entity* self) {
     Primitive* prim;
     s16 firstPrimIndex;
@@ -986,7 +975,6 @@ void EntityFloorSpikes(Entity* self) {
     prim->x0 = self->posX.i.hi - 16;
     prim->y0 = self->posY.i.hi - 16;
 }
-#endif
 
 // table with globe on it that can be broken
 void EntityTableWithGlobe(Entity* self) {

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -128,7 +128,7 @@ typedef enum {
 INCLUDE_ASM("asm/us/st/nz0/nonmatchings/33FCC", EntityCloseBossRoom);
 
 // blocks that move to close slogra/gaibon room
-// assembler skips a nop
+// assembler skips a nop | needs rodata
 #ifndef NON_MATCHING
 INCLUDE_ASM("asm/us/st/nz0/nonmatchings/33FCC", EntityBossRoomBlock);
 #else

--- a/src/st/nz0/43F9C.c
+++ b/src/st/nz0/43F9C.c
@@ -6,11 +6,6 @@
 
 #include "nz0.h"
 
-// aspatch skips a nop. TODO: fix compiler
-// matching in decomp.me: https://decomp.me/scratch/oDgqZ
-#ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/43F9C", func_801C3F9C);
-#else
 void func_801C3F9C(Unkstruct_801C3F9C** self) {
     Collider collider;
     Entity* newEntity;
@@ -52,7 +47,6 @@ void func_801C3F9C(Unkstruct_801C3F9C** self) {
         return;
     }
 }
-#endif
 
 // Called by EntityAxeKnight
 INCLUDE_ASM("asm/us/st/nz0/nonmatchings/43F9C", func_801C4198);

--- a/src/st/sel/func_801B8A8C.c
+++ b/src/st/sel/func_801B8A8C.c
@@ -2,7 +2,7 @@
 
 // TODO almost matching but one single jump makes not so. The original jump
 // points to a 'nop' while the current build toolchain points to the
-// instruction right after the 'nop'.
+// instruction right after the 'nop'. | needs rodata
 #ifndef NON_MATCHING
 INCLUDE_ASM("asm/us/st/sel/nonmatchings/func_801B8A8C", func_801B8A8C);
 #else


### PR DESCRIPTION
This PR replaces the ASPATCH command with my custom script named MASPSX. It's very new, and so is likely to have bugs and/or missing functionality. That said it's producing an :ok: build across all overlays, and is matching a few functions that required psyq3.5/aspsx.

I have not attempted to match any of the functions that require rodata, nor any of the functions that refused to compile / had diffs.

Note that I have added `-gcoff` to the `CC_FLAGS`, this will give you line numbers in asm-differ.

----------------------

Thank you in advance for contributing to sotn-decomp.
Before submitting this PR, please make sure:

- [x] The PR is small and focuses to address a single task
- [x] `make all` reports all `OK`
- [x] `make format` reports no files changed
- [x] Have Actions enabled in your fork to run the auto-formatter
