### PR TITLE
Equipment struct update

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -793,10 +793,8 @@ typedef struct {
     /* 0x19 */ u8 isConsumable;
     /* 0x1A */ u8 enemyInvincibilityFrames;
     /* 0x1B */ u8 unk1B;
-    /* 0x1C */ u16 unk1C;
-    /* 0x1E */ u16 unk1E;
-    /* 0x20 */ u16 unk20;
-    /* 0x22 */ u16 unk22;
+    /* 0x1C */ u32 unk1C;
+    /* 0x20 */ u32 unk20;
     /* 0x24 */ u16 mpUsage;
     /* 0x26 */ u16 stunFrames;
     /* 0x28 */ u16 hitType;

--- a/tools/splat_ext/equipment.py
+++ b/tools/splat_ext/equipment.py
@@ -40,10 +40,8 @@ def serialize_equipment(content: str) -> bytearray:
         serialized_data += utils.from_bool(item["isConsumable"])
         serialized_data += utils.from_u8(item["enemyInvincibilityFrames"])
         serialized_data += utils.from_u8(item["unk1B"])
-        serialized_data += utils.from_16(item["unk1C"])
-        serialized_data += utils.from_16(item["unk1E"])
-        serialized_data += utils.from_16(item["unk20"])
-        serialized_data += utils.from_16(item["unk22"])
+        serialized_data += utils.from_u32(item["unk1C"])
+        serialized_data += utils.from_u32(item["unk20"])
         serialized_data += utils.from_16(item["mpUsage"])
         serialized_data += utils.from_16(item["stunFrames"])
         serialized_data += utils.from_16(item["hitType"])
@@ -119,10 +117,8 @@ class PSXSegEquipment(N64Segment):
                 "isConsumable": utils.to_bool(item_data[0x19:]),
                 "enemyInvincibilityFrames": utils.to_u8(item_data[0x1A:]),
                 "unk1B": utils.to_u8(item_data[0x1B:]),
-                "unk1C": utils.to_u16(item_data[0x1C:]),
-                "unk1E": utils.to_u16(item_data[0x1E:]),
-                "unk20": utils.to_u16(item_data[0x20:]),
-                "unk22": utils.to_u16(item_data[0x22:]),
+                "unk1C": utils.to_u32(item_data[0x1C:]),
+                "unk20": utils.to_u32(item_data[0x20:]),
                 "mpUsage": utils.to_u16(item_data[0x24:]),
                 "stunFrames": utils.to_u16(item_data[0x26:]),
                 "hitType": utils.to_u16(item_data[0x28:]),


### PR DESCRIPTION
I'm currently working on decompiling func_800FA7E8. Scratch here: https://decomp.me/scratch/pSeXX

This references unk1C and unk20 in Equipment, and it reads them with the `lw` instruction, indicating to me that these are each 32-bit values. unk1E and unk22 do not exist. I'm therefore updating the struct to show these.

Some preliminary analysis indicates that these variables are related to the action of pressing both attack buttons at the same time. All items have 0 for both of these, except that for unk20, Heaven Sword has 1, and Shield Rod and Mablung Sword have 16382. For unk1C, we have the Heaven Sword and all the shields. These again correspond to pairing with other weapons. I will hopefully get a decomp working, but for now, there seems to be sufficient evidence to change the struct members to match this configuration.