### PR TITLE
GameAPI helper signatures

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -903,6 +903,61 @@ typedef struct {
     /* 8003C8B4 */ void* unused13C;
 } GameApi; /* size=0x140 */
 
+/**** Helper signatures ****/
+extern void (*g_api_FreePrimitives)(s32);
+extern s16 (*g_api_AllocPrimitives)(PrimitiveType type, s32 count);
+extern void (*g_api_CheckCollision)(s32 x, s32 y, Collider* res, s32 unk);
+extern void (*g_api_func_80102CD8)(s32 arg0);
+extern void (*g_api_UpdateAnim)(FrameProperty* frameProps, s32* arg1);
+extern void (*g_api_AccelerateX)(s32 value);
+extern Entity* (*g_api_GetFreeDraEntity)(s16 start, s16 end);
+extern void (*g_api_GetEquipProperties)(
+    s32 handId, Equipment* res, s32 equipId);
+extern void (*g_api_func_800EA5E4)(s32);
+extern void (*g_api_func_800EAF28)(s32);
+extern void (*g_api_PlaySfx)(s32 sfxId);
+extern s16 (*g_api_func_800EDB58)(s32, s32);
+extern void (*g_api_func_800EA538)(s32 arg0);
+extern void (*g_api_g_pfn_800EA5AC)(u16 arg0, u8 arg1, u8 arg2, u8 arg3);
+extern Entity* (*g_api_func_8011AAFC)(Entity* self, u32 flags, s32 arg2);
+extern bool (*g_api_func_80131F68)(void);
+extern DR_ENV* (*g_api_func_800EDB08)(POLY_GT4* poly);
+extern void (*g_api_func_80118894)(Entity*);
+extern EnemyDef* g_api_enemyDefs;
+extern void* g_api_UpdateUnarmedAnim;
+extern void (*g_api_func_8010DBFC)(s32*, s32*);
+extern void (*g_api_func_8010E168)(s32 arg0, s16 arg1);
+extern void (*g_api_func_8010DFF0)(s32 arg0, s32 arg1);
+extern u16 (*g_api_DealDamage)(Entity* enemyEntity, Entity* attackerEntity);
+extern void (*g_api_LoadEquipIcon)(s32 equipIcon, s32 palette, s32 index);
+extern Equipment* g_api_D_800A4B04;
+extern Accessory* g_api_D_800A7718;
+extern void (*g_api_AddHearts)(s32 value);
+extern s32 (*g_api_func_800FD4C0)(s32 bossId, s32 action);
+extern void* (*g_api_func_8010E0A8)(void);
+extern void (*g_api_func_800FE044)(s32, s32);
+extern void (*g_api_AddToInventory)(u16 itemId, s32 itemCategory);
+extern RelicOrb* g_api_D_800A8720;
+extern s32 (*g_api_func_80134714)(s32 arg0, s32 arg1, s32 arg2);
+extern s32 (*g_api_func_80134678)(s16 arg0, u16 arg1);
+extern void (*g_api_func_800F53A4)(void);
+extern u32 (*g_api_CheckEquipmentItemCount)(u32 itemId, u32 equipType);
+extern void (*g_api_func_8010BF64)(Unkstruct_8010BF64* arg0);
+extern void (*g_api_func_800F1FC4)(s32 arg0);
+extern void (*g_api_func_8011A3AC)(
+    Entity* entity, s32 arg1, s32 arg2, Unkstruct_8011A3AC* arg3);
+extern s32 (*g_api_func_800FF460)(s32 arg0);
+extern s32 (*g_api_func_800FF494)(EnemyDef* arg0);
+extern bool (*g_api_func_80133940)(void);
+extern bool (*g_api_func_80133950)(void);
+extern bool (*g_api_func_800F27F4)(s32 arg0);
+extern s32 (*g_api_func_800FF110)(s32 arg0);
+extern s32 (*g_api_func_800FD664)(s32 arg0);
+extern s32 (*g_api_func_800FD5BC)(Unkstruct_800FD5BC* arg0);
+extern void (*g_api_LearnSpell)(s32 spellId);
+extern void (*g_api_func_800E2438)(const char* str);
+/***************************/
+
 typedef struct {
     /* 0x00 */ s16 x;
     /* 0x02 */ s16 y;


### PR DESCRIPTION
Often when I decompile an entity I get `extern ? (*g_api_AllocPrimitives)(s32, s32, s32);` which is obviously wrong. By adding some helper signatures in `game.h` the mips2c output should look a bit nicer and remove a bit of busy-work out from our shoulders.