### PR TITLE
Lint followup + Relics docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ format:
 	clang-format -i $$(find $(SRC_DIR)/ -type f -name "*.c")
 	clang-format -i $$(find $(SRC_DIR)/ -type f -name "*.h")
 	clang-format -i $$(find $(INCLUDE_DIR)/ -type f -name "*.h")
+	$(PYTHON) tools/lints/fixed.py src/
+	$(PYTHON) tools/lints/relics.py src/
 	black tools/*.py
 	black tools/splat_ext/*.py
 	black tools/split_jpt_yaml/*.py

--- a/include/game.h
+++ b/include/game.h
@@ -651,7 +651,8 @@ typedef enum {
     RELIC_TOOTH_OF_VLAD,
     RELIC_RIB_OF_VLAD,
     RELIC_RING_OF_VLAD,
-    RELIC_EYE_OF_VLAD
+    RELIC_EYE_OF_VLAD,
+    RELIC_END,
 } RelicIds;
 
 typedef struct {

--- a/include/game.h
+++ b/include/game.h
@@ -621,6 +621,9 @@ typedef struct {
     u32 unk8;
 } FamiliarStats;
 
+#define RELIC_FLAG_DISABLE 0
+#define RELIC_FLAG_FOUND 1
+#define RELIC_FLAG_ACTIVE 2
 typedef enum {
     RELIC_SOUL_OF_BAT,
     RELIC_FIRE_OF_BAT,

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -699,7 +699,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
         if ((g_StageId == STAGE_ST0) ||
             (g_CurrentPlayableCharacter != PLAYER_ALUCARD)) {
 
-            for (i = 0; i < 30; i++) {
+            for (i = 0; i < RELIC_END; i++) {
                 g_Status.relics[i] = 1;
             }
             // These relics are special for Richter
@@ -765,7 +765,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
                 g_Status.statsBase[STAT_INT] = 6;
                 g_Status.statsBase[STAT_LCK] = 6;
                 g_Status.gold = 0;
-                for (i = 0; i < 30; i++) {
+                for (i = 0; i < RELIC_END; i++) {
                     g_Status.relics[i] = 0;
                 }
                 // If we died in prologue and needed Maria's rescue
@@ -931,7 +931,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
                     g_Status.exp = 110000;
                 }
 
-                for (i = 0; i < 30; i++) {
+                for (i = 0; i < RELIC_END; i++) {
                     g_Status.relics[i] = 3;
                     if (D_800A872C[i].unk0 != 0) {
                         g_Status.relics[i] = 1;

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -700,7 +700,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
             (g_CurrentPlayableCharacter != PLAYER_ALUCARD)) {
 
             for (i = 0; i < RELIC_END; i++) {
-                g_Status.relics[i] = 1;
+                g_Status.relics[i] = RELIC_FLAG_FOUND;
             }
             // These relics are special for Richter
             g_Status.relics[RELIC_CUBE_OF_ZOE] |= 2;
@@ -766,7 +766,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
                 g_Status.statsBase[STAT_LCK] = 6;
                 g_Status.gold = 0;
                 for (i = 0; i < RELIC_END; i++) {
-                    g_Status.relics[i] = 0;
+                    g_Status.relics[i] = RELIC_FLAG_DISABLE;
                 }
                 // If we died in prologue and needed Maria's rescue
                 if (D_801397FC != 0) {
@@ -932,9 +932,9 @@ void InitStatsAndGear(bool DeathTakeItems) {
                 }
 
                 for (i = 0; i < RELIC_END; i++) {
-                    g_Status.relics[i] = 3;
+                    g_Status.relics[i] = RELIC_FLAG_FOUND | RELIC_FLAG_ACTIVE;
                     if (D_800A872C[i].unk0 != 0) {
-                        g_Status.relics[i] = 1;
+                        g_Status.relics[i] = RELIC_FLAG_FOUND;
                     }
                 }
                 // In Demo mode, Alucard gets 50 of everything holdable

--- a/src/dra/demo.c
+++ b/src/dra/demo.c
@@ -26,12 +26,12 @@ void DemoGameInit(s32 arg0) {
     if (g_StageId != STAGE_ST0) {
         g_Status.level = 99;
         for (i = 0; i < RELIC_BAT_CARD; i++) {
-            g_Status.relics[i] = 3;
+            g_Status.relics[i] = RELIC_FLAG_FOUND | RELIC_FLAG_ACTIVE;
         }
         for (; i < RELIC_END; i++) {
-            g_Status.relics[i] = 1;
+            g_Status.relics[i] = RELIC_FLAG_FOUND;
         }
-        g_Status.relics[RELIC_GAS_CLOUD] = 1;
+        g_Status.relics[RELIC_GAS_CLOUD] = RELIC_FLAG_FOUND;
         g_Status.hp = 80;
         g_Status.hpMax = 80;
         g_Status.subWeapon = 0;

--- a/src/dra/demo.c
+++ b/src/dra/demo.c
@@ -25,10 +25,10 @@ void DemoGameInit(s32 arg0) {
     InitStatsAndGear(0);
     if (g_StageId != STAGE_ST0) {
         g_Status.level = 99;
-        for (i = 0; i < 18; i++) {
+        for (i = 0; i < RELIC_BAT_CARD; i++) {
             g_Status.relics[i] = 3;
         }
-        for (; i < 30; i++) {
+        for (; i < RELIC_END; i++) {
             g_Status.relics[i] = 1;
         }
         g_Status.relics[RELIC_GAS_CLOUD] = 1;

--- a/src/dra/gameover.c
+++ b/src/dra/gameover.c
@@ -348,7 +348,7 @@ s32 func_800E6300(void) {
     s32 i;
 
     for (i = 0; i < RELIC_END; i++) {
-        if ((D_800A872C[i].unk0 > 0) && (g_Status.relics[i] & 2)) {
+        if (D_800A872C[i].unk0 > 0 && g_Status.relics[i] & RELIC_FLAG_ACTIVE) {
             return D_800A872C[i].unk0;
         }
     }

--- a/src/dra/gameover.c
+++ b/src/dra/gameover.c
@@ -347,7 +347,7 @@ void func_800E6250(void) {
 s32 func_800E6300(void) {
     s32 i;
 
-    for (i = 0; i < 30; i++) {
+    for (i = 0; i < RELIC_END; i++) {
         if ((D_800A872C[i].unk0 > 0) && (g_Status.relics[i] & 2)) {
             return D_800A872C[i].unk0;
         }


### PR DESCRIPTION
Follow up to #412 . This also integrates the two new linters within the formatter. By the way, are we happier with `RELIC_END` or `RELIC_COUNT`?