### PR TITLE
Decompile RIC func_8015D1D0

### DIFF
--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -270,18 +270,18 @@ void func_8015D120(void) {
 }
 
 s32 func_8015D1D0(s16 subWpnId, s16 subWpnUnk6) {
-    Entity* var_v1;
+    Entity* entity;
     s32 b0MatchCount;
-    s32 i;
     s32 nullObjCount;
+    s32 i;
 
-    var_v1 = &g_Entities[32];
-    for (i = 0, b0MatchCount = 0, nullObjCount = 0; i < 0x10; i++, var_v1++) {
-        if (var_v1->objectId == 0) {
+    entity = &g_Entities[32];
+    for (i = 0, b0MatchCount = 0, nullObjCount = 0; i < 0x10; i++, entity++) {
+        if (entity->objectId == 0) {
             nullObjCount++;
         }
-        if (var_v1->ext.generic.unkB0 != 0 &&
-            var_v1->ext.generic.unkB0 == subWpnId) {
+        if (entity->ext.generic.unkB0 != 0 &&
+            entity->ext.generic.unkB0 == subWpnId) {
             b0MatchCount++;
         }
         if (b0MatchCount >= subWpnUnk6) {

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -269,4 +269,27 @@ void func_8015D120(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/20920", func_8015D1D0);
+s32 func_8015D1D0(s16 subWpnId, s16 subWpnUnk6) {
+    Entity* var_v1;
+    s32 b0MatchCount;
+    s32 i;
+    s32 nullObjCount;
+
+    var_v1 = &g_Entities[32];
+    for (i = 0, b0MatchCount = 0, nullObjCount = 0; i < 0x10; i++, var_v1++) {
+        if (var_v1->objectId == 0) {
+            nullObjCount++;
+        }
+        if (var_v1->ext.generic.unkB0 != 0 &&
+            var_v1->ext.generic.unkB0 == subWpnId) {
+            b0MatchCount++;
+        }
+        if (b0MatchCount >= subWpnUnk6) {
+            return -1;
+        }
+    }
+    if (nullObjCount == 0) {
+        return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This one's logic is a little odd. It is only called by func_8015D250, in one place. I'll be interested to learn how it's supposed to work and what the unkB0 and unk6 entries are from those structs. In any case, it's a strange but short function and therefore the code is self-contained, no changes outside the function itself.

Note: With this PR, src/ric/20920.c is fully decompiled and contains no INCLUDE_ASM macros!
