### PR TITLE
Fix checking WARP.PRG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,6 +521,7 @@ check_saturn_docker:
 	docker run --rm -e INPUT_FILENAME=t_bat_li.o -e OUTPUT_FILENAME=T_BAT.PRG -v $(SATURN_BUILD_ABS):/build -w /build binutils-sh-elf:latest /bin/bash -c ./strip.sh
 	docker run --rm -e INPUT_FILENAME=zero_li.o -e OUTPUT_FILENAME=0.BIN -v $(SATURN_BUILD_ABS):/build -w /build binutils-sh-elf:latest /bin/bash -c ./strip.sh
 	docker run --rm -e INPUT_FILENAME=stage_02_li.o -e OUTPUT_FILENAME=STAGE_02.PRG -v $(SATURN_BUILD_ABS):/build -w /build binutils-sh-elf:latest /bin/bash -c ./strip.sh
+	docker run --rm -e INPUT_FILENAME=warp_li.o -e OUTPUT_FILENAME=WARP.PRG -v $(SATURN_BUILD_ABS):/build -w /build binutils-sh-elf:latest /bin/bash -c ./strip.sh
 	# check hashes
 	sha1sum --check config/check.saturn.sha
 
@@ -530,6 +531,7 @@ check_saturn_native:
 	sh-elf-objcopy ./build/saturn/t_bat_li.o -O binary ./build/saturn/T_BAT.PRG
 	sh-elf-objcopy ./build/saturn/zero_li.o -O binary ./build/saturn/0.BIN
 	sh-elf-objcopy ./build/saturn/stage_02_li.o -O binary ./build/saturn/STAGE_02.PRG
+	sh-elf-objcopy ./build/saturn/warp_li.o -O binary ./build/saturn/WARP.PRG
 	# check hashes
 	sha1sum --check config/check.saturn.sha
 

--- a/config/check.saturn.sha
+++ b/config/check.saturn.sha
@@ -2,4 +2,4 @@ f03234c4f21819d30d34b05aaa7e352702dca0dc  build/saturn/GAME.PRG
 d513a3a1fcab77dcb792fedfe974434c80591328  build/saturn/T_BAT.PRG
 54c2e3e59f9f627bc0df6d9ab5acff4987fa4722  build/saturn/0.BIN
 f44004e15fffa15253a513372d999becc143f43f  build/saturn/STAGE_02.PRG
-ebc09d976d67777a255c6a6015319acafb6eba47  disks/saturn/WARP.PRG
+ebc09d976d67777a255c6a6015319acafb6eba47  build/saturn/WARP.PRG


### PR DESCRIPTION
The objcopy step was being skipped, and the file off the disk was being checked rather than the built version.