### PR TITLE
Decompile DRA func_8010DB38 to UpdateUnarmedAnim

### DIFF
--- a/config/symbols.us.dra.txt
+++ b/config/symbols.us.dra.txt
@@ -976,6 +976,7 @@ CopySupportOvlCallback = 0x80107750;
 UpdateCd = 0x80108448;
 EntityAlucard = 0x8010A5BC;
 SetPlayerStep = 0x8010D584;
+UpdateUnarmedAnim = 0x8010DB38;
 UpdateAnim = 0x8010DDA0;
 AccelerateX = 0x8010E390;
 CheckChainLimit = 0x8010EC8C;

--- a/include/game.h
+++ b/include/game.h
@@ -848,7 +848,7 @@ typedef struct {
     /* 8003C808 */ EnemyDef* enemyDefs;
     /* 8003C80C */ void* func_80118970;
     /* 8003C810 */ void* func_80118B18;
-    /* 8003C814 */ void* func_8010DB38;
+    /* 8003C814 */ void* UpdateUnarmedAnim;
     /* 8003C818 */ void (*func_8010DBFC)(s32*, s32*);
     /* 8003C81C */ void* func_80118C28;
     /* 8003C820 */ void (*func_8010E168)(s32 arg0, s16 arg1);

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -265,8 +265,25 @@ void func_8010DA48(u32 arg0) {
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010DA70);
 
-INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010DB38);
+u32 UpdateUnarmedAnim(s8* frameProps, u16** frames) {
+    s32 var_v0;
+    u16* frameIndex;
 
+    frameIndex =
+        frames[g_CurrentEntity->ext.generic.unkAC] + PLAYER.animFrameIdx;
+    if (*frameIndex == 0xFFFF) {
+        return -1;
+    }
+    if (frameProps != NULL) {
+        frameProps = &frameProps[(*frameIndex >> 9) << 2];
+        g_CurrentEntity->hitboxOffX = *frameProps++;
+        g_CurrentEntity->hitboxOffY = *frameProps++;
+        g_CurrentEntity->hitboxWidth = *frameProps++;
+        g_CurrentEntity->hitboxHeight = *frameProps++;
+    }
+    g_CurrentEntity->animCurFrame = *frameIndex & 0x1FF;
+    return PLAYER.animFrameDuration >= 0 ? 0 : -1;
+}
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010DBFC);
 
 u32 UpdateAnim(s8* frameProps, s32* frames) {

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -266,7 +266,6 @@ void func_8010DA48(u32 arg0) {
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8010DA70);
 
 u32 UpdateUnarmedAnim(s8* frameProps, u16** frames) {
-    s32 var_v0;
     u16* frameIndex;
 
     frameIndex =


### PR DESCRIPTION
This function is only called in one place. That place is in the function I have decompiled in a separate PR, EntityUnarmedAttack. This function appears to update the animation for that entity, and therefore I have given it this name.

Discovering that this function, which does a subset of what UpdateAnim does, exists might mean we want to think about looking more deeply into UpdateAnim, and determining if it should have a more particular name.