### PR TITLE
Improve saturn pc-relative labels

### DIFF
--- a/config/saturn/zero.bin.yaml
+++ b/config/saturn/zero.bin.yaml
@@ -135,10 +135,10 @@ segments:
       - start: 0x28B8C
         type: c
         file: zero
-        end: 0x28F83
+        end: 0x28F87
 
       # after PER
-      - start: 0x28F84
+      - start: 0x28F88
         type: data
         file: zero
         end: 0x295DF
@@ -222,10 +222,10 @@ segments:
       - start: 0x2C1A8
         type: c
         file: zero
-        end: 0x2C303 
+        end: 0x2C307
 
       # after SEGA_MTH.A
-      - start: 0x2C304
+      - start: 0x2C308
         type: data
         file: zero
         end: 0x2C363

--- a/src/saturn/zero.c
+++ b/src/saturn/zero.c
@@ -729,7 +729,7 @@ INCLUDE_ASM("asm/saturn/zero/f_nonmat", f602CF4C, func_0602CF4C);
 //_MoveOldToNew
 INCLUDE_ASM("asm/saturn/zero/f_nonmat", f602CF8C, func_0602CF8C);
 
-INCLUDE_ASM("asm/saturn/zero/data", d602D004, d_0602D004);
+INCLUDE_ASM("asm/saturn/zero/data", d602D008, d_0602D008);
 
 // SEGA_CDC.A
 
@@ -934,7 +934,7 @@ INCLUDE_ASM("asm/saturn/zero/data", d602FB84, d_0602FB84);
 
 // _MTH_Hypot (C)
 INCLUDE_ASM("asm/saturn/zero/f_nonmat", f6030228, func_06030228);
-INCLUDE_ASM("asm/saturn/zero/data", d6030384, d_06030384);
+INCLUDE_ASM("asm/saturn/zero/data", d6030388, d_06030388);
 
 // SEGA_BUP.A
 const char* bup_version = "BUP Version 1.25 1997-06-20";


### PR DESCRIPTION
This PR makes some updates to the splitter to have better pc-relative labels. For example instead of:
```
/* 0x06066426 0xD127 */ mov.l @(0x09E, pc), r1
...
/* 0x060664C4 */ .word 0x0605
/* 0x060664C6 */ .word 0xC680
```
Now theres:
```
/* 0x06066426 0xD127 */ mov.l @(dat_060664C4, pc), r1
...
dat_060664C4: /* source: 06066426 */
/* 060664C4 */ .long 0x0605C680
```

I had to fix a couple of address errors in the yaml to make this work.