### PR TITLE
Sort callers and callees in analyze_calls.py

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -348,7 +348,6 @@ class sotn_function:
                 href=caller + ".svg",
             )
             graph.edge(caller, self.unique_name, taillabel=str(flags[0]))
-        # print("done")
         imgbytes = graph.pipe(format="svg")
         return imgbytes
 

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -330,7 +330,7 @@ class sotn_function:
             fillcolor=graph_colors[self.decompile_status],
         )
 
-        for callee, flags in self.callees.items():
+        for callee, flags in sorted(self.callees.items()):
             graph.node(
                 callee,
                 style="filled",
@@ -338,8 +338,8 @@ class sotn_function:
                 href=callee + ".svg",
             )
             graph.edge(self.unique_name, callee, headlabel=str(flags[0]))
-        # print("callers")
-        for caller, flags in self.callers.items():
+
+        for caller, flags in sorted(self.callers.items()):
             graph.node(
                 caller,
                 style="filled",

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -329,7 +329,8 @@ class sotn_function:
             style="filled",
             fillcolor=graph_colors[self.decompile_status],
         )
-
+        # We sort the items so they will be alphabetized. This reduces changes from
+        # one run to the next. Any differences should be due to changes in the repo.
         for callee, flags in sorted(self.callees.items()):
             graph.node(
                 callee,
@@ -338,7 +339,7 @@ class sotn_function:
                 href=callee + ".svg",
             )
             graph.edge(self.unique_name, callee, headlabel=str(flags[0]))
-
+        # Same sorting as above
         for caller, flags in sorted(self.callers.items()):
             graph.node(
                 caller,


### PR DESCRIPTION
As requested by Sozud, this will sort the callees and callers alphabetically when generating the call graphs. Therefore, between two runs of the tool, the result should be more deterministic.

This also has the nice side effect that, because sorting places capital letters first, decompiled functions with names with capital letters (such as **A**llocEntity) will be placed before those with func_, so they are highlighted.

Of course, if a function's name changes, it will move around in the call graphs, but hopefully this change will mean we only see movement in the graphs between two CI runs in the places where relevant changes have occurred.
