### PR TITLE
Decompile DRA BlinkMenuCursor

### DIFF
--- a/config/symbols.us.dra.txt
+++ b/config/symbols.us.dra.txt
@@ -950,6 +950,7 @@ DrawStatChanges = 0x800F72BC;
 DrawPauseMenu = 0x800F74B4;
 DrawSpellMenu = 0x800F7B60;
 DrawSystemMenu = 0x800F8374;
+BlinkMenuCursor = 0x800F8C98;
 DrawConsumableCount = 0x800F8E18;
 LoadWeaponPrg = 0x800FA8C4;
 func_800FD39C = 0x800FD39C;

--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -1125,7 +1125,46 @@ void func_800F8990(MenuContext* ctx, s32 x, s32 y) {
     }
 }
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/5298C", func_800F8C98);
+void BlinkMenuCursor(s32 left, s32 top, s32 right, s32 bottom, s32 arg4) {
+
+    s32 var_s2;
+    u8 blink_value;
+
+    u32* temp_s3 = g_CurrentBuffer->ot;
+    LINE_G2* temp_s0 = &g_CurrentBuffer->lineG2[g_GpuUsage.line];
+
+    if (arg4 != 0) {
+        var_s2 = g_MenuData.menus[arg4 - 1].unk18 + 4;
+    } else {
+        var_s2 = 0x80;
+    }
+    SetSemiTrans(temp_s0, 0);
+    SetShadeTex(temp_s0, 1);
+    if (g_blinkTimer & 0x20) {
+        blink_value = g_blinkTimer & 0x1F;
+    } else {
+        blink_value = 0x1F - (g_blinkTimer & 0x1F);
+    }
+    blink_value *= 4;
+    blink_value -= 0x80;
+
+    if (arg4 != 0) {
+        blink_value = 0xFF;
+    }
+
+    temp_s0->r0 = blink_value;
+    temp_s0->g0 = blink_value;
+    temp_s0->b0 = blink_value;
+    temp_s0->r1 = blink_value;
+    temp_s0->g1 = blink_value;
+    temp_s0->b1 = blink_value;
+    temp_s0->x0 = left;
+    temp_s0->y0 = top;
+    temp_s0->x1 = right;
+    temp_s0->y1 = bottom;
+    AddPrim(&temp_s3[var_s2], temp_s0);
+    g_GpuUsage.line++;
+}
 
 void DrawConsumableCount(s32 itemId, s32 hand, MenuContext* ctx) {
     u8 outstring[16];

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -216,7 +216,7 @@ typedef struct {
 } DamageParam;
 
 typedef struct {
-    /* 8013761C */ MenuContext menus[3];
+    /* 8013761C */ MenuContext menus[3]; // 761C, 763A, 7658
     /* 80137676 */ s16 D_80137676;
     /* 80137678 */ s16 D_80137678[6];
     /* 80137684 */ s32 unused1; // No known use yet, one may be found


### PR DESCRIPTION
This is another one of the menu functions.

I believe it relates to the cursor-blinking animation in the menus, given that it loads a blink_value from the g_blinkTimer, and stores its values into a primitive. I've chosen to call it BlinkMenuCursor. There's a chance I'm wrong, but at least for now this name seems reasonable.

Thank you @Xeeynamo for the final adjustment on args to get this matching!

I also included a small adjustment to the comments on the MenuData struct - it's handy to know where all three menus are. This didn't seem worth having a whole dedicated PR for such a tiny change to only a few characters, but let me know if you would like it removed.
