### PR TITLE
use jlabel for rodata labels

### DIFF
--- a/config/splat.hd.dra.yaml
+++ b/config/splat.hd.dra.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".data"
@@ -175,7 +176,7 @@ segments:
       - [0x75A90, c, 75DA0]
       - [0x75C44, c, 75F54_hd]
       - [0x94F7C, c, 953A0_hd]
-      - [0x95E88, sbss]  
+      - [0x95E88, sbss]
   - name: dra_data
     type: data
     start: 0x9B270

--- a/config/splat.us.dra.yaml
+++ b/config/splat.us.dra.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".data"

--- a/config/splat.us.main.yaml
+++ b/config/splat.us.main.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   section_order:
     - ".rodata"
     - ".text"

--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stcen.yaml
+++ b/config/splat.us.stcen.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stdre.yaml
+++ b/config/splat.us.stdre.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stmad.yaml
+++ b/config/splat.us.stmad.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stno3.yaml
+++ b/config/splat.us.stno3.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stnp3.yaml
+++ b/config/splat.us.stnp3.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stnz0.yaml
+++ b/config/splat.us.stnz0.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".data"
@@ -77,7 +78,7 @@ segments:
       - [0x305A4, rodata]
       - [0x305FC, rodata] # EntitySlogra .rodata, 33FCC
       - [0x30618, rodata] # EntityGaibon .rodata, 33FCC
-      - [0x3063C, rodata] 
+      - [0x3063C, rodata]
       - [0x30790, .rodata, 3E30C]
       - [0x307B0, .rodata, 3E30C]
       - [0x307C8, rodata]

--- a/config/splat.us.strwrp.yaml
+++ b/config/splat.us.strwrp.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stsel.yaml
+++ b/config/splat.us.stsel.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".rodata"

--- a/config/splat.us.stst0.yaml
+++ b/config/splat.us.stst0.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".data"

--- a/config/splat.us.stwrp.yaml
+++ b/config/splat.us.stwrp.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   section_order:
     - ".data"

--- a/config/splat.us.tt_000.yaml
+++ b/config/splat.us.tt_000.yaml
@@ -14,6 +14,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
+  asm_jtbl_label_macro: jlabel
   section_order:
     - ".rodata"
     - ".text"

--- a/include/macro.inc
+++ b/include/macro.inc
@@ -1,3 +1,7 @@
+.macro jlabel label
+    glabel \label
+.endm
+
 .macro glabel label
     .global \label
     \label:


### PR DESCRIPTION
Compare https://decomp.me/scratch/dhUE5 with https://decomp.me/scratch/NZt5p.

e.g. with this PR:

![image](https://github.com/Xeeynamo/sotn-decomp/assets/22226349/bf999863-a66f-4b64-abbe-a41e4be34181)

vs without:

![image](https://github.com/Xeeynamo/sotn-decomp/assets/22226349/04141d82-aedd-4451-817c-ff98e9e10a17)


Thank you in advance for contributing to sotn-decomp.
Before submitting this PR, please make sure:

- [x] The PR is small and focuses to address a single task
- [x] `make all` reports all `OK`
- [x] `make format` reports no files changed
- [x] Have Actions enabled in your fork to run the auto-formatter
