### PR TITLE
w_000 matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ $(BUILD_DIR)/weapon/f%.bin: $(BUILD_DIR)/weapon/f%.elf
 $(BUILD_DIR)/weapon/w%.bin: $(BUILD_DIR)/weapon/w%.elf
 	$(OBJCOPY) -O binary $< $@
 	printf '\x00' | dd of=$@ bs=1 seek=12287 count=1 conv=notrunc
-$(BUILD_DIR)/weapon/w0_%.elf: $(BUILD_DIR)/$(SRC_DIR)/weapon/w_%.c.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.data.s.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.sbss.s.o
+$(BUILD_DIR)/weapon/w0_%.elf: $(BUILD_DIR)/$(SRC_DIR)/weapon/header.c.o $(BUILD_DIR)/$(SRC_DIR)/weapon/w_%.c.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.data.s.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.sbss.s.o
 	$(LD) $(LD_FLAGS) --no-check-sections -o $@ \
 		-Map $(BUILD_DIR)/weapon/w0_$*.map \
 		-T weapon0.ld \
@@ -254,7 +254,7 @@ $(BUILD_DIR)/weapon/w0_%.elf: $(BUILD_DIR)/$(SRC_DIR)/weapon/w_%.c.o $(BUILD_DIR
 		-T $(CONFIG_DIR)/undefined_syms_auto.$(VERSION).weapon.txt \
 		-T $(CONFIG_DIR)/undefined_funcs_auto.$(VERSION).weapon.txt \
 		$^
-$(BUILD_DIR)/weapon/w1_%.elf: $(BUILD_DIR)/$(SRC_DIR)/weapon/w_%.c.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.data.s.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.sbss.s.o
+$(BUILD_DIR)/weapon/w1_%.elf: $(BUILD_DIR)/$(SRC_DIR)/weapon/header.c.o $(BUILD_DIR)/$(SRC_DIR)/weapon/w_%.c.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.data.s.o $(BUILD_DIR)/$(ASM_DIR)/weapon/data/w_%.sbss.s.o
 	$(LD) $(LD_FLAGS) --no-check-sections -o $@ \
 		-Map $(BUILD_DIR)/weapon/w1_$*.map \
 		-T weapon1.ld \

--- a/config/splat.us.weapon.yaml
+++ b/config/splat.us.weapon.yaml
@@ -34,7 +34,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x04000, data, w_000]
+      - [0x04040, data, w_000]
       - [0x050D4, c, w_000]
       - [0x05700, sbss, w_000]
   - name: f_001
@@ -49,7 +49,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x0B000, data, w_001]
+      - [0x0B040, data, w_001]
       - [0x0C014, c, w_001]
       - [0xD430, sbss, w_001]
   - name: f_002
@@ -64,7 +64,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x12000, data, w_002]
+      - [0x12040, data, w_002]
       - [0x12BDC, c, w_002]
       - [0x13200, sbss, w_002]
   - name: f_003
@@ -79,7 +79,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x19000, data, w_003]
+      - [0x19040, data, w_003]
       - [0x19C40, c, w_003]
       - [0x1A26C, sbss, w_003]
   - name: f_004
@@ -94,7 +94,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x20000, data, w_004]
+      - [0x20040, data, w_004]
       - [0x2131C, c, w_004]
       - [0x2196C, sbss, w_004]
   - name: f_005
@@ -109,7 +109,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x27000, data, w_005]
+      - [0x27040, data, w_005]
       - [0x2831C, c, w_005]
       - [0x28998, sbss, w_005]
   - name: f_006
@@ -124,7 +124,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x2E000, data, w_006]
+      - [0x2E040, data, w_006]
       - [0x2EC54, c, w_006]
       - [0x2F9B8, sbss, w_006]
   - name: f_007
@@ -139,7 +139,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x35000, data, w_007]
+      - [0x35040, data, w_007]
       - [0x35CA0, c, w_007]
       - [0x36918, sbss, w_007]
   - name: f_008
@@ -154,7 +154,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x3C000, data, w_008]
+      - [0x3C040, data, w_008]
       - [0x3CB4C, c, w_008]
       - [0x3DF78, sbss, w_008]
   - name: f_009
@@ -169,7 +169,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x43000, data, w_009]
+      - [0x43040, data, w_009]
       - [0x43B4C, c, w_009]
       - [0x450F0, sbss, w_009]
   - name: f_010
@@ -184,7 +184,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x4A000, data, w_010]
+      - [0x4A040, data, w_010]
       - [0x4ACC0, c, w_010]
       - [0x4CC1C, sbss, w_010]
   - name: f_011
@@ -199,7 +199,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x51000, data, w_011]
+      - [0x51040, data, w_011]
       - [0x51CDC, c, w_011]
       - [0x53810, sbss, w_011]
   - name: f_012
@@ -214,7 +214,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x58000, data, w_012]
+      - [0x58040, data, w_012]
       - [0x58ACC, c, w_012]
       - [0x59B28, sbss, w_012]
   - name: f_013
