### PR TITLE
Generate web pages for call trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ disks/
 .vscode/settings.json
 tools/go
 tools/sotn_calltree.txt
+tools/generated_graphs/*
 tools/saturn_toolchain/GCCSH
 config/saturn/game_syms.txt
 config/saturn/stage_02_syms.txt


### PR DESCRIPTION
Very happy to have this working!

Now, when you run `python3 analyze_calls.py ALL`, it will generate the call graphs for every function in the game, and save as an SVG file in the directory `tools/generated_graphs`. It will then finish by creating an `index.html` that links to every one of those graphs. Each graph's bubbles are clickable to take you to the next graph.

I have deployed an example of the result of this, linked in the sotn decomp Discord, but because it is hosted on my personal computer, I will not be linking it here (accessible to the wider internet and crawlers, etc). It would be great if this script could be worked into the CI to create a publicly visible list of functions linking to graphs, which would automatically update whenever the repo gets updated.

As always, be sure to run `make force_extract` before invoking this.

It will be very exciting once this is up and running!
