### PR TITLE
Decompile RIC func_8015FB84; improve SubweaponDef struct

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -672,7 +672,7 @@ typedef struct {
 
 typedef struct {
     /* 0x00 */ s16 attack;
-    /* 0x02 */ s16 unk2;
+    /* 0x02 */ s16 heartCost;
     /* 0x04 */ u16 attackElement;
     /* 0x06 */ u8 unk6;
     /* 0x07 */ u8 sp17;
@@ -681,7 +681,7 @@ typedef struct {
     /* 0x0B */ u8 unkB;
     /* 0x0C */ u16 sp1C;
     /* 0x0E */ u16 sp1E;
-    /* 0x10 */ u8 sp20;
+    /* 0x10 */ u8 crashId; // the ID for the crash version of this subweapon
     /* 0x11 */ u8 unk11;
     /* 0x12 */ u16 sp22; // entity->objectRoomIndex
 } SubweaponDef;          /* size=0x14 */

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -258,17 +258,17 @@ s32 func_800FE3C4(SubweaponDef* subwpn, s32 subweaponId, bool useHearts) {
         *subwpn = g_Subweapons[g_Status.subWeapon];
         accessoryCount = CheckEquipmentItemCount(0x4D, 4);
         if (accessoryCount == 1) {
-            subwpn->unk2 = subwpn->unk2 / 2;
+            subwpn->heartCost = subwpn->heartCost / 2;
         }
         if (accessoryCount == 2) {
-            subwpn->unk2 = subwpn->unk2 / 3;
+            subwpn->heartCost = subwpn->heartCost / 3;
         }
-        if (subwpn->unk2 <= 0) {
-            subwpn->unk2 = 1;
+        if (subwpn->heartCost <= 0) {
+            subwpn->heartCost = 1;
         }
-        if (g_Status.hearts >= subwpn->unk2) {
+        if (g_Status.hearts >= subwpn->heartCost) {
             if (useHearts) {
-                g_Status.hearts -= subwpn->unk2;
+                g_Status.hearts -= subwpn->heartCost;
             }
             return g_Status.subWeapon;
         } else {

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -499,7 +499,7 @@ void func_8011A290(Entity* entity) {
     entity->unk58 = subwpn.sp18;
     entity->unk6A = subwpn.sp1E;
     entity->objectRoomIndex = subwpn.sp22;
-    entity->ext.generic.unkB2 = subwpn.sp20;
+    entity->ext.generic.unkB2 = subwpn.crashId;
     func_80118894(entity);
 }
 

--- a/src/ric/22380.c
+++ b/src/ric/22380.c
@@ -93,7 +93,33 @@ void func_8015FAB8(Entity* entity) {
     func_8015F9F0(entity);
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/22380", func_8015FB84);
+// We're playing as Richter and we used a subweapon (normal or crash)
+s32 func_8015FB84(SubweaponDef* subwpn, s32 isItemCrash, s32 useHearts) {
+    s32 pad[2]; // Needed so stack pointer moves properly
+    u8 crashId;
+    // Not an item crash. Just read the item in.
+    if (isItemCrash == 0) {
+        *subwpn = D_80154688[g_Status.subWeapon];
+        if (g_Status.hearts >= subwpn->heartCost) {
+            if (useHearts) {
+                g_Status.hearts -= subwpn->heartCost;
+            }
+            return g_Status.subWeapon;
+        }
+    } else {
+        // If it's a crash, load the subweapon by referencing our
+        // subweapon's crash ID and loading that.
+        crashId = D_80154688[g_Status.subWeapon].crashId;
+        *subwpn = D_80154688[crashId];
+        if (g_Status.hearts >= subwpn->heartCost) {
+            if (useHearts) {
+                g_Status.hearts -= subwpn->heartCost;
+            }
+            return g_Status.subWeapon;
+        }
+    }
+    return -1;
+}
 
 INCLUDE_ASM("asm/us/ric/nonmatchings/22380", func_8015FDB0);
 


### PR DESCRIPTION
Primary purpose of this is to decompile the function. Testing in debugger indicates that this runs every frame, and only has the useHearts parameter set to 1 when the player actually uses their subweapon. I applied similar emulator-driven logic to determine the purpose of the second parameter which I identified as isItemCrash.

Through the decompiling of this function, I have also identified two previously-unknown members of the SubweaponDef struct. I'm quite confident about the heartCost, as it is the amount that is subtracted from the player's hearts. I'm also fairly confident about the crashId, since its logic corresponds directly to the isItemCrash parameter that the function takes, and is the only reason I can think of that a subweapon would point to another subweapon (note the double-reference to D_80154688).

Updating the struct broke two other functions which referred to the placeholder names for those struct members; I have therefore updated those functions to use my new names (heartCost and crashId).

- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