@@ -229,7 +229,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x5F000, data, w_013]
+      - [0x5F040, data, w_013]
       - [0x5F62C, c, w_013]
       - [0x60C10, sbss, w_013]
   - name: f_014
@@ -244,7 +244,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x66000, data, w_014]
+      - [0x66040, data, w_014]
       - [0x665BC, c, w_014]
       - [0x67584, sbss, w_014]
   - name: f_015
@@ -259,7 +259,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x6D000, data, w_015]
+      - [0x6D040, data, w_015]
       - [0x6D7E4, c, w_015]
       - [0x6EFC8, sbss, w_015]
   - name: f_016
@@ -274,7 +274,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x74000, data, w_016]
+      - [0x74040, data, w_016]
       - [0x7460C, c, w_016]
       - [0x75D74, sbss, w_016]
   - name: f_017
@@ -289,7 +289,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x7B000, data, w_017]
+      - [0x7B040, data, w_017]
       - [0x7B3AC, c, w_017]
       - [0x7C0F4, sbss, w_017]
   - name: f_018
@@ -304,7 +304,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x82000, data, w_018]
+      - [0x82040, data, w_018]
       - [0x82740, c, w_018]
       - [0x831B4, sbss, w_018]
   - name: f_019
@@ -319,7 +319,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x89000, data, w_019]
+      - [0x89040, data, w_019]
       - [0x89554, c, w_019]
       - [0x89DB4, sbss, w_019]
   - name: f_020
@@ -334,7 +334,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x90000, data, w_020]
+      - [0x90040, data, w_020]
       - [0x90BC8, c, w_020]
       - [0x92238, sbss, w_020]
   - name: f_021
@@ -349,7 +349,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x97000, data, w_021]
+      - [0x97040, data, w_021]
       - [0x977B4, c, w_021]
       - [0x98B78, sbss, w_021]
   - name: f_022
@@ -364,7 +364,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x9E000, data, w_022]
+      - [0x9E040, data, w_022]
       - [0x9E814, c, w_022]
       - [0x9EF80, sbss, w_022]
   - name: f_023
@@ -379,7 +379,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xA5000, data, w_023]
+      - [0xA5040, data, w_023]
       - [0xA5D80, c, w_023]
       - [0xA797C, sbss, w_023]
   - name: f_024
@@ -394,7 +394,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xAC000, data, w_024]
+      - [0xAC040, data, w_024]
       - [0xACDE0, c, w_024]
       - [0xAEBF4, sbss, w_024]
   - name: f_025
@@ -409,7 +409,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xB3000, data, w_025]
+      - [0xB3040, data, w_025]
       - [0xB3B74, c, w_025]
       - [0xB5918, sbss, w_025]
   - name: f_026
@@ -424,7 +424,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xBA000, data, w_026]
+      - [0xBA040, data, w_026]
       - [0xBAB9C, c, w_026]
       - [0xBCC3C, sbss, w_026]
   - name: f_027
@@ -439,7 +439,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xC1000, data, w_027]
+      - [0xC1040, data, w_027]
       - [0xC1D54, c, w_027]
       - [0xC36EC, sbss, w_027]
   - name: f_028
@@ -454,7 +454,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xC8000, data, w_028]
+      - [0xC8040, data, w_028]
       - [0xC8BF4, c, w_028]
       - [0xCA954, sbss, w_028]
   - name: f_029
@@ -469,7 +469,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xCF000, data, w_029]
+      - [0xCF040, data, w_029]
       - [0xCFDD8, c, w_029]
       - [0xD19A0, sbss, w_029]
   - name: f_030
@@ -484,7 +484,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xD6000, data, w_030]
+      - [0xD6040, data, w_030]
       - [0xD66DC, c, w_030]
       - [0xD8C44, sbss, w_030]
   - name: f_031
@@ -499,7 +499,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xDD000, data, w_031]
+      - [0xDD040, data, w_031]
       - [0xDD918, c, w_031]
       - [0xDDF88, sbss, w_031]
   - name: f_032
@@ -514,7 +514,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xE4000, data, w_032]
+      - [0xE4040, data, w_032]
       - [0xE4924, c, w_032]
       - [0xE5020, sbss, w_032]
   - name: f_033
@@ -529,7 +529,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xEB000, data, w_033]
+      - [0xEB040, data, w_033]
       - [0xEBC58, c, w_033]
       - [0xEC2C8, sbss, w_033]
   - name: f_034
@@ -544,7 +544,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xF2000, data, w_034]
+      - [0xF2040, data, w_034]
       - [0xF2950, c, w_034]
       - [0xF33F0, sbss, w_034]
   - name: f_035
@@ -559,7 +559,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0xF9000, data, w_035]
+      - [0xF9040, data, w_035]
       - [0xF954C, c, w_035]
       - [0xF9B78, sbss, w_035]
   - name: f_036
@@ -574,7 +574,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x100000, data, w_036]
+      - [0x100040, data, w_036]
       - [0x10055C, c, w_036]
       - [0x100B88, sbss, w_036]
   - name: f_037
@@ -589,7 +589,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x107000, data, w_037]
+      - [0x107040, data, w_037]
       - [0x1077C4, c, w_037]
       - [0x108BE4, sbss, w_037]
   - name: f_038
