### PR TITLE
Decompile EntityAxeKnightRotateAxe

### DIFF
--- a/src/saturn/sattypes.h
+++ b/src/saturn/sattypes.h
@@ -13,8 +13,20 @@ typedef unsigned long long u64;
 #define LOW(x) (*(s32*)&(x))
 
 typedef void (*PfnEntityUpdate)(struct Entity*);
+
+struct Unk0600B344 {
+    s16 unk0;
+    u8 pad2[6];
+    s16 unk8;
+    u8 pad[0x3];
+    s16 zPriority;
+    u8 pad3[0x1];
+    s32 unk14;
+    s32 unk18;
+};
+
 typedef struct Entity {
-    /* 0x00 */ void* unk0;
+    /* 0x00 */ struct Unk0600B344* unk0;
     /* 0x04 */ s16 posX;
     /* 0x06 */ s16 posX_lo;
     /* 0x08 */ s16 posY;
@@ -24,7 +36,7 @@ typedef struct Entity {
     /* 0x14 */ u16 hitboxOffX;
     /* 0x16 */ s16 hitboxOffY;
     s16 pad3[3];
-    /* 0x1E */ s16 unk1E;
+    /* 0x1E */ s16 rotAngle;
     /* 0x20 */ s16 unk1A;
     /* 0x22 */ s16 unk1C;
     s16 pad3_8;

--- a/src/saturn/stage_02.c
+++ b/src/saturn/stage_02.c
@@ -266,7 +266,25 @@ const u16 pad_060EA260 = 0xCCCC;
 const u16 pad_060EA262 = 0xCCCD;
 
 INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EA264, func_060EA264);
-INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAC54, func_060EAC54);
+
+// SAT: func_060EAC54
+void EntityAxeKnightRotateAxe(Entity* self) {
+    self->unk0->unk0 |= 0x40;
+
+    if (self->params != 0) {
+        self->unk0->unk8 += 0x80;
+    } else {
+        self->unk0->unk8 -= 0x80;
+    }
+    if (self->params != 0) {
+        self->rotAngle += 0x80;
+    } else {
+        self->rotAngle -= 0x80;
+    }
+
+    self->rotAngle &= 0xFFF;
+}
+
 INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EACC0, func_060EACC0);
 INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAF2C, func_060EAF2C);
 INCLUDE_ASM("asm/saturn/stage_02/f_nonmat", f60EAFAC, func_060EAFAC);

--- a/src/saturn/stage_02.h
+++ b/src/saturn/stage_02.h
@@ -3,14 +3,6 @@
 
 #include "sattypes.h"
 
-struct Unk0600B344 {
-    u8 pad[0xd];
-    s16 zPriority;
-    u8 pad2[0x1];
-    s32 unk14;
-    s32 unk18;
-};
-
 struct Unk0600B344* func_0600B344(s32, s32, s32, s32);
 struct Unk060ED26C {
     s32 unk0;


### PR DESCRIPTION
It looks like the stuff needed for the Saturn to render is duplicated in the `Unk0600B344` struct.