### PR TITLE
Split unk10 to two bytes in Equipment

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -781,7 +781,8 @@ typedef struct {
     /* 0x0C */ u16 element;
     /* 0x0E */ u8 itemCategory;
     /* 0x0F */ u8 weaponId;
-    /* 0x10 */ u16 unk10;
+    /* 0x10 */ u8 unk10;
+    /* 0x11 */ u8 unk11;
     /* 0x12 */ u8 playerAnim;
     /* 0x13 */ u8 unk13;
     /* 0x14 */ u8 unk14;

--- a/tools/splat_ext/equipment.py
+++ b/tools/splat_ext/equipment.py
@@ -28,7 +28,8 @@ def serialize_equipment(content: str) -> bytearray:
         serialized_data += utils.from_16(item["element"])
         serialized_data += utils.from_u8(item["itemCategory"])
         serialized_data += utils.from_u8(item["weaponId"])
-        serialized_data += utils.from_16(item["unk10"])
+        serialized_data += utils.from_u8(item["unk10"])
+        serialized_data += utils.from_u8(item["unk11"])
         serialized_data += utils.from_u8(item["playerAnim"])
         serialized_data += utils.from_u8(item["unk13"])
         serialized_data += utils.from_u8(item["unk14"])
@@ -106,7 +107,8 @@ class PSXSegEquipment(N64Segment):
                 "element": utils.to_u16(item_data[0x0C:]),
                 "itemCategory": utils.to_u8(item_data[0x0E:]),
                 "weaponId": utils.to_u8(item_data[0x0F:]),
-                "unk10": utils.to_u16(item_data[0x10:]),
+                "unk10": utils.to_u8(item_data[0x10:]),
+                "unk11": utils.to_u8(item_data[0x11:]),
                 "playerAnim": utils.to_u8(item_data[0x12:]),
                 "unk13": utils.to_u8(item_data[0x13:]),
                 "unk14": utils.to_u8(item_data[0x14:]),


### PR DESCRIPTION
I am currently working on func_8010EDB8 (scratch here: https://decomp.me/scratch/G7vpg) which handles a lot of the processing that happens when the player uses a weapon.

This appears to be referencing an unk11 member of the Equipment struct, but previously unk10 was a u16. As far as I can tell, we have not done anything to reference unk10, and therefore it is reasonable to assume these are two separate variables.

More work needs to be done, but for now I think the fact that this function uses unk11 is enough evidence to conclude that they are two separate values.

I have modified the struct in game.h, as well as modified equipment.py, to reflect this different organization of values in the struct.
