### PR TITLE
Check chain limit

### DIFF
--- a/config/symbols.us.dra.txt
+++ b/config/symbols.us.dra.txt
@@ -971,6 +971,7 @@ EntityAlucard = 0x8010A5BC;
 SetPlayerStep = 0x8010D584;
 UpdateAnim = 0x8010DDA0;
 AccelerateX = 0x8010E390;
+CheckChainLimit = 0x8010EC8C;
 AlucardHandleDamage = 0x8011405C;
 GetFreeDraEntity = 0x8011879C;
 EntityNumberMovesToHpMeter = 0x80118D0C;

--- a/include/game.h
+++ b/include/game.h
@@ -776,7 +776,8 @@ typedef struct {
     /* 0x13 */ u8 unk13;
     /* 0x14 */ u8 unk14;
     /* 0x15 */ u8 lockDuration;
-    /* 0x16 */ u16 chainable;
+    /* 0x16 */ u8 chainable;
+    /* 0x17 */ u8 unk17;
     /* 0x18 */ u8 specialMove;
     /* 0x19 */ u8 isConsumable;
     /* 0x1A */ u8 enemyInvincibilityFrames;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -686,8 +686,41 @@ s32 func_8010EADC(s16 arg0, s16 arg1) {
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010EB5C);
 
-// DECOMP_ME_WIP func_8010EC8C https://decomp.me/scratch/N8Srk
-INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010EC8C);
+s32 CheckChainLimit(s32 itemId, bool unkBool) {
+    Entity* entity;
+    s32 existing_count;
+    s32 i;
+    s32 chain_limit;
+
+    chain_limit = D_800A4B04[itemId].chainable;
+    if (chain_limit & 0x80) {
+        return -(s32)((u16)g_Player.unk46 >> 0xF);
+    }
+    entity = &g_Entities[16];
+    for (i = 16, existing_count = 0; i < 64; i++, entity++) {
+        // Hack to load unkAE as an s16 (struct has s8)
+        // Longer term, figure out what g_Entites[16-64] are
+        // and make dedicated ent extension.
+        if (*(s16*)&entity->ext.generic.unkAE != itemId) {
+            continue;
+        }
+
+        if (unkBool) {
+            if (entity->params & 0x8000) {
+                existing_count++;
+            }
+        } else {
+            if (!(entity->params & 0x8000)) {
+                existing_count++;
+            }
+        }
+
+        if (!(existing_count < chain_limit)) {
+            return -1;
+        }
+    }
+    return 0;
+}
 
 void func_8010ED54(u8 arg0) {
     PLAYER.accelerationY = 0;

--- a/tools/splat_ext/equipment.py
+++ b/tools/splat_ext/equipment.py
@@ -33,7 +33,8 @@ def serialize_equipment(content: str) -> bytearray:
         serialized_data += utils.from_u8(item["unk13"])
         serialized_data += utils.from_u8(item["unk14"])
         serialized_data += utils.from_u8(item["lockDuration"])
-        serialized_data += utils.from_16(item["chainable"])
+        serialized_data += utils.from_u8(item["chainable"])
+        serialized_data += utils.from_u8(item["unk17"])
         serialized_data += utils.from_u8(item["specialMove"])
         serialized_data += utils.from_bool(item["isConsumable"])
         serialized_data += utils.from_u8(item["enemyInvincibilityFrames"])
@@ -110,7 +111,8 @@ class PSXSegEquipment(N64Segment):
                 "unk13": utils.to_u8(item_data[0x13:]),
                 "unk14": utils.to_u8(item_data[0x14:]),
                 "lockDuration": utils.to_u8(item_data[0x15:]),
-                "chainable": utils.to_u16(item_data[0x16:]),
+                "chainable": utils.to_u8(item_data[0x16:]),
+                "unk17": utils.to_u8(item_data[0x17:]),
                 "specialMove": utils.to_u8(item_data[0x18:]),
                 "isConsumable": utils.to_bool(item_data[0x19:]),
                 "enemyInvincibilityFrames": utils.to_u8(item_data[0x1A:]),


### PR DESCRIPTION
When throwable items are used, there is a limit to how many you can "chain" together. For example, if you equip a Buffalo Star, and press the throw button as fast as possible, you will throw three of them, and then you will not be able to throw more until those three despawn.

This function enforces that limit. Given an item ID that could be on screen, it iterates through g_Entities[16-64] and counts up how many entities match the one you have thrown. If that number is not below the chain limit, -1 will be returned, indicating that creating more of them is not allowed.

A few mysteries still exist. I do not know what the unkBool is, but it directly corresponds with the top bit of entity->params. I also do not know what the unkAE is, but it clearly indicates the item ID of a thrown entity.

Using the previous Equipment struct definition, this code was producing an `lhu` instruction, where the assembly uses `lbu`. Therefore, I determine that the `chainable` member should be a u8 instead of a u16. I have adjusted the struct to match this, and also modified the splat extraction to show unk17 separately. I will look into what this unk17 might be.

This function is only called by func_8010EDB8. Its purpose seems clear so I have given it this name.

This is also the final function called by func_8010EDB8 which is not decompiled.