### PR TITLE
Fix small bug in analyze_calls

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -323,7 +323,7 @@ class sotn_function:
             ]
 
     def render_svg(self):
-        graph = graphviz.Digraph(self.unique_name)
+        graph = graphviz.Digraph(self.unique_name, graph_attr={"ranksep": "2"})
         graph.node(
             self.unique_name,
             style="filled",
@@ -337,7 +337,7 @@ class sotn_function:
                 fillcolor=graph_colors[flags[1]],
                 href=callee + ".svg",
             )
-            graph.edge(self.unique_name, callee, str(flags[0]))
+            graph.edge(self.unique_name, callee, headlabel=str(flags[0]))
         # print("callers")
         for caller, flags in self.callers.items():
             graph.node(
@@ -346,7 +346,7 @@ class sotn_function:
                 fillcolor=graph_colors[flags[1]],
                 href=caller + ".svg",
             )
-            graph.edge(caller, self.unique_name, str(flags[0]))
+            graph.edge(caller, self.unique_name, taillabel=str(flags[0]))
         # print("done")
         imgbytes = graph.pipe(format="svg")
         return imgbytes


### PR DESCRIPTION
Small bugfix, little overall impact. Should be able to merge, but if you're curious what I changed here:

One of the important functions in analyze_calls is the one that resolves ambiguous function names for duplicates. For example, when UpdateEntityRichter calls UpdateAnim, it is unclear whether it is calling the `dra` version of that function, or the `servant` version of that function. `find_func_match` aims to resolve those ambiguities by matching based on the file paths. Something which is in, for example, `no3`, is almost certainly calling the `no3` version of a function. We can resolve the vast majority of function naming ambiguities this way.

Due to an oversight in an `assert` statement (forgot to use an ==1), we were not properly detecting failures in resolving those ambiguities. Thus, if you look to https://raw.githubusercontent.com/Xeeynamo/sotn-decomp/gh-duplicates/function_calls/ric.UpdateEntityRichter.svg, you will see (4th from the far right) that we thought this RIC function was calling `servant/UpdateAnim`. This is of course incorrect. It turns out that, currently, UpdateAnim is the only function which has this type of overlap. Notably, most functions that share names are because they are identical duplicates, but these UpdateAnim functions are not identical (though they are similar). For now, I've hard-coded this to use the `dra` version of UpdateAnim.

I also fixed a problem with the __repr__ method of `sotn_function`, which is only used in debugging.

I have also made some slight adjustments to the formatting of the rendered graphs. The numbers next to the arrows, which indicate how many times a given function is called, are now adjusted to be further from the central node, so that it is more clear which number belongs to which arrow. The graphs have also been stretched vertically, for the same reason, to reduce how much the arrows bunch up. For large functions this should be especially beneficial.
