### PR TITLE
Decompile DRA func_8011A9D8

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -179,8 +179,9 @@ typedef struct Primitive {
 
 // Flags for entity->flags
 #define FLAG_UNK_10000 0x10000
-#define FLAG_UNK_20000 0x20000
+#define FLAG_UNK_20000 0x20000 // func_8011A9D8 will destroy if not set
 #define FLAG_FREE_POLYGONS 0x00800000
+#define FLAG_UNK_00200000 0x00200000
 #define FLAG_UNK_02000000 0x02000000
 #define FLAG_UNK_04000000 0x04000000
 #define FLAG_UNK_08000000 0x08000000

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -589,19 +589,19 @@ void func_8011A9D8(void) {
 
     entity = &g_Entities[4];
     g_CurrentEntity = &g_Entities[4];
-    for(i=4; i < 0x40; i++, g_CurrentEntity++, entity++){
-        if (!(entity->flags & 0x20000)) {
+    for (i = 4; i < 0x40; i++, g_CurrentEntity++, entity++) {
+        if (!(entity->flags & FLAG_UNK_20000)) {
             DestroyEntity(entity);
         }
-        if (g_CurrentPlayableCharacter == PLAYER_ALUCARD && 
-            (entity->objectId - 0x37) < 6U && 
+        if (g_CurrentPlayableCharacter == PLAYER_ALUCARD &&
+            0x36 < entity->objectId && entity->objectId < 0x3D &&
             entity->step != 0) {
-                entity->pfnUpdate(entity);
-        }
-        if ((entity->flags & 0x02000000) && (entity->step != 0)) {
-            entity->flags |= 0x200000;
             entity->pfnUpdate(entity);
-            entity->flags &= 0xFFDFFFFF;
+        }
+        if (entity->flags & FLAG_UNK_02000000 && entity->step != 0) {
+            entity->flags |= FLAG_UNK_00200000;  // set a flag
+            entity->pfnUpdate(entity);           // update
+            entity->flags &= ~FLAG_UNK_00200000; // unset that same flag
         }
     }
 }

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -583,7 +583,28 @@ label:
         goto loop_1;
 }
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_8011A9D8);
+void func_8011A9D8(void) {
+    Entity* entity;
+    s32 i;
+
+    entity = &g_Entities[4];
+    g_CurrentEntity = &g_Entities[4];
+    for(i=4; i < 0x40; i++, g_CurrentEntity++, entity++){
+        if (!(entity->flags & 0x20000)) {
+            DestroyEntity(entity);
+        }
+        if (g_CurrentPlayableCharacter == PLAYER_ALUCARD && 
+            (entity->objectId - 0x37) < 6U && 
+            entity->step != 0) {
+                entity->pfnUpdate(entity);
+        }
+        if ((entity->flags & 0x02000000) && (entity->step != 0)) {
+            entity->flags |= 0x200000;
+            entity->pfnUpdate(entity);
+            entity->flags &= 0xFFDFFFFF;
+        }
+    }
+}
 
 Entity* func_8011AAFC(Entity* self, u32 flags, s32 arg2) {
     Entity* entity;


### PR DESCRIPTION
Yet another random function decompiled.

This uses two flags in entity->flags. One was already listed in game.h, the other was not. They are now each included. I also added a comment to one of them mentioning its purpose; this could lead to a rename in the future when more uses of it are found.

- [ ] The PR is small and focuses to address a single task
- [ ] `make all` reports all `OK`
- [ ] `make format` reports no files changed
- [ ] Have Actions enabled in your fork to run the auto-formatter
