### PR TITLE
Add spritesheet tool

### DIFF
--- a/tools/splat_ext/spritesheet.py
+++ b/tools/splat_ext/spritesheet.py
@@ -126,10 +126,10 @@ def serialize_spritesheet(writer, name: str, content: str, optimized: bool) -> s
             return f"size for '{file_name}' is {width}x{height} but it must be less than {max_width}x{max_height}"
         if (width & 3) != 0:
             return f"size for '{file_name}' is {width}x{height} but the width must be a multiple of 4"
-        if info["planes"] != 1 or info["bitdepth"] != 8:
+        if info["planes"] != 1 or (info["bitdepth"] != 8 and info["bitdepth"] != 4):
             return f"'{file_name}' must be an indexed image"
-        if len(palette) != 16:
-            return f"'{file_name}' palette must be of 16 colors but found {len(palette)} colors instead"
+        if len(palette) > 16:
+            return f"'{file_name}' palette must be of 16 colors or less but found {len(palette)} colors instead"
 
         bytes_per_row = int(width / 2)
         padding = 4 - (int((width * height + 1) / 2) & 3)

--- a/tools/spritesheet.py
+++ b/tools/spritesheet.py
@@ -109,9 +109,9 @@ def split(name, spritesheet, out_path):
 
         spritesheet_desc.append(
             {
-                "name": out_sprite_path,
                 "x": x,
                 "y": y,
+                "name": out_sprite_path,
             }
         )
     with open(os.path.join(out_path, f"{name}.spritesheet.json"), "w") as f:


### PR DESCRIPTION
Creates a tool in python that assembles a spritesheet descriptor (e.g. `assets/ric/richter.spritesheet.json`) and its individual sprites into a single spritesheet as PNG. Values such as horizontal and vertical alignment are preserved and the palette of the spritesheet is copied from the very first sprite. This can be achieved by running `./tools/spritesheet.py merge assets/ric/richter.spritesheet.json richter.png`.

The tool is also able to do a round trip, by splitting the spritesheet into their individual sprites and recrearting the spritesheet descriptor with `/tools/spritesheet.py split richter.png assets/ric/`. Note this will not re-create the `padding` field as that seems to be some kind of left-over. I do not think it is important at all as this tool is for modding and not for matching.

Last, but not least, I made minor tweaks to the script to build back the individual frames. I noticed I was performing extra sanity checks purely based on the specific output I was initially getting from the original game files. For instance I was previously forcing the sprites to be exactly 16 colours for a 8-bit PNG. The change makes the checks more lax by allowing 4-bit PNGs and less than 16 colours.

---

How to mod:
```
make extract_ric
./tools/spritesheet.py merge assets/ric/richter.spritesheet.json richter.png
```
Now you can modify your `richter.png` spritesheet. To test it back in-game do:
```
./tools/spritesheet.py split richter.png assets/ric/
make ric
make disk
```