@@ -604,7 +604,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x10E000, data, w_038]
+      - [0x10E040, data, w_038]
       - [0x10EDEC, c, w_038]
       - [0x10F844, sbss, w_038]
   - name: f_039
@@ -619,7 +619,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x115000, data, w_039]
+      - [0x115040, data, w_039]
       - [0x115DEC, c, w_039]
       - [0x116A28, sbss, w_039]
   - name: f_040
@@ -634,7 +634,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x11C000, data, w_040]
+      - [0x11C040, data, w_040]
       - [0x11C874, c, w_040]
       - [0x11D540, sbss, w_040]
   - name: f_041
@@ -649,7 +649,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x123000, data, w_041]
+      - [0x123040, data, w_041]
       - [0x123574, c, w_041]
       - [0x124200, sbss, w_041]
   - name: f_042
@@ -664,7 +664,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x12A000, data, w_042]
+      - [0x12A040, data, w_042]
       - [0x12A764, c, w_042]
       - [0x12B5EC, sbss, w_042]
   - name: f_043
@@ -679,7 +679,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x131000, data, w_043]
+      - [0x131040, data, w_043]
       - [0x13205C, c, w_043]
       - [0x132D74, sbss, w_043]
   - name: f_044
@@ -694,7 +694,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x138000, data, w_044]
+      - [0x138040, data, w_044]
       - [0x1382C0, c, w_044]
       - [0x138F24, sbss, w_044]
   - name: f_045
@@ -709,7 +709,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x13F000, data, w_045]
+      - [0x13F040, data, w_045]
       - [0x13F378, c, w_045]
       - [0x1403B8, sbss, w_045]
   - name: f_046
@@ -724,7 +724,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x146000, data, w_046]
+      - [0x146040, data, w_046]
       - [0x146C64, c, w_046]
       - [0x147EC0, sbss, w_046]
   - name: f_047
@@ -739,7 +739,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x14D000, data, w_047]
+      - [0x14D040, data, w_047]
       - [0x14D568, c, w_047]
       - [0x14E6A4, sbss, w_047]
   - name: f_048
@@ -754,7 +754,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x154000, data, w_048]
+      - [0x154040, data, w_048]
       - [0x155050, c, w_048]
       - [0x1563B4, sbss, w_048]
   - name: f_049
@@ -769,7 +769,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x15B000, data, w_049]
+      - [0x15B040, data, w_049]
       - [0x15C14C, c, w_049]
       - [0x15D8CC, sbss, w_049]
   - name: f_050
@@ -784,7 +784,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x162000, data, w_050]
+      - [0x162040, data, w_050]
       - [0x163080, c, w_050]
       - [0x164BF8, sbss, w_050]
   - name: f_051
@@ -799,7 +799,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x169000, data, w_051]
+      - [0x169040, data, w_051]
       - [0x169ED4, c, w_051]
       - [0x16B0E0, sbss, w_051]
   - name: f_052
@@ -814,7 +814,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x170000, data, w_052]
+      - [0x170040, data, w_052]
       - [0x170CB0, c, w_052]
       - [0x172B84, sbss, w_052]
   - name: f_053
@@ -829,7 +829,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x177000, data, w_053]
+      - [0x177040, data, w_053]
       - [0x178280, c, w_053]
       - [0x179894, sbss, w_053]
   - name: f_054
@@ -844,7 +844,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x17E000, data, w_054]
+      - [0x17E040, data, w_054]
       - [0x17EF0C, c, w_054]
       - [0x17F8F8, sbss, w_054]
   - name: f_055
@@ -859,7 +859,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x185000, data, w_055]
+      - [0x185040, data, w_055]
       - [0x1861A0, c, w_055]
       - [0x186C2C, sbss, w_055]
   - name: f_056
@@ -874,7 +874,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x18C000, data, w_056]
+      - [0x18C040, data, w_056]
       - [0x18D060, c, w_056]
       - [0x18E0B8, sbss, w_056]
   - name: f_057
@@ -889,7 +889,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x193000, data, w_057]
+      - [0x193040, data, w_057]
       - [0x1940B4, c, w_057]
       - [0x1946E0, sbss, w_057]
   - name: f_058
@@ -904,7 +904,7 @@ segments:
     vram: 0x8017A000
     subalign: 4
     subsegments:
-      - [0x19A000, data, w_058]
+      - [0x19A040, data, w_058]
       - [0x19AC50, c, w_058]
       - [0x19BB40, sbss, w_058]
   - [0x19D000]

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -46,6 +46,18 @@ def apply_psx_servant(config, version, name):
     config["objdump_executable"] = "mipsel-linux-gnu-objdump"
 
 
+def apply_psx_weapon(config, version, name):
+    config["baseimg"] = f"disks/{version}" + (f"SERVANT/{name}.bin").upper()
+    config["myimg"] = f"build/{version}/weapon/w0_{name[2:]}.bin"
+    config["mapfile"] = f"build/{version}/weapon/w0_{name[2:]}.map"
+    config["source_directories"] = [
+        f"src/weapon/{name}",
+        "include",
+        f"asm/{version}/weapon/{name}",
+    ]
+    config["objdump_executable"] = "mipsel-linux-gnu-objdump"
+
+
 def apply_psx_stage(config, version, name):
     config["baseimg"] = f"disks/{version}" + (f"ST/{name}/{name}.BIN").upper()
     config["myimg"] = f"build/{version}" + (f"{name}.bin").upper()
