### PR TITLE
Dockerfile to check setup instructions

### DIFF
--- a/DockerfileSetup
+++ b/DockerfileSetup
@@ -1,0 +1,9 @@
+# build container and tag it as sotn-build:latest
+# docker build --tag sotn-build:latest -f DockerfileSetup . 
+FROM ubuntu:22.04
+ADD ./setup.sh setup.sh
+
+# we copy twice which is inefficient but allows setup.sh
+# to be closer to what an actual user would do
+ADD sotncue disks
+RUN sh ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,31 @@
+# starting from Ubuntu 22.04
+
+apt-get update
+
+# install git and clone the repo
+apt-get install -y git
+git clone https://github.com/Xeeynamo/sotn-decomp.git
+cd sotn-decomp
+
+# update submodules
+git submodule update --init --recursive
+
+# install debian packages
+apt-get install -y $(cat tools/requirements-debian.txt)
+
+# install rust and add to environment
+curl https://sh.rustup.rs -sSf | bash -s -- -y
+echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+
+make update-dependencies
+
+# copy sotn.us.cue/bin into disks
+cp -r /disks/* /sotn-decomp/disks
+
+# install python packages (has to be done twice for some reason?)
+pip3 install -r tools/requirements-python.txt
+
+# extract disk, build and check
+make extract_disk
+make extract -j && make build -j
+make check


### PR DESCRIPTION
I'm not sure this actually needs to be in the repo or not but I made this so we can easily check the PSX setup instructions from a clean slate. This does a fully in-container build using the host filesystem as little as possible for that reason. setup.sh should be pretty much exactly what a user would need to do from a fresh system. The Dockerfile assumes that sotn.us.cue is in the "sotncue" folder. I'm thinking maybe not adding something like this to the CI since it would introduce another thing that can go wrong there. I figure if someone says the instructions are wrong we run this to double check. 