### PR TITLE
Decompile DRA func_800FE97C

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -707,7 +707,7 @@ typedef struct {
     /* 80097BFC */ u32 subWeapon;
     /* 80097C00 */ u32 equipment[7];
     /* 80097C1C */ u32 attackHands[2]; // right hand, left hand
-    /* 80097C24 */ u32 defenseEquip;
+    /* 80097C24 */ s32 defenseEquip;
     /* 80097C28 */ u16 defenseElement;
     /* 80097C2A */ u16 D_80097C2A;
     /* 80097C2C */ u16 D_80097C2C;

--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -309,9 +309,9 @@ typedef struct {
     /* 0x0E */ s16 unk0E;
 } RelicDesc;
 
-typedef struct{
+typedef struct {
     s32 unk0;
     s32 unk4;
-    s32 unk8;
+    s32 damageTaken;
     s32 unkC;
 } Unkstruct_800FE97C;

--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -308,3 +308,10 @@ typedef struct {
     /* 0x0C */ s16 unk0C;
     /* 0x0E */ s16 unk0E;
 } RelicDesc;
+
+typedef struct{
+    s32 unk0;
+    s32 unk4;
+    s32 unk8;
+    s32 unkC;
+} Unkstruct_800FE97C;

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -474,7 +474,7 @@ void AddHearts(s32 value) {
     }
 }
 
-//Note: Arg3 is unused, but is given in the call from func_80113D7C
+// Note: Arg3 is unused, but is given in the call from func_80113D7C
 s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 ret;
     s32 var_s1;
@@ -488,7 +488,7 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         var_s1 *= 2;
     }
     if (g_Status.D_80097C2A & arg0->unk0) {
-        var_s1 /=  2;
+        var_s1 /= 2;
     }
     if (g_Status.D_80097C2C & arg0->unk0) {
         if (!(g_Status.D_80097C2C & arg0->unk0 & 0x200)) {
@@ -496,8 +496,8 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
         arg0->unk0 &= ~0x200;
     }
-    
-    if (g_Status.D_80097C2E & arg0->unk0){
+
+    if (g_Status.D_80097C2E & arg0->unk0) {
         if (var_s1 < 1) {
             var_s1 = 1;
         }
@@ -511,9 +511,11 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
         return 5;
     }
-    //Player wearing cat-eye circlet. Same as above if-statement but
-    // with var_s1 doubled. Item description says "Big HP restore" so makes sense
-    if (CheckEquipmentItemCount(0x2B, 1) != 0 && arg0->unk4 == 7) {
+    // Player wearing cat-eye circlet. Same as above if-statement but
+    //  with var_s1 doubled. Item description says "Big HP restore" so makes
+    //  sense
+    if (CheckEquipmentItemCount(ITEM_CAT_EYE_CIRCLET, HEAD_TYPE) != 0 &&
+        arg0->unk4 == 7) {
         var_s1 *= 2;
         if (var_s1 < 1) {
             var_s1 = 1;
@@ -528,9 +530,9 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
         return 5;
     }
-    
-    //Ballroom mask???
-    itemCount = CheckEquipmentItemCount(0x1C, 1);
+
+    // Ballroom mask???
+    itemCount = CheckEquipmentItemCount(ITEM_BALLROOM_MASK, HEAD_TYPE);
     if ((itemCount != 0) && (arg0->unk0 & 0xF980)) {
         if (itemCount == 1) {
             var_s1 -= var_s1 / 5;
@@ -540,43 +542,40 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
     }
     if (g_Player_unk0C & 0x80) {
-        arg0->unk8 = g_Status.hpMax / 8;
+        arg0->damageTaken = g_Status.hpMax / 8;
         ret = 8;
-    }
-    else if (arg0->unk0 & 0x200) {
-        arg0->unk8 = var_s1 - (g_Status.defenseEquip * 2);
-        if (arg0->unk8 <= 0) {
-            arg0->unk8 = 0;
+    } else if (arg0->unk0 & 0x200) {
+        arg0->damageTaken = var_s1 - (g_Status.defenseEquip * 2);
+        if (arg0->damageTaken <= 0) {
+            arg0->damageTaken = 0;
         }
         ret = 7;
-    }
-    else if (arg0->unk4 == 6) {
+    } else if (arg0->unk4 == 6) {
         if (D_8003C8C4 == ((D_8003C8C4 / 10) * 0xA)) {
-            arg0->unk8 = 1;
+            arg0->damageTaken = 1;
         } else {
-            arg0->unk8 = 0;
+            arg0->damageTaken = 0;
         }
         ret = 9;
-    }
-    else {
+    } else {
         if (arg0->unk4 < 0x10U) {
-            arg0->unk8 = var_s1 - g_Status.defenseEquip;
+            arg0->damageTaken = var_s1 - g_Status.defenseEquip;
         } else {
-            arg0->unk8 = g_Status.hpMax / 8;
+            arg0->damageTaken = g_Status.hpMax / 8;
         }
         if (g_Player_unk0C & 0x4000) {
-            arg0->unk8 *= 2;
+            arg0->damageTaken *= 2;
         }
-        //Check for player wearing a Talisman
-        itemCount = CheckEquipmentItemCount(0x53U, 4U);
-        if (itemCount != 0){
+        // Check for player wearing a Talisman
+        itemCount = CheckEquipmentItemCount(ITEM_TALISMAN, ACCESSORY_TYPE);
+        if (itemCount != 0) {
             if (itemCount * g_Status.statsTotal[3] >= (rand() & 0x1FF)) {
                 return 2;
             }
         }
-        if (arg0->unk8 > 0) {
+        if (arg0->damageTaken > 0) {
             if (arg0->unk4 < 2U) {
-                if ((arg0->unk8 * 2) >= g_Status.hpMax) {
+                if ((arg0->damageTaken * 2) >= g_Status.hpMax) {
                     arg0->unk4 = 4;
                 } else if ((var_s1 * 50) >= g_Status.hpMax) {
                     arg0->unk4 = 3;
@@ -586,18 +585,19 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
             }
             ret = 3;
         } else {
-            if ((g_Status.defenseEquip > 99) && !(arg0->unk0 & 0x180) && !(g_Player_unk0C & 0x80)) {
+            if ((g_Status.defenseEquip > 99) && !(arg0->unk0 & 0x180) &&
+                !(g_Player_unk0C & 0x80)) {
                 arg0->unk4 = 0U;
                 ret = 1;
             } else {
                 arg0->unk4 = 2U;
                 ret = 3;
             }
-            arg0->unk8 = 1;
+            arg0->damageTaken = 1;
         }
     }
-    
-    if (g_Status.hp <= arg0->unk8) {
+    // If our HP is less than the damage, we die.
+    if (g_Status.hp <= arg0->damageTaken) {
         g_Status.hp = 0;
         if (ret == 7) {
             return 7;
@@ -611,11 +611,16 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         if (ret != 9) {
             func_800FE8F0();
         }
-        g_Status.hp -= arg0->unk8;
-        if ((CheckEquipmentItemCount(0x36, 3) != 0) && (ret != 9)) {
-            AddHearts(arg0->unk8);
+        // Here is where we actually take the damage away.
+        g_Status.hp -= arg0->damageTaken;
+        // Blood cloak gives hearts when damage is taken
+        if ((CheckEquipmentItemCount(ITEM_BLOOD_CLOAK, CAPE_TYPE) != 0) &&
+            (ret != 9)) {
+            AddHearts(arg0->damageTaken);
         }
-        if (CheckEquipmentItemCount(0x16, 2) != 0) {
+        // Fury Plate "DEF goes up when damage taken", that logic is not here
+        // though.
+        if (CheckEquipmentItemCount(ITEM_FURY_PLATE, ARMOR_TYPE) != 0) {
             if (*D_80139828 < 0x200) {
                 *D_80139828 = 0x200;
             }

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -474,7 +474,155 @@ void AddHearts(s32 value) {
     }
 }
 
-INCLUDE_ASM("dra/nonmatchings/5D6C4", func_800FE97C);
+//Note: Arg3 is unused, but is given in the call from func_80113D7C
+s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
+    s32 ret;
+    s32 var_s1;
+    s32 itemCount;
+
+    var_s1 = arg2;
+    func_800F53A4();
+    arg0->unk0 = arg1 & ~0x1F;
+    arg0->unk4 = arg1 & 0x1F;
+    if (g_Status.defenseElement & arg0->unk0) {
+        var_s1 *= 2;
+    }
+    if (g_Status.D_80097C2A & arg0->unk0) {
+        var_s1 /=  2;
+    }
+    if (g_Status.D_80097C2C & arg0->unk0) {
+        if (!(g_Status.D_80097C2C & arg0->unk0 & 0x200)) {
+            return 0;
+        }
+        arg0->unk0 &= ~0x200;
+    }
+    
+    if (g_Status.D_80097C2E & arg0->unk0){
+        if (var_s1 < 1) {
+            var_s1 = 1;
+        }
+        arg0->unkC = var_s1;
+        if (g_Status.hp != g_Status.hpMax) {
+            func_800FE8F0();
+            g_Status.hp += arg0->unkC;
+            if (g_Status.hpMax < g_Status.hp) {
+                g_Status.hp = g_Status.hpMax;
+            }
+        }
+        return 5;
+    }
+    //Player wearing cat-eye circlet. Same as above if-statement but
+    // with var_s1 doubled. Item description says "Big HP restore" so makes sense
+    if (CheckEquipmentItemCount(0x2B, 1) != 0 && arg0->unk4 == 7) {
+        var_s1 *= 2;
+        if (var_s1 < 1) {
+            var_s1 = 1;
+        }
+        arg0->unkC = var_s1;
+        if (g_Status.hp != g_Status.hpMax) {
+            func_800FE8F0();
+            g_Status.hp += arg0->unkC;
+            if (g_Status.hpMax < g_Status.hp) {
+                g_Status.hp = g_Status.hpMax;
+            }
+        }
+        return 5;
+    }
+    
+    //Ballroom mask???
+    itemCount = CheckEquipmentItemCount(0x1C, 1);
+    if ((itemCount != 0) && (arg0->unk0 & 0xF980)) {
+        if (itemCount == 1) {
+            var_s1 -= var_s1 / 5;
+        }
+        if (itemCount == 2) {
+            var_s1 -= var_s1 / 3;
+        }
+    }
+    if (g_Player_unk0C & 0x80) {
+        arg0->unk8 = g_Status.hpMax / 8;
+        ret = 8;
+    }
+    else if (arg0->unk0 & 0x200) {
+        arg0->unk8 = var_s1 - (g_Status.defenseEquip * 2);
+        if (arg0->unk8 <= 0) {
+            arg0->unk8 = 0;
+        }
+        ret = 7;
+    }
+    else if (arg0->unk4 == 6) {
+        if (D_8003C8C4 == ((D_8003C8C4 / 10) * 0xA)) {
+            arg0->unk8 = 1;
+        } else {
+            arg0->unk8 = 0;
+        }
+        ret = 9;
+    }
+    else {
+        if (arg0->unk4 < 0x10U) {
+            arg0->unk8 = var_s1 - g_Status.defenseEquip;
+        } else {
+            arg0->unk8 = g_Status.hpMax / 8;
+        }
+        if (g_Player_unk0C & 0x4000) {
+            arg0->unk8 *= 2;
+        }
+        //Check for player wearing a Talisman
+        itemCount = CheckEquipmentItemCount(0x53U, 4U);
+        if (itemCount != 0){
+            if (itemCount * g_Status.statsTotal[3] >= (rand() & 0x1FF)) {
+                return 2;
+            }
+        }
+        if (arg0->unk8 > 0) {
+            if (arg0->unk4 < 2U) {
+                if ((arg0->unk8 * 2) >= g_Status.hpMax) {
+                    arg0->unk4 = 4;
+                } else if ((var_s1 * 50) >= g_Status.hpMax) {
+                    arg0->unk4 = 3;
+                } else {
+                    arg0->unk4 = 2;
+                }
+            }
+            ret = 3;
+        } else {
+            if ((g_Status.defenseEquip > 99) && !(arg0->unk0 & 0x180) && !(g_Player_unk0C & 0x80)) {
+                arg0->unk4 = 0U;
+                ret = 1;
+            } else {
+                arg0->unk4 = 2U;
+                ret = 3;
+            }
+            arg0->unk8 = 1;
+        }
+    }
+    
+    if (g_Status.hp <= arg0->unk8) {
+        g_Status.hp = 0;
+        if (ret == 7) {
+            return 7;
+        }
+        if (ret == 9) {
+            ret = 6;
+        } else {
+            ret = 4;
+        }
+    } else {
+        if (ret != 9) {
+            func_800FE8F0();
+        }
+        g_Status.hp -= arg0->unk8;
+        if ((CheckEquipmentItemCount(0x36, 3) != 0) && (ret != 9)) {
+            AddHearts(arg0->unk8);
+        }
+        if (CheckEquipmentItemCount(0x16, 2) != 0) {
+            if (*D_80139828 < 0x200) {
+                *D_80139828 = 0x200;
+            }
+        }
+    }
+    return ret;
+}
 
 // !FAKE: explicitly casting two pointers to s32
 // before comparing them, that's weird

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -786,7 +786,7 @@ void LearnSpell(s32 spellId);
 void func_800FDE00(void);
 s32 func_800FE3C4(SubweaponDef* subwpn, s32 subweaponId, bool useHearts);
 void GetEquipProperties(s32 handId, Equipment* res, s32 equipId);
-s32 func_800FE97C(s32*, s32, s32, s32);
+s32 func_800FE97C(Unkstruct_800FE97C*, s32, s32, s32);
 s32 func_800FEEA4(s32, s32);
 void func_800FF0A0(s32 arg0);
 void func_80102CD8(s32);


### PR DESCRIPTION
Several comments on this one, it's weird.

This appears to handle some of the logic involved when the player takes damage. It is called by 3 functions. One is EntityAlucard, and of the other two one is decompiled and one is not. I have decompiled the other one, and will submit that PR next.

The first argument is a pointer to a structure which holds some of the results of this function. This is similar to CheckCollision which stores the results in a Collider struct. Most of the members of this struct are still unknown.

The logic with the ballroom mask is extremely strange and is worth further research. There appears to be a bug since it tests whether the player is wearing two ballroom masks, which should be impossible.

Overall lots of unknowns being used here, but hopefully this function and others like it will be helpful in identifying those. I hope I successfully replaced everything that has an enum.

The line which has `if ((g_Status.defenseEquip > 99)` was causing an issue with SLTI vs SLTIU, so the type of defenseEquip has been changed to match this.