### PR TITLE
Make the analyze_calls index.html properly use multiple lines

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -254,7 +254,7 @@ def generate_html(function_list):
         [f for f in function_list if f.overlay != "mad"],
         key=lambda x: (x.overlay, x.name),
     )
-    html = '<html><head><meta charset="UTF-8"></head><body>'
+    html = '<html><head><meta charset="UTF-8"></head><body>\n'
     active_overlay = ""
     # Now iterate through all functions, creating links to their SVG files.
     for f in sorted_funcs:
@@ -262,13 +262,13 @@ def generate_html(function_list):
         if f.overlay != active_overlay:
             # End the previous overlay's list, unless this is the first overlay.
             if active_overlay != "":
-                html += "</ul>"
+                html += "</ul>\n"
             active_overlay = f.overlay
-            html += f"<h2>{active_overlay}</h2>"
-            html += "<ul>"
+            html += f"<h2>{active_overlay}</h2>\n"
+            html += "<ul>\n"
         dec_symbol = "✅" if f.decompile_status == "True" else "❌"
-        html += f'<li><a href="{f.unique_name}.svg">{dec_symbol + f.name}</a></li>'
-    html += "</ul>"
+        html += f'<li><a href="{f.unique_name}.svg">{dec_symbol + f.name}</a></li>\n'
+    html += "</ul>\n"
     html += "</body></html>"
     return html
 


### PR DESCRIPTION
In the interest of improving the diffs shown in "Update reports" commits (example here: https://github.com/Xeeynamo/sotn-decomp/commit/50e507f0c0e0cccfbdaaa83be521f1af3884ee1d), we recently changed the SVG generation code to be more deterministic, such that any differences are only the result of actual changes to the source code of the repo.

While perusing this latest diff, I noticed that the index.html is showing as a "large diff", which is because the generated HTML code does not contain any newlines. To be clear, HTML has its own tags which control the lines in the final rendered page, but the actual text in the HTML file does not care about whether the code is on multiple lines or is all in one line. 

For the sake of generating diffs, it is heavily preferred for the HTML to run as multiple lines. With this change, the raw HTML file will be more intelligible and diffs should be able to properly show individual changes, rather than struggling to deal with changes that are technically all within a single-line file.
