### PR TITLE
Integrate HD build to the CI

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -22,12 +22,12 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        version: ["us"]
+        version: ["us", "hd"]
         include:
           - dependency: us
             version: us
-          # - dependency: pspeu
-          #   version: hd
+          - dependency: pspeu
+            version: hd
     # Building and testing cannot work if the repository owner is not Xeeynamo
     # due to the missing secrets to clone the game's data repository
     if: github.repository == 'Xeeynamo/sotn-decomp'
@@ -65,21 +65,13 @@ jobs:
       - name: Extract dependencies
         run: make extract_disk
       - name: Split game data
-        if: matrix.version == 'us'
         run: make -j extract
-      - name: Split game data (DRA only)
-        if: matrix.version != 'us'
-        run: make -j extract_dra
       - name: Build binaries
-        if: matrix.version == 'us'
         run: make -j build
-      - name: Build binaries (DRA only)
-        if: matrix.version != 'us'
-        run: make -j dra
       - name: Check if they match
         run: make check
       - name: Remove clutter from build folder
-        run: rm -rf build/asm build/src
+        run: rm -rf build/$(VERSION)/asm build/$(VERSION)/src build/$(VERSION)/assets
       - name: Export build folder
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v3
@@ -89,12 +81,12 @@ jobs:
   generate-progress-report:
     strategy:
       matrix:
-        version: ["us"]
+        version: ["us", "hd"]
         include:
           - dependency: us
             version: us
-          # - dependency: pspeu
-          #   version: hd
+          - dependency: pspeu
+            version: hd
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: build-and-test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,9 @@ endef
 
 all: build check
 saturn: build_saturn_native check_saturn_native
-build: main dra ric cen dre mad no3 np3 nz0 sel st0 wrp rwrp tt_000
+build: build_$(VERSION)
+build_us: main dra ric cen dre mad no3 np3 nz0 sel st0 wrp rwrp tt_000
+build_hd: dra
 clean:
 	git clean -fdx assets/
 	git clean -fdx asm/
@@ -107,9 +109,9 @@ format:
 check:
 	sha1sum --check config/check.$(VERSION).sha
 expected: check
-	mkdir -p expected
-	rm -rf expected/build
-	cp -r build expected/
+	mkdir -p expected/build
+	rm -rf expected/build/$(VERSION)
+	cp -r build/$(VERSION) expected/build/
 
 main: main_dirs $(MAIN_TARGET).exe
 main_dirs:
@@ -234,7 +236,9 @@ $(BUILD_DIR)/stmad.elf: $$(call list_o_files,st/mad)
 $(BUILD_DIR)/st%.elf: $$(call list_o_files,st/$$*)
 	$(call link,st$*,$@)
 
-extract: extract_main extract_dra extract_ric extract_stcen extract_stdre extract_stmad extract_stno3 extract_stnp3 extract_stnz0 extract_stsel extract_stst0 extract_stwrp extract_strwrp extract_tt_000
+extract: extract_$(VERSION)
+extract_us: extract_main extract_dra extract_ric extract_stcen extract_stdre extract_stmad extract_stno3 extract_stnp3 extract_stnz0 extract_stsel extract_stst0 extract_stwrp extract_strwrp extract_tt_000
+extract_hd: extract_dra
 extract_main: $(SPLAT_APP)
 	$(SPLAT) $(CONFIG_DIR)/splat.$(VERSION).$(MAIN).yaml
 extract_dra: $(SPLAT_APP)

--- a/src/dra/42398.c
+++ b/src/dra/42398.c
@@ -1,4 +1,5 @@
 #include "dra.h"
+#if defined(VERSION_US)
 
 #define DISP_ALL_H 240
 #define DISP_STAGE_W 256
@@ -810,3 +811,4 @@ void HandleTitle(void) {
         break;
     }
 }
+#endif

--- a/src/dra/47BB8.c
+++ b/src/dra/47BB8.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 s32 DecompressData(u8* dst, u8* src);
 
@@ -1476,3 +1477,4 @@ void FreePrimitives(s32 primitiveIndex) {
 }
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/47BB8", RenderPrimitives);
+#endif

--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -1,4 +1,5 @@
 #include "dra.h"
+#if defined(VERSION_US)
 
 #define CH(x) ((x)-0x20)
 
@@ -1653,3 +1654,4 @@ s32 func_800FD664(s32 arg0) { return g_StageId & 0x20 ? arg0 << 1 : arg0; }
 u8 GetEquipItemCategory(s32 equipId) {
     return D_800A4B04[g_Status.equipment[equipId]].itemCategory;
 }
+#endif

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 s32 func_800FD6C4(s32 equipTypeFilter) {
     s32 var_a0;
@@ -1341,3 +1342,4 @@ void func_801026BC(s32 arg0) {
 }
 
 void func_801027A4(void) { func_801026BC(0); }
+#endif

--- a/src/dra/62D70.c
+++ b/src/dra/62D70.c
@@ -3,6 +3,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_80102D70(void) {
     switch (D_801379AC.start) {
@@ -393,3 +394,4 @@ void func_80107360(
     poly->u3 = u + width;
     poly->v3 = v + height;
 }
+#endif

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -1,5 +1,6 @@
 #include "dra.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_801092E8(s32 arg0) {
     D_800A37D8.D_800A37D8 = D_800ACE48[arg0 * 2];
@@ -891,3 +892,4 @@ INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_80111018);
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_801112AC);
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/692E8", func_8011151C);
+#endif

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_80111830(void) {
     s32 var_v0;
@@ -171,3 +172,4 @@ void func_801139CC(s32 arg0) {
         PLAYER.accelerationY = 0;
     }
 }
+#endif

--- a/src/dra/73AAC.c
+++ b/src/dra/73AAC.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_80113AAC(void) {
     s32 var_s1 = 0;
@@ -234,3 +235,4 @@ void func_80115C50(void) {
         }
     }
 }
+#endif

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_80115F54(void) {
     Unkstruct_800ECBF8_1* temp_s0;
@@ -2874,3 +2875,4 @@ void func_80134E64(void) {
 
 INCLUDE_ASM("asm/us/dra/nonmatchings/75F54", func_80134F50);
 void func_80134F50();
+#endif

--- a/src/dra/953A0.c
+++ b/src/dra/953A0.c
@@ -2,6 +2,7 @@
 #include "dra.h"
 #include "objects.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 void func_801353A0(void) {
     if (*(u16*)&D_801396F4 == 0)
@@ -119,3 +120,4 @@ void func_801361F8(void) {
 }
 
 void nullsub_10(void) {}
+#endif

--- a/src/dra/cd.c
+++ b/src/dra/cd.c
@@ -1,6 +1,7 @@
 #include "dra.h"
 #include "lba.h"
 #include "sfx.h"
+#if defined(VERSION_US)
 
 #if USE_CD_SPEED_DOUBLE == 0
 #define CDL_MODE_SPEED CdlModeSpeedNormal
@@ -935,3 +936,4 @@ void UpdateCd(void) {
         func_8010838C(CdStep_CdShellOpenErr);
     }
 }
+#endif


### PR DESCRIPTION
I can only hope it will work at first try.

The trick lies in `extract: extract_$(VERSION)` and `build: build_$(VERSION)` to customise different versions/ports to do different things and keep the flow the same.

You can now do:
```
export VERSION=hd
make build
```

or:
```
VERSION=hd make build
```

or:
```
make build_hd
```

If we are happy with this pattern we might want to do the same with the Saturn version too.