### PR TITLE
Decompile _SsReadDeltaValue

### DIFF
--- a/src/main/psxsdk/libsnd/libsnd_internal.h
+++ b/src/main/psxsdk/libsnd/libsnd_internal.h
@@ -92,4 +92,16 @@ void SpuVmKeyOff(s32, s16, s16, u16);
 void SeAutoVol(s16, s16, s16, s16);
 void SeAutoPan(s16, s16, s16, s16);
 
+// similar to
+// https://github.com/AliveTeam/sound_rev/blob/7a9223139c3375bf10e96a4ac17d77b973979e20/psx_seq_player/lib_snd.hpp#L127C1-L184C7
+struct SeqStruct {
+    u8* seq_ptr;
+    u8* read_pos;
+    u8 pad8[0x78];
+    u32 unk80;
+    u8 pad84[40];
+};
+
+extern struct SeqStruct* _ss_score[32];
+
 #endif

--- a/src/main/psxsdk/libsnd/miditime.c
+++ b/src/main/psxsdk/libsnd/miditime.c
@@ -1,4 +1,28 @@
 #include "common.h"
+#include "libsnd_internal.h"
 
-INCLUDE_ASM(
-    "asm/us/main/nonmatchings/psxsdk/libsnd/miditime", _SsReadDeltaValue);
+s32 _SsReadDeltaValue(s16 arg0, s16 arg1) {
+    s32 temp_v0;
+    s32 var_v0;
+    u8 temp_v1_2;
+    u32 var_a0;
+    u8* temp_v1;
+    struct SeqStruct* temp_a1 = &_ss_score[arg0][arg1];
+    var_a0 = *temp_a1->read_pos++;
+    if (var_a0 == 0) {
+        return 0;
+    }
+
+    // variable length quantity decoding (midi)
+    if (var_a0 & 0x80) {
+        var_a0 &= 0x7F;
+        do {
+            temp_v1_2 = *temp_a1->read_pos++;
+            var_a0 = (var_a0 << 7) + (temp_v1_2 & 0x7F);
+        } while (temp_v1_2 & 0x80);
+    }
+
+    temp_v0 = ((var_a0 << 2) + var_a0) * 2;
+    temp_a1->unk80 += temp_v0;
+    return temp_v0;
+}

--- a/src/main/psxsdk/libsnd/miditime.c
+++ b/src/main/psxsdk/libsnd/miditime.c
@@ -22,7 +22,7 @@ s32 _SsReadDeltaValue(s16 arg0, s16 arg1) {
         } while (temp_v1_2 & 0x80);
     }
 
-    temp_v0 = ((var_a0 << 2) + var_a0) * 2;
+    temp_v0 = var_a0 * 10;
     temp_a1->unk80 += temp_v0;
     return temp_v0;
 }


### PR DESCRIPTION
I'm not sure about `struct SeqStruct* temp_a1 = &_ss_score[arg0][arg1];` since it doesn't seem to make sense with the struct definition. I got the idea from https://github.com/AliveTeam/sound_rev/blob/7a9223139c3375bf10e96a4ac17d77b973979e20/psx_seq_player/lib_snd.cpp#L201

Co-authored-by: Mc-muffin <8714476+Mc-muffin@users.noreply.github.com>