### PR TITLE
Changes to MenuContext

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -253,15 +253,17 @@ typedef struct {
 typedef struct {
     /* 0x00 */ s16 cursorX;
     /* 0x02 */ s16 cursorY;
-    /* 0x04 */ s16 unk4;
-    /* 0x06 */ s16 unk6;
+    /* 0x04 */ s16 cursorW;
+    /* 0x06 */ s16 cursorH;
     /* 0x08 */ RECT unk1;
     /* 0x10 */ s16 w;
-    /* 0x10 */ s16 h;
-    /* 0x14 */ int unk14;
+    /* 0x12 */ s16 h;
+    /* 0x14 */ s16 unk14;
+    /* 0x16 */ s16 unk16;
     /* 0x18 */ s16 unk18;
     /* 0x1A */ s16 unk1A;
-    /* 0x1C */ s16 unk1C;
+    /* 0x1C */ u8 unk1C;
+    /* 0x1D */ u8 unk1D;
 } MenuContext; // size = 0x1E
 #define SIZEOF_MENUCONTEXT (0x1E)
 

--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -362,19 +362,19 @@ void func_800F6508(MenuContext* context, s32 x, s32 y) {
 }
 
 // Draw main menu cursor
-void func_800F6568(MenuContext* arg0) {
+void func_800F6568(MenuContext* context) {
     s32 height;
     s32 r;
 
-    height = arg0->unk6 / 5;
+    height = context->cursorH / 5;
     if (g_blinkTimer & 0x20) {
         r = (g_blinkTimer & 0x1F) + 0x40;
     } else {
         r = 0x5F - (g_blinkTimer & 0x1F);
     }
-    DrawMenuRect(arg0, arg0->cursorX,
-                 arg0->cursorY + (height * g_MenuNavigation.cursorMain),
-                 arg0->unk4, height, r, 0, 0);
+    DrawMenuRect(context, context->cursorX,
+                 context->cursorY + (height * g_MenuNavigation.cursorMain),
+                 context->cursorW, height, r, 0, 0);
 }
 
 // Draw equip menu cursor
@@ -875,7 +875,7 @@ void func_800F8990(MenuContext* ctx, s32 x, s32 y) {
     totalItemCount = func_800FD6C4(*new_var);
     curX = 0;
     curY = 0;
-    itemsPerPage = Cols + ctx->unk6 / Height * Cols;
+    itemsPerPage = Cols + ctx->cursorH / Height * Cols;
     for (i = 0; i < itemsPerPage; i++) {
         itemIndex = i + -ctx->h / Height * Cols;
         if (itemIndex >= totalItemCount) {


### PR DESCRIPTION
I am currently working on decompiling func_800F8F28. This relates to the system pause menus, and makes heavy use of the MenuContext struct. This calls several members of this struct, in ways that have revealed more details about this struct, including some of its members which were unknown in size or purpose previously.

This PR serves to adjust the struct, and also adjusts the few places in existing code which accessed the unk4 and unk6 members (now known as cursorW and cursorH).

This PR, on its own, serves minimal functional benefit. However, in the interest of "One PR for one change", I wanted to submit this first, rather than having my future PR for func_800F8F28 serve the purpose of both decompiling the function, and changing the struct. The struct is ready for changes now so I am submitting this first so it can be considered separately.

Full list of changes to the struct:
unk4 and unk6 are now cursorW and cursorH.
Fixed typo on the list of addresses that had 0x10 on two separate struct members
Split unk14 into unk14 and unk16; my func_800F8F28 accesses these two locations individually.
Split unk1C into unk1C and unk1D; same deal there.

- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
