### PR TITLE
Rename UpdateStageEntities

### DIFF
--- a/config/symbols.us.stcen.txt
+++ b/config/symbols.us.stcen.txt
@@ -14,6 +14,7 @@ EntityUnkId1B = 0x80190A78;
 EntityMovingElevator = 0x80190B64;
 Random = 0x80190E4C;
 Update = 0x80190E7C;
+UpdateStageEntities = 0x80191178;
 EntityNumericDamage = 0x80192398;
 CreateEntityWhenInVerticalRange = 0x80192B00;
 CreateEntityWhenInHorizontalRange = 0x80192C18;

--- a/config/symbols.us.stdre.txt
+++ b/config/symbols.us.stdre.txt
@@ -27,6 +27,7 @@ EntityFadeToWhite1 = 0x8019697C;
 EntityFadeToWhite2 = 0x80196CC8;
 Random = 0x80196F90;
 Update = 0x80196FC0;
+UpdateStageEntities = 0x801972BC;
 EntityNumericDamage = 0x801984DC;
 CreateEntityFromLayout = 0x80198B80;
 CreateEntityWhenInVerticalRange = 0x80198C44;

--- a/config/symbols.us.stno3.txt
+++ b/config/symbols.us.stno3.txt
@@ -60,6 +60,7 @@ EntityUnkId5E = 0x801C12E8;
 EntityWargExplosionPuffOpaque = 0x801C14B8;
 Random = 0x801C184C;
 Update = 0x801C187C;
+UpdateStageEntities = 0x801C1B78;
 EntityNumericDamage = 0x801C2D98;
 CreateEntityFromLayout = 0x801C343C;
 CreateEntityWhenInVerticalRange = 0x801C3500;

--- a/config/symbols.us.stnp3.txt
+++ b/config/symbols.us.stnp3.txt
@@ -34,6 +34,7 @@ EntitySmallGaibonProjectile = 0x801B8D84;
 EntityLargeGaibonProjectile = 0x801B8E94;
 Random = 0x801B90BC;
 Update = 0x801B90EC;
+UpdateStageEntities = 0x801B93E8;
 EntityNumericDamage = 0x801BA608;
 CreateEntityFromLayout = 0x801BACAC;
 CreateEntityWhenInVerticalRange = 0x801BAD70;

--- a/config/symbols.us.stnz0.txt
+++ b/config/symbols.us.stnz0.txt
@@ -67,6 +67,7 @@ EntityLargeGaibonProjectile = 0x801B6BBC;
 EntityMariaCutscene = 0x801B7D58;
 Random = 0x801B94D4;
 Update = 0x801B9504;
+UpdateStageEntities = 0x801B9800;
 TestCollisions = 0x801B9908;
 EntityNumericDamage = 0x801BAA20;
 CreateEntityFromLayout = 0x801BB0C4;

--- a/config/symbols.us.strwrp.txt
+++ b/config/symbols.us.strwrp.txt
@@ -3,6 +3,7 @@ UNK_Invincibility0 = 0x80180690;
 g_Rooms = 0x801811AC;
 Random = 0x8018A168;
 Update = 0x8018A198;
+UpdateStageEntities = 0x8018A494;
 CreateEntityWhenInVerticalRange = 0x8018BE1C;
 CreateEntityWhenInHorizontalRange = 0x8018BF34;
 DestroyEntity = 0x8018D580;

--- a/config/symbols.us.stst0.txt
+++ b/config/symbols.us.stst0.txt
@@ -27,6 +27,7 @@ EntityDraculaRainAttack = 0x801AF154;
 SetGameState = 0x801B0030;
 Random = 0x801B186C;
 Update = 0x801B189C;
+UpdateStageEntities = 0x801B1B98;
 EntityNumericDamage = 0x801B2A3C;
 CreateEntityFromLayout = 0x801B30E0;
 CreateEntityWhenInVerticalRange = 0x801B31A4;

--- a/src/st/cen/10E4C.c
+++ b/src/st/cen/10E4C.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/10E4C", func_80191178);
+INCLUDE_ASM("asm/us/st/cen/nonmatchings/10E4C", UpdateStageEntities);
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/10E4C", func_80191280);
 

--- a/src/st/dre/16F90.c
+++ b/src/st/dre/16F90.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/16F90", func_801972BC);
+INCLUDE_ASM("asm/us/st/dre/nonmatchings/16F90", UpdateStageEntities);
 
 INCLUDE_ASM("asm/us/st/dre/nonmatchings/16F90", func_801973C4);
 

--- a/src/st/no3/4184C.c
+++ b/src/st/no3/4184C.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/4184C", func_801C1B78);
+INCLUDE_ASM("asm/us/st/no3/nonmatchings/4184C", UpdateStageEntities);
 
 INCLUDE_ASM("asm/us/st/no3/nonmatchings/4184C", func_801C1C80);
 

--- a/src/st/np3/390BC.c
+++ b/src/st/np3/390BC.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-void func_801B93E8(void) {
+void UpdateStageEntities(void) {
     Entity* entity;
     for (entity = &g_Entities[STAGE_ENTITY_START];
          entity < &g_Entities[TOTAL_ENTITY_COUNT]; entity++) {

--- a/src/st/nz0/394D4.c
+++ b/src/st/nz0/394D4.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-void func_801B9800(void) {
+void UpdateStageEntities(void) {
     Entity* entity;
     for (entity = &g_Entities[STAGE_ENTITY_START];
          entity < &g_Entities[TOTAL_ENTITY_COUNT]; entity++) {

--- a/src/st/rwrp/A168.c
+++ b/src/st/rwrp/A168.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A168", func_8018A494);
+INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A168", UpdateStageEntities);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A168", func_8018A59C);
 

--- a/src/st/st0/3186C.c
+++ b/src/st/st0/3186C.c
@@ -3,7 +3,7 @@
 
 #include "../update.h"
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/3186C", func_801B1B98);
+INCLUDE_ASM("asm/us/st/st0/nonmatchings/3186C", UpdateStageEntities);
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/3186C", func_801B1CA0);
 

--- a/src/st/wrp/81E8.c
+++ b/src/st/wrp/81E8.c
@@ -20,7 +20,7 @@ extern LayoutEntity* g_pStObjLayout[];
 
 #include "../update.h"
 
-void func_80188514(void) {
+void UpdateStageEntities(void) {
     Entity* entity;
     for (entity = &g_Entities[STAGE_ENTITY_START];
          entity < &g_Entities[TOTAL_ENTITY_COUNT]; entity++) {

--- a/src/st/wrp/header.c
+++ b/src/st/wrp/header.c
@@ -15,7 +15,7 @@ s16** g_SpriteBanks[];
 void* g_Cluts[];
 RoomDef g_TileLayers[];
 void* g_EntityGfxs[];
-void func_80188514(void);
+void UpdateStageEntities(void);
 
 Overlay g_StageOverlay = {
     /* 0x00 */ Update,
@@ -28,7 +28,7 @@ Overlay g_StageOverlay = {
     /* 0x1C */ NULL,
     /* 0x20 */ g_TileLayers,
     /* 0x24 */ g_EntityGfxs,
-    /* 0x28 */ func_80188514,
+    /* 0x28 */ UpdateStageEntities,
     /* 0x2C */ 0x00000000,
     /* 0x30 */ 0x00000000,
     /* 0x34 */ 0x00000000,


### PR DESCRIPTION
I wasn't able to get this to work for MAD for some reason. Splat wouldn't extract the asm under the new filename.