@@ -77,6 +89,8 @@ def apply(config, args):
             apply_psx_stage(config, version, name[3:])
         elif name.startswith("tt_"):
             apply_psx_servant(config, version, name)
+        elif name.startswith("w_"):
+            apply_psx_weapon(config, version, name)
         elif name is "dra" or name is "main":
             apply_psx_base(config, version, name)
         else:

--- a/include/entity.h
+++ b/include/entity.h
@@ -103,7 +103,7 @@ typedef struct ET_Generic {
     } unkB8;
 } ET_Generic;
 
-typedef struct ET_EquipItemDrop {
+typedef struct {
     /* 0x00 */ u16 timer;
     /* 0x02 */ s16 unk7E;
     /* 0x04 */ u8 unk80;
@@ -119,6 +119,24 @@ typedef struct ET_EquipItemDrop {
     /* 0x16 */ s16 unk92;
     /* 0x18 */ s16 unk94;
 } ET_EquipItemDrop;
+
+typedef struct {
+    /* 0x7C */ s32 unk7C;
+    /* 0x80 */ s32 unk80;
+    /* 0x84 */ s32 unk84;
+    /* 0x88 */ s32 unk88;
+    /* 0x8C */ s32 unk8C;
+    /* 0x90 */ s32 unk90;
+    /* 0x94 */ s32 unk94;
+    /* 0x98 */ s32 unk98;
+    /* 0x9C */ s32 unk9C;
+    /* 0xA0 */ s32 unkA0;
+    /* 0xA4 */ s32 unkA4;
+    /* 0xA8 */ s32 unkA8;
+    /* 0xAC */ u8 unkAC;
+    /* 0xAD */ u8 unkAD;
+    /* 0xAE */ s16 equipId;
+} ET_Weapon;
 
 typedef struct {
     /* 0x7C */ char pad_7C[0x4];
@@ -310,6 +328,7 @@ typedef union {
     /* 0x7C */ struct Primitive* prim;
     /* 0x7C */ ET_Generic generic;
     /* 0x7C */ ET_EquipItemDrop equipItemDrop;
+    /* 0x7C */ ET_Weapon weapon;
     /* 0x7C */ ET_SoulStealOrb soulStealOrb;
     /* 0x7C */ ET_GaibonSlogra GS_Props;
     /* 0x7C */ ET_WarpRoom warpRoom;

--- a/include/game.h
+++ b/include/game.h
@@ -107,7 +107,10 @@ typedef struct Primitive {
 
 #include "entity.h"
 
-#define COLORS_PER_PAL 16
+#define COLORS_PER_PAL (16)
+#define COLOR_BPP (16)
+#define COLOR_LEN ((COLOR_BPP) / 8)
+#define PALETTE_LEN ((COLORS_PER_PAL) * ((COLOR_BPP) / 8))
 #define OTSIZE 0x200
 #define MAXSPRT16 0x280
 
@@ -1010,7 +1013,7 @@ typedef struct {
     /* 8003C808 */ EnemyDef* enemyDefs;
     /* 8003C80C */ void* func_80118970;
     /* 8003C810 */ void* func_80118B18;
-    /* 8003C814 */ void* UpdateUnarmedAnim;
+    /* 8003C814 */ s32 (*UpdateUnarmedAnim)(s8* frameProps, u16** frames);
     /* 8003C818 */ void (*func_8010DBFC)(s32*, s32*);
     /* 8003C81C */ void* func_80118C28;
     /* 8003C820 */ void (*func_8010E168)(s32 arg0, s16 arg1);
@@ -1076,7 +1079,7 @@ extern bool (*g_api_func_80131F68)(void);
 extern DR_ENV* (*g_api_func_800EDB08)(POLY_GT4* poly);
 extern void (*g_api_func_80118894)(Entity*);
 extern EnemyDef* g_api_enemyDefs;
-extern void* g_api_UpdateUnarmedAnim;
+extern u32 (*g_api_UpdateUnarmedAnim)(s8* frameProps, u16** frames);
 extern void (*g_api_func_8010DBFC)(s32*, s32*);
 extern void (*g_api_func_8010E168)(s32 arg0, s16 arg1);
 extern void (*g_api_func_8010DFF0)(s32 arg0, s32 arg1);

--- a/include/game.h
+++ b/include/game.h
@@ -1147,6 +1147,15 @@ typedef struct {
 } SpriteParts; // size = 4 + count*sizeof(SpritePart)
 
 typedef struct {
+    /* 0x00 */ u16** frames;
+    /* 0x04 */ s8* frameProps;
+    /* 0x08 */ s16 unk8;
+    /* 0x0A */ u16 soundId;
+    /* 0x0C */ u8 ACshift;
+    /* 0x0D */ u8 soundFrame;
+} AnimSoundEvent;
+
+typedef struct {
     /* 800730D8 0x00 */ u16* layout;
     /* 800730DC 0x04 */ u32 tileDef;
     /* 800730E0 0x08 */ f32 scrollX;

--- a/include/macros.h
+++ b/include/macros.h
@@ -8,7 +8,7 @@ typedef enum {
     UNK_ENTITY_6,
     UNK_ENTITY_7,
     UNK_ENTITY_8,
-    UNK_ENTITY_10 = 0x10,
+    E_WEAPON = 0x10,
     UNK_ENTITY_13 = 0x13,
     UNK_ENTITY_20 = 0x20,
     UNK_ENTITY_51 = 0x51, // SubWeapons container falling liquid

--- a/include/weapon.h
+++ b/include/weapon.h
@@ -22,4 +22,7 @@ typedef struct {
     /* 0x3C */ void* func_ptr_8017003C;
 } Weapon /* 0x40 */;
 
+#define N_WEAPON_PAL 12
+extern u16 D_8006EDCC[][N_WEAPON_PAL * PALETTE_LEN];
+
 #endif

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -837,7 +837,7 @@ void func_8010ED54(u8 arg0) {
 INCLUDE_ASM("dra/nonmatchings/692E8", func_8010EDB8);
 
 void func_8010FAF4(void) {
-    DestroyEntity(&g_Entities[UNK_ENTITY_10]);
+    DestroyEntity(&g_Entities[E_WEAPON]);
     g_Player.unk46 = 0;
 }
 

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -112,16 +112,16 @@ INCLUDE_ASM("dra/nonmatchings/71830", func_80111DE8);
 bool func_8011203C(void) {
     s32 collision = func_80111D24();
 
-    if (g_Entities[UNK_ENTITY_10].step == 5) {
+    if (g_Entities[E_WEAPON].step == 5) {
         if (collision == false) {
-            DestroyEntity(&g_Entities[UNK_ENTITY_10]);
+            DestroyEntity(&g_Entities[E_WEAPON]);
             return true;
         }
         return false;
-    } else if (g_Entities[UNK_ENTITY_10].step <= 2) {
-        if (g_Entities[UNK_ENTITY_10].step != 0) {
+    } else if (g_Entities[E_WEAPON].step <= 2) {
+        if (g_Entities[E_WEAPON].step != 0) {
             g_Player.unk46 = 0;
-            g_Entities[UNK_ENTITY_10].step = 3;
+            g_Entities[E_WEAPON].step = 3;
         }
     }
     return false;

--- a/src/dra/73AAC.c
+++ b/src/dra/73AAC.c
@@ -129,7 +129,7 @@ void func_80113EE0(void) {
     g_Player.unk46 = 0;
     PLAYER.rotAngle = 0;
     PLAYER.zPriority = g_zEntityCenter.S16.unk0;
-    if (g_Entities[UNK_ENTITY_10].entityId == E_UNK_22) {
+    if (g_Entities[E_WEAPON].entityId == E_UNK_22) {
         func_8010FAF4();
     }
 }

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -284,7 +284,7 @@ void func_80118670(void) {
 
 void func_801186EC(void) {
     if (PLAYER.step_s == 0) {
-        if (g_Entities[UNK_ENTITY_10].entityId == E_NONE) {
+        if (g_Entities[E_WEAPON].entityId == E_NONE) {
             D_80138008 = 0x10;
             func_8011AAFC(g_CurrentEntity, 0x15003D, 0);
             PLAYER.step_s++;
@@ -323,7 +323,7 @@ void func_80118894(Entity* self) {
     s32 i;
     s32 search_value;
 
-    if (self == &g_Entities[UNK_ENTITY_10]) {
+    if (self == &g_Entities[E_WEAPON]) {
         if (!(self->params & 0x8000)) {
             self->enemyId = 1;
             return;

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -786,7 +786,7 @@ INCLUDE_ASM("dra/nonmatchings/75F54", func_8011AC3C);
 // Name comes purely from emulator breakpoint experiments, could be wrong
 void EntityUnarmedAttack(Entity* entity) {
     Equipment equip;
-    animSoundEvent* temp_s1;
+    AnimSoundEvent* temp_s1;
     u16 paramsTopBit;
 
     entity->posX.val = PLAYER.posX.val;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -260,16 +260,6 @@ typedef struct {
     /* 80137692 */ u8 D_80137692;
 } MenuData;
 
-// Used in EntityUnarmedAttack, more research would be useful
-typedef struct {
-    u16** frames;
-    s8* frameProps;
-    s16 unk8;
-    u16 soundId;
-    u8 ACshift;
-    u8 soundFrame;
-} animSoundEvent;
-
 // All the Joseph's Cloak color fields are in RGB555 format
 typedef struct {
     u16 liningDark;
@@ -390,7 +380,7 @@ extern s16 D_800ACF8A[]; // collection of sounds?
 extern s16 D_800ACF60[]; // collection of sounds?
 extern u8 D_800AD094[];
 extern PfnEntityUpdate D_800AD0C4[];
-extern animSoundEvent* D_800AD53C[];
+extern AnimSoundEvent* D_800AD53C[];
 extern s32 D_800ADC44;
 extern RECT D_800AE130;
 extern s32 D_800AE270[];

--- a/src/saturn/sattypes.h
+++ b/src/saturn/sattypes.h
@@ -270,7 +270,7 @@ typedef enum {
     UNK_ENTITY_6,
     UNK_ENTITY_7,
     UNK_ENTITY_8,
-    UNK_ENTITY_10 = 0x10,
+    E_WEAPON = 0x10,
     UNK_ENTITY_13 = 0x13,
     UNK_ENTITY_20 = 0x20,
     UNK_ENTITY_51 = 0x51,

--- a/src/weapon/header.c
+++ b/src/weapon/header.c
@@ -1,0 +1,25 @@
+#include <weapon.h>
+
+void EntityWeaponAttack(Entity* self);
+void func_ptr_80170004(void);
+void func_ptr_80170008(void);
+void func_ptr_8017000C(void);
+void func_ptr_80170010(void);
+void func_ptr_80170014(void);
+int func_ptr_80170018(void);
+void LoadWeaponPalette(s32 clutIndex);
+void func_ptr_80170020(void);
+void func_ptr_80170024(void);
+void func_ptr_80170028(void);
+void func_ptr_8017002C(void);
+void func_ptr_80170030(void);
+void func_ptr_80170034(void);
+void func_ptr_80170038(void);
+void func_ptr_8017003C(void);
+
+Weapon g_Weapon = {
+    EntityWeaponAttack, func_ptr_80170004, func_ptr_80170008, func_ptr_8017000C,
+    func_ptr_80170010,  func_ptr_80170014, func_ptr_80170018, LoadWeaponPalette,
+    func_ptr_80170020,  func_ptr_80170024, func_ptr_80170028, func_ptr_8017002C,
+    func_ptr_80170030,  func_ptr_80170034, func_ptr_80170038, func_ptr_8017003C,
+};

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -11,8 +11,8 @@ typedef struct {
 
 extern s16 D_4000_8017A040[];
 extern AnimSoundEvent D_4000_8017B06C[];
-extern s16* D_4000_8017B0BC[];
-extern s32 D_4000_8017B0D0;
+extern s16* D_4000_8017B0BC[5];
+extern s32 D_4000_8017B0D0; // dstClutIndex
 
 void DestroyEntity(Entity* entity) {
     s32 i;
@@ -29,25 +29,19 @@ void DestroyEntity(Entity* entity) {
         *ptr++ = NULL;
 }
 
-#define N_WEAPON_PAL 12
-extern u16 D_8006EDCC[N_WEAPON_PAL * PALETTE_LEN];
 void LoadWeaponPalette(s32 clutIndex) {
     RECT dstRect;
     u16* src;
     u16* dst;
     s32 i;
-    void** new_var;
 
-    new_var = &D_8006EDCC[D_4000_8017B0D0 * LEN(D_8006EDCC)];
-    src = D_4000_8017B0BC[clutIndex];
-    do {
-        dst = new_var;
-    } while (0);
+    dst = src = D_4000_8017B0BC[clutIndex];
+    dst = D_8006EDCC[D_4000_8017B0D0];
     if (src == NULL) {
         return;
     }
 
-    for (i = 0; i < LEN(D_8006EDCC); i++) {
+    for (i = 0; i < LEN(*D_8006EDCC); i++) {
         *dst++ = *src++;
     }
 
@@ -58,11 +52,25 @@ void LoadWeaponPalette(s32 clutIndex) {
     LoadImage(&dstRect, &D_8006EDCC);
 }
 
-void SetSpriteBank1(s16* arg0);
-INCLUDE_ASM("weapon/nonmatchings/w_000", SetSpriteBank1);
+void SetSpriteBank1(s16* spriteBankPtr) {
+    s16** spriteBankDst = g_api.o.spriteBanks;
 
-void SetSpriteBank2(s16* arg0);
-INCLUDE_ASM("weapon/nonmatchings/w_000", SetSpriteBank2);
+    spriteBankDst += 0x10;
+    if (D_4000_8017B0D0 != 0) {
+        spriteBankDst += 2;
+    }
+    *spriteBankDst = spriteBankPtr;
+}
+
+void SetSpriteBank2(s16* spriteBankPtr) {
+    s16** spriteBankDst = g_api.o.spriteBanks;
+
+    spriteBankDst += 0x11;
+    if (D_4000_8017B0D0 != 0) {
+        spriteBankDst += 2;
+    }
+    *spriteBankDst = spriteBankPtr;
+}
 
 void ResetAnimation(u8 arg0) {
     g_CurrentEntity->ext.weapon.unkAC = arg0;

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -189,7 +189,6 @@ void EntityWeaponAttack(Entity* self) {
     self->unk1C = PLAYER.unk1C;
     self->rotPivotY = PLAYER.rotPivotY;
 }
-// #endif
 
 void func_ptr_80170004(void) {}
 

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -1,26 +1,196 @@
 #include "weapon_private.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", DestroyEntity);
+typedef struct {
+    /* 0x00 */ u16** frames;
+    /* 0x04 */ s8* frameProps;
+    /* 0x08 */ s16 unk8;
+    /* 0x0A */ u16 soundId;
+    /* 0x0C */ u8 ACshift;
+    /* 0x0D */ u8 soundFrame;
+} AnimSoundEvent;
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", LoadWeaponPalette);
+extern s16 D_4000_8017A040[];
+extern AnimSoundEvent D_4000_8017B06C[];
+extern s16* D_4000_8017B0BC[];
+extern s32 D_4000_8017B0D0;
 
+void DestroyEntity(Entity* entity) {
+    s32 i;
+    s32 length;
+    u32* ptr;
+
+    if (entity->flags & FLAG_HAS_PRIMS) {
+        g_api.FreePrimitives(entity->primIndex);
+    }
+
+    ptr = (u32*)entity;
+    length = sizeof(Entity) / sizeof(u32);
+    for (i = 0; i < length; i++)
+        *ptr++ = NULL;
+}
+
+#define N_WEAPON_PAL 12
+extern u16 D_8006EDCC[N_WEAPON_PAL * PALETTE_LEN];
+void LoadWeaponPalette(s32 clutIndex) {
+    RECT dstRect;
+    u16* src;
+    u16* dst;
+    s32 i;
+    void** new_var;
+
+    new_var = &D_8006EDCC[D_4000_8017B0D0 * LEN(D_8006EDCC)];
+    src = D_4000_8017B0BC[clutIndex];
+    do {
+        dst = new_var;
+    } while (0);
+    if (src == NULL) {
+        return;
+    }
+
+    for (i = 0; i < LEN(D_8006EDCC); i++) {
+        *dst++ = *src++;
+    }
+
+    dstRect.w = 0x100;
+    dstRect.h = 3;
+    dstRect.x = 0;
+    dstRect.y = 0xF1;
+    LoadImage(&dstRect, &D_8006EDCC);
+}
+
+void SetSpriteBank1(s16* arg0);
 INCLUDE_ASM("weapon/nonmatchings/w_000", SetSpriteBank1);
 
+void SetSpriteBank2(s16* arg0);
 INCLUDE_ASM("weapon/nonmatchings/w_000", SetSpriteBank2);
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", ResetAnimation);
+void ResetAnimation(u8 arg0) {
+    g_CurrentEntity->ext.weapon.unkAC = arg0;
+    g_CurrentEntity->animFrameDuration = 0;
+    g_CurrentEntity->animFrameIdx = 0;
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", DecelerateX);
+void DecelerateX(s32 amount) {
+    if (g_CurrentEntity->velocityX < 0) {
+        g_CurrentEntity->velocityX += amount;
+        if (g_CurrentEntity->velocityX > 0) {
+            g_CurrentEntity->velocityX = 0;
+        }
+    } else {
+        g_CurrentEntity->velocityX -= amount;
+        if (g_CurrentEntity->velocityX < 0) {
+            g_CurrentEntity->velocityX = 0;
+        }
+    }
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", DecelerateY);
+void DecelerateY(s32 amount) {
+    if (g_CurrentEntity->velocityY < 0) {
+        g_CurrentEntity->velocityY += amount;
+        if (g_CurrentEntity->velocityY > 0) {
+            g_CurrentEntity->velocityY = 0;
+        }
+    } else {
+        g_CurrentEntity->velocityY -= amount;
+        if (g_CurrentEntity->velocityY < 0) {
+            g_CurrentEntity->velocityY = 0;
+        }
+    }
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", SetSpeedX);
+void SetSpeedX(s32 speed) {
+    if (g_CurrentEntity->facing == 1) {
+        speed = -speed;
+    }
+    g_CurrentEntity->velocityX = speed;
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", DestroyEntityWeapon);
+void DestroyEntityWeapon(bool arg0) {
+    if (arg0 == false) {
+        DestroyEntity(&g_Entities[E_WEAPON]);
+    }
+    if (arg0 == true && g_Player.unk48 != 0) {
+        DestroyEntity(&g_Entities[E_WEAPON]);
+        g_Player.unk48 = 0;
+    }
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", SetWeaponProperties);
+void SetWeaponProperties(Entity* self, s32 kind) {
+    Equipment equip;
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", EntityWeaponAttack);
+    g_api.GetEquipProperties(D_4000_8017B0D0, &equip, self->ext.weapon.equipId);
+    switch (kind) {
+    case 0:
+    case 1:
+        self->attack = equip.attack;
+        self->attackElement = equip.element;
+        self->hitboxState = equip.hitType;
+        self->nFramesInvincibility = equip.enemyInvincibilityFrames;
+        self->unk58 = equip.stunFrames;
+        self->unk6A = equip.hitEffect;
+        self->entityRoomIndex = equip.criticalRate;
+        g_api.func_80118894(self);
+        break;
+    case 2:
+        self->attack = equip.attack;
+        break;
+    }
+    if (self->hitboxState == 4) {
+        self->attack = 0xFF;
+    }
+}
+
+void EntityWeaponAttack(Entity* self) {
+    u8 temp_v1;
+    AnimSoundEvent* sndEvnet;
+    s32 mask;
+
+    self->posX.val = g_Entities->posX.val;
+    self->posY.val = PLAYER.posY.val;
+    self->facing = PLAYER.facing;
+    mask = 0x17F;
+    sndEvnet = &D_4000_8017B06C[(self->params >> 8) & mask];
+    temp_v1 = sndEvnet->ACshift;
+
+    if (!(PLAYER.ext.weapon.unkAC >= temp_v1 &&
+          PLAYER.ext.weapon.unkAC < temp_v1 + 7 && g_Player.unk46 != 0)) {
+        DestroyEntity(self);
+        return;
+    }
+
+    if (self->step == 0) {
+        SetSpriteBank1(D_4000_8017A040);
+        self->animSet = ANIMSET_OVL(0x10);
+        self->palette = 0x110;
+        self->unk5A = 0x64;
+        if (D_4000_8017B0D0 != 0) {
+            self->animSet += 2;
+            self->palette += 0x18;
+            self->unk5A += 2;
+        }
+        self->palette += sndEvnet->unk8;
+        self->flags = FLAG_UNK_20000 | FLAG_UNK_40000;
+        self->zPriority = PLAYER.zPriority - 2;
+        self->blendMode = 0x30;
+        SetWeaponProperties(self, 0);
+        self->step++;
+    }
+    self->ext.generic.unkAC = PLAYER.ext.weapon.unkAC - sndEvnet->ACshift;
+    if (PLAYER.animFrameDuration == 1 &&
+        PLAYER.animFrameIdx == sndEvnet->soundFrame) {
+        g_api.PlaySfx(sndEvnet->soundId);
+    }
+
+    if (g_api.UpdateUnarmedAnim(sndEvnet->frameProps, sndEvnet->frames) < 0) {
+        DestroyEntity(self);
+        return;
+    }
+
+    self->unk19 = PLAYER.unk19;
+    self->unk1C = PLAYER.unk1C;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
+// #endif
 
 void func_ptr_80170004(void) {}
 
@@ -32,7 +202,7 @@ void func_ptr_80170010(void) {}
 
 void func_ptr_80170014(void) {}
 
-INCLUDE_ASM("weapon/nonmatchings/w_000", func_ptr_80170018);
+int func_ptr_80170018(void) { return 0; }
 
 void func_ptr_80170020(void) {}
 

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -1,14 +1,5 @@
 #include "weapon_private.h"
 
-typedef struct {
-    /* 0x00 */ u16** frames;
-    /* 0x04 */ s8* frameProps;
-    /* 0x08 */ s16 unk8;
-    /* 0x0A */ u16 soundId;
-    /* 0x0C */ u8 ACshift;
-    /* 0x0D */ u8 soundFrame;
-} AnimSoundEvent;
-
 extern s16 D_4000_8017A040[];
 extern AnimSoundEvent D_4000_8017B06C[];
 extern s16* D_4000_8017B0BC[5];

--- a/tools/decompile.py
+++ b/tools/decompile.py
@@ -222,12 +222,23 @@ parser.add_argument(
     default=None,
     required=False,
 )
+parser.add_argument(
+    "-f",
+    "--force",
+    help="force decompiling only the first occurrence",
+    default=None,
+    required=False,
+    action="store_true",
+)
 
 args = parser.parse_args()
 if __name__ == "__main__":
     funcs = get_nonmatching_functions(asm_dir, args.function)
     if len(funcs) == 0:
         print(f"function {args.function} not found or already decompiled")
+
+    if args.force:
+        funcs = funcs[:1]
 
     if args.overlay == None:
         if len(funcs) > 1:


### PR DESCRIPTION
![f_000](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/abcc5bd5-ed0c-4fc7-88fa-aa6e796aac1b)

Matches w_000, effectively opening the doors to understand how hand equippables work. That includes weapons, shields, consumable; all of them internally named as Weapons). This overlay is used by:

* Tyrfing
* Namakura
* Gladius
* Scimitar
* Cutlass
* Saber
* Falchion
* Broadsword
* Bekatowa
* Damascus sword
* Hunter sword
* Bastard sword
* Talwar
* Sword of Hador
* Luminus
* Harper
* Gram
* Mormegil
* Terminus Est
* Dark Blade
* Mourneblade
* Badelaire

Due to the nature of splat, renaming the symbols is hella hard but possible once we start importing the `.data` section in it. As far I know this overlay does not contain any `.rodata`.

Checklist to convert it from Draft to Ready:

- [x] Decompile [func_4000_8017B1D8](https://decomp.me/scratch/HLPI0)
- [x] Confirm name of the functions
- [X] ~~Put shareable code in the appropriate folder (either as `.h` or `.c`~~ not all overlays have identical functions (see w_029). Needs more research
- [X] ~~Import `.data` in the C file~~ needs substancial re-work in the spriteparts asset extractor
- [x] Move `AnimSoundEvent` to the appropriate header
- [X] ~~Rename `Entity::unk58` and `Entity::`unk6A`~~ more appropriate as a separate PR
