### PR TITLE
Document familar IDs

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -657,6 +657,16 @@ typedef enum {
     NUM_RELICS,
 } RelicIds;
 
+typedef enum {
+    FAMILIAR_BAT,
+    FAMILIAR_GHOST,
+    FAMILIAR_FAIRIE,
+    FAMILIAR_DEMON,
+    FAMILIAR_SWORD,
+    FAMILIAR_YOUSEI,    // JP only
+    FAMILIAR_NOSE_DEMON // JP only
+} FamiliarIds;
+
 typedef struct {
     /* 80097964 */ u8 relics[30];
     /* 80097982 */ u8 spells[8];

--- a/include/game.h
+++ b/include/game.h
@@ -664,7 +664,8 @@ typedef enum {
     FAMILIAR_DEMON,
     FAMILIAR_SWORD,
     FAMILIAR_YOUSEI,    // JP only
-    FAMILIAR_NOSE_DEMON // JP only
+    FAMILIAR_NOSE_DEMON, // JP only
+    NUM_FAMILIARS
 } FamiliarIds;
 
 typedef struct {

--- a/include/game.h
+++ b/include/game.h
@@ -660,7 +660,7 @@ typedef enum {
 typedef enum {
     FAMILIAR_BAT,
     FAMILIAR_GHOST,
-    FAMILIAR_FAIRIE,
+    FAMILIAR_FAERIE,
     FAMILIAR_DEMON,
     FAMILIAR_SWORD,
     FAMILIAR_YOUSEI,    // JP only

--- a/include/game.h
+++ b/include/game.h
@@ -663,7 +663,7 @@ typedef enum {
     FAMILIAR_FAERIE,
     FAMILIAR_DEMON,
     FAMILIAR_SWORD,
-    FAMILIAR_YOUSEI,    // JP only
+    FAMILIAR_YOUSEI,     // JP only
     FAMILIAR_NOSE_DEMON, // JP only
     NUM_FAMILIARS
 } FamiliarIds;

--- a/include/game.h
+++ b/include/game.h
@@ -710,7 +710,7 @@ typedef struct {
     /* 80097C38 */ s32 timerSeconds;
     /* 80097C3C */ s32 timerFrames;
     /* 80097C40 */ u32 D_80097C40;
-    /* 80097C44 */ FamiliarStats statsFamiliars[7];
+    /* 80097C44 */ FamiliarStats statsFamiliars[NUM_FAMILIARS];
 } PlayerStatus; /* size=0x334 */
 
 typedef struct {

--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -170,8 +170,8 @@ s32 CalcAttack(s32 equipId, s32 otherEquipId) {
         totalAttack += 5;
     }
     if (equipId == 0x7E) { // Equippable Sword Familiar
-        totalAttack +=
-            g_Status.statsFamiliars[4].level; // Level of sword familiar
+        totalAttack += g_Status.statsFamiliars[FAMILIAR_SWORD]
+                           .level; // Level of sword familiar
     }
     if (D_8013982C != 0) {
         totalAttack += 20;

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -784,7 +784,7 @@ void InitStatsAndGear(bool DeathTakeItems) {
         g_Status.level = 1;
         g_Status.killCount = 0;
 
-        for (i = 0; i < 7; i++) {
+        for (i = 0; i < NUM_FAMILIARS; i++) {
             g_Status.statsFamiliars[i].level = 1;
             g_Status.statsFamiliars[i].exp = 0;
             g_Status.statsFamiliars[i].unk8 = 0;


### PR DESCRIPTION
I checked this by editing the level of the familiar and looking at the familiar status menu. The JP only ones still get shown in the menu if you have the relic.