### PR TITLE
TT_000 func_8017110C matching

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -214,6 +214,7 @@ typedef struct Primitive {
 #define FLAG_UNK_10000 0x10000
 #define FLAG_UNK_20000 0x20000 // func_8011A9D8 will destroy if not set
 #define FLAG_UNK_40000 0x40000
+#define FLAG_UNK_80000 0x80000
 #define FLAG_UNK_100000 0x100000
 #define FLAG_UNK_00200000 0x00200000
 

--- a/src/servant/tt_000/10E8.c
+++ b/src/servant/tt_000/10E8.c
@@ -70,7 +70,7 @@ Entity* func_8017110C(Entity* self) {
         if (e->hitboxState == 0) {
             continue;
         }
-        if (e->flags & 0x200000) {
+        if (e->flags & FLAG_UNK_00200000) {
             continue;
         }
 
@@ -113,8 +113,8 @@ Entity* func_8017110C(Entity* self) {
             continue;
         }
 
-        if (!(e->flags & 0x80000)) {
-            e->flags |= 0x80000;
+        if (!(e->flags & FLAG_UNK_80000)) {
+            e->flags |= FLAG_UNK_80000;
             return e;
         }
         if (e->hitPoints >= D_80170664[D_80174C30.unk0 / 10][0]) {


### PR DESCRIPTION
Took me a day to compile this nasty one. I got a match only by using the ternary operator `x ? y : z`, otherwise it wouldn't match. I was not able to get rid of the temporary variables `selfX` and `entityX`. If you want to play with the scratch you will find it here: https://decomp.me/scratch/JRqtW