### PR TITLE
Decompile all w_040 and w_042

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -121,11 +121,12 @@ typedef struct {
 } ET_EquipItemDrop;
 
 typedef struct {
-    /* 0x7C */ s32 unk7C;
+    /* 0x7C */ s16 unk7C;
+    /* 0x7E */ s16 unk7E;
     /* 0x80 */ s32 unk80;
     /* 0x84 */ s32 unk84;
     /* 0x88 */ s32 unk88;
-    /* 0x8C */ s32 unk8C;
+    /* 0x8C */ struct Entity* parent;
     /* 0x90 */ s32 unk90;
     /* 0x94 */ s32 unk94;
     /* 0x98 */ s32 unk98;

--- a/src/weapon/w_015.c
+++ b/src/weapon/w_015.c
@@ -5,13 +5,13 @@ INCLUDE_ASM("weapon/nonmatchings/w_015", EntityWeaponAttack);
 
 void func_ptr_80170004(Entity* self) {
     if (self->step == 0) {
-        self->animSet = self->ext.generic.unk8C.entityPtr->animSet;
-        self->animCurFrame = self->ext.generic.unk8C.entityPtr->animCurFrame;
-        self->facing = self->ext.generic.unk8C.entityPtr->facing;
-        self->zPriority = self->ext.generic.unk8C.entityPtr->zPriority - 2;
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->animCurFrame = self->ext.weapon.parent->animCurFrame;
+        self->facing = self->ext.weapon.parent->facing;
+        self->zPriority = self->ext.weapon.parent->zPriority - 2;
         self->flags = FLAG_UNK_08000000;
-        self->palette = self->ext.generic.unk8C.entityPtr->palette;
-        self->unk5A = self->ext.generic.unk8C.entityPtr->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->unk5A = self->ext.weapon.parent->unk5A;
         self->ext.generic.unk7C.s = 10;
         self->blendMode = 0x10;
         self->unk19 = 8;

--- a/src/weapon/w_040.c
+++ b/src/weapon/w_040.c
@@ -1,15 +1,229 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_040", func_11C000_8017AC14);
+extern AnimationFrame D_11C000_8017A724[];
+extern AnimationFrame D_11C000_8017A748[];
+extern AnimationFrame D_11C000_8017A7DC[];
+extern AnimationFrame D_11C000_8017A7B8[];
+extern AnimationFrame D_11C000_8017A804[];
+extern AnimationFrame D_11C000_8017A80C[];
+extern FrameProperty D_11C000_8017A844[];
+extern s32 D_11C000_8017A85C[];
+extern s32 D_11C000_8017B540;
 
-INCLUDE_ASM("weapon/nonmatchings/w_040", EntityWeaponAttack);
+void func_11C000_8017AC14(void) {
+    RECT rect;
+    RECT rectDummy;
+    s16 color;
 
-INCLUDE_ASM("weapon/nonmatchings/w_040", func_ptr_80170004);
+    color = (D_8003C8C4 >> 1) % 2 ? 0x039C : 0x199D;
+    D_8006EDCC[g_HandId][10] = color;
 
-INCLUDE_ASM("weapon/nonmatchings/w_040", func_ptr_80170008);
+    rect.x = 0;
+    rect.y = 0xF1;
+    rect.w = 0x100;
+    rect.h = 3;
+    LoadImage(&rect, D_8006EDCC);
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_040", func_ptr_8017000C);
+void EntityWeaponAttack(Entity* self) {
+    Collider col;
+    s32 var_a2;
+    s16 xMod;
+
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(g_Animset);
+        self->animSet = ANIMSET_OVL(16);
+        self->palette = 0x110;
+        self->unk5A = 0x64;
+        if (g_HandId != 0) {
+            self->palette += 0x18;
+            self->unk5A += 2;
+            self->animSet += 2;
+        }
+
+        self->zPriority = PLAYER.zPriority + 2;
+        self->facing = PLAYER.facing;
+        self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->unk4C = D_11C000_8017A804;
+        self->posY.i.hi -= 4;
+
+        D_11C000_8017B540 %= 4;
+        SetSpeedX(D_11C000_8017A85C[D_11C000_8017B540]);
+        self->velocityY = -FIX(2.5);
+        g_Player.D_80072F14 = 4;
+        D_11C000_8017B540++;
+        self->step++;
+        break;
+    case 1:
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        self->velocityY += 0x2800;
+        g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi, &col, 0);
+        if (col.effects & EFFECT_SOLID) {
+            self->posY.i.hi += col.unk18;
+            self->unk4C = D_11C000_8017A7DC;
+            self->animFrameDuration = 0;
+            self->animFrameIdx = 0;
+            self->blendMode = 0x30;
+            g_api.func_80134714(0x619, 0x50, 0);
+            g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x38, 0);
+            self->step++;
+            return;
+        }
+
+        if (self->velocityX < 0) {
+            xMod = -4;
+        } else {
+            xMod = 4;
+        }
+        g_api.CheckCollision(
+            (s16)(xMod + self->posX.i.hi), self->posY.i.hi, &col, 0);
+        if (col.effects & EFFECT_UNK_0002) {
+            if (xMod < 0) {
+                self->posX.i.hi += col.unkC;
+            } else {
+                self->posX.i.hi += col.unk4;
+            }
+            self->velocityX /= -2;
+        }
+
+        g_api.CheckCollision(
+            self->posX.i.hi, (s16)(self->posY.i.hi - 8), &col, 0);
+        if (col.effects & EFFECT_SOLID) {
+            self->posY.i.hi += col.unk20 + 1;
+            self->velocityY = FIX(1);
+            self->velocityX /= 2;
+            return;
+        }
+        break;
+    case 2:
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+        }
+        break;
+    }
+}
+
+void func_ptr_80170004(Entity* self) {
+    switch (self->step) {
+    case 0:
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->facing = (self->facing + 1) & 1;
+        self->flags = FLAG_UNK_08000000;
+        self->zPriority = self->ext.weapon.parent->zPriority - 2;
+        self->unk4C = D_11C000_8017A724;
+        self->unk19 |= 3;
+        self->unk1C = 0;
+        self->unk1A = 0;
+        self->rotPivotY = 0x16;
+        self->posY.i.hi -= 0x16;
+        self->step++;
+        break;
+    case 1:
+        self->unk1A += 4;
+        if (self->unk1A >= 0x100) {
+            self->unk1A = 0x100;
+            self->unk4C = D_11C000_8017A748;
+            self->animFrameIdx = 0;
+            self->animFrameDuration = 0;
+            self->ext.weapon.equipId =
+                self->ext.weapon.parent->ext.weapon.equipId;
+            SetWeaponProperties(self, 0);
+            self->step++;
+        }
+        self->unk1C = self->unk1A;
+        break;
+    case 2:
+        if (self->animFrameDuration == 1) {
+            if ((self->animFrameIdx == 0xB || self->animFrameIdx == 0xF ||
+                 self->animFrameIdx == 0x13) &&
+                g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x3E, 0) !=
+                    NULL) {
+                g_api.PlaySfx(0x655);
+            }
+        }
+        if (self->animFrameDuration < 0) {
+            self->unk4C = D_11C000_8017A80C;
+            self->animFrameIdx = 0;
+            self->animFrameDuration = 0;
+            g_api.PlaySfx(0x6E7);
+            self->step++;
+        }
+        break;
+    case 3:
+        if (self->unk1A == 0x40) {
+            g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x46, 0);
+        }
+        if (self->animFrameIdx >= 5) {
+            self->unk1A -= 4;
+        }
+        if (self->unk1A < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        self->unk1C = self->unk1A;
+        break;
+    }
+    g_api.UpdateAnim(D_11C000_8017A844, NULL);
+    func_11C000_8017AC14();
+}
+
+void func_ptr_80170008(Entity* self) {
+    s32 var_a1;
+
+    if (self->step == 0) {
+        if (self->ext.weapon.parent->entityId == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->flags = FLAG_UNK_08000000;
+        self->zPriority = self->ext.weapon.parent->zPriority - 2;
+        self->unk4C = D_11C000_8017A724;
+        self->posY.i.hi -= 0xA;
+        var_a1 = 0x18;
+        if (self->facing == 0) {
+            var_a1 = -0x18;
+        }
+        self->posX.i.hi = var_a1 + self->posX.i.hi;
+        SetSpeedX(-FIX(2.5));
+        self->unk4C = D_11C000_8017A7B8;
+        self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
+        self->attackElement |= 0x8000;
+        SetWeaponProperties(self, 0);
+        self->step++;
+    } else {
+        self->posX.val += self->velocityX;
+        if (self->hitFlags != 0) {
+            DestroyEntity(self);
+            return;
+        }
+    }
+
+    g_api.UpdateAnim(D_11C000_8017A844, NULL);
+}
+
+void func_ptr_8017000C(Entity* self) {
+    if (self->step == 0) {
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->zPriority = self->ext.weapon.parent->zPriority + 2;
+        self->unk4C = D_11C000_8017A7DC;
+        self->blendMode = 0x30;
+        self->posY.i.hi += 0x10;
+        self->step++;
+    } else if (self->animFrameDuration < 0) {
+        DestroyEntity(self);
+    }
+}
 
 void func_ptr_80170010(Entity* self) {}
 

--- a/src/weapon/w_040.c
+++ b/src/weapon/w_040.c
@@ -59,7 +59,7 @@ void EntityWeaponAttack(Entity* self) {
     case 1:
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
-        self->velocityY += 0x2800;
+        self->velocityY += FIX(0.15625);
         g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi, &col, 0);
         if (col.effects & EFFECT_SOLID) {
             self->posY.i.hi += col.unk18;

--- a/src/weapon/w_041.c
+++ b/src/weapon/w_041.c
@@ -1,7 +1,20 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_041", func_123000_8017A914);
+void func_123000_8017A914(void) {
+    RECT rect;
+    RECT rectDummy;
+    s16 color;
+
+    color = (D_8003C8C4 >> 1) % 2 ? 0x039C : 0x199D;
+    D_8006EDCC[g_HandId][8] = color;
+
+    rect.x = 0;
+    rect.y = 0xF1;
+    rect.w = 0x100;
+    rect.h = 3;
+    LoadImage(&rect, D_8006EDCC);
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_041", func_123000_8017A994);
 

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -87,7 +87,7 @@ void EntityWeaponAttack(Entity* self) {
     case 1:
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
-        self->velocityY += 0x2800;
+        self->velocityY += FIX(0.15625);
         g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi, &col, 0);
         if (col.effects & EFFECT_SOLID) {
             self->posY.i.hi += col.unk18;
@@ -244,7 +244,7 @@ void func_ptr_80170008(Entity* self) {
         self->rotAngle -= 0x60;
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
-        self->velocityY += 0x2800;
+        self->velocityY += FIX(0.15625);
         if (self->hitFlags != 0) {
             self->animSet = 2;
             self->palette = 0x8170;

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -1,6 +1,21 @@
 #include "weapon_private.h"
 #include "shared.h"
 
+// data
+extern AnimationFrame D_12A000_8017A604[];
+extern AnimationFrame D_12A000_8017A620[];
+extern AnimationFrame D_12A000_8017A684[];
+extern AnimationFrame D_12A000_8017A6B4[];
+extern AnimationFrame D_12A000_8017A6AC[];
+extern AnimationFrame D_12A000_8017A6BC[];
+extern FrameProperty D_12A000_8017A6DC[];
+extern s32 D_12A000_8017A6F4[];
+extern AnimationFrame D_12A000_8017A704[];
+extern s32 D_12A000_8017A740[];
+extern s32 D_12A000_8017A74C[];
+extern s32 D_12A000_8017B5F0;
+
+// rodata
 extern const char D_12A000_8017A760[]; // "\no\n"
 extern s32 D_12A000_8017B5EC;          // g_DebugWaitInfoTimer
 
@@ -24,15 +39,250 @@ void DebugInputWait(const char* msg) {
         DebugShowWaitInfo(msg);
 }
 
-INCLUDE_ASM("weapon/nonmatchings/w_042", func_12A000_8017AC08);
+void func_12A000_8017AC08(void) {
+    RECT rect;
+    RECT rectDummy;
+    s16 color;
 
-INCLUDE_ASM("weapon/nonmatchings/w_042", EntityWeaponAttack);
+    color = (D_8003C8C4 >> 1) % 2 ? 0x039C : 0x199D;
+    D_8006EDCC[g_HandId][8] = color;
 
-INCLUDE_ASM("weapon/nonmatchings/w_042", func_ptr_80170004);
+    rect.x = 0;
+    rect.y = 0xF1;
+    rect.w = 0x100;
+    rect.h = 3;
+    LoadImage(&rect, D_8006EDCC);
+}
 
-INCLUDE_ASM("weapon/nonmatchings/w_042", func_ptr_80170008);
+void EntityWeaponAttack(Entity* self) {
+    Collider col;
+    s32 var_a2;
+    s16 xMod;
 
-INCLUDE_ASM("weapon/nonmatchings/w_042", func_ptr_8017000C);
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(g_Animset);
+        self->animSet = ANIMSET_OVL(16);
+        self->palette = 0x110;
+        self->unk5A = 0x64;
+        if (g_HandId != 0) {
+            self->palette += 0x18;
+            self->unk5A += 2;
+            self->animSet += 2;
+        }
+
+        self->zPriority = PLAYER.zPriority + 2;
+        self->facing = PLAYER.facing;
+        self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->unk4C = D_12A000_8017A6B4;
+        self->posY.i.hi -= 4;
+
+        D_12A000_8017B5F0 %= 4;
+        SetSpeedX(D_12A000_8017A6F4[D_12A000_8017B5F0]);
+        self->velocityY = -FIX(2.5);
+        g_Player.D_80072F14 = 4;
+        D_12A000_8017B5F0++;
+        self->step++;
+        break;
+    case 1:
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        self->velocityY += 0x2800;
+        g_api.CheckCollision(self->posX.i.hi, self->posY.i.hi, &col, 0);
+        if (col.effects & EFFECT_SOLID) {
+            self->posY.i.hi += col.unk18;
+            self->unk4C = D_12A000_8017A684;
+            self->animFrameDuration = 0;
+            self->animFrameIdx = 0;
+            self->blendMode = 0x30;
+            g_api.func_80134714(0x619, 0x50, 0);
+            g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x38, 0);
+            self->step++;
+            return;
+        }
+
+        if (self->velocityX < 0) {
+            xMod = -4;
+        } else {
+            xMod = 4;
+        }
+        g_api.CheckCollision(
+            (s16)(xMod + self->posX.i.hi), self->posY.i.hi, &col, 0);
+        if (col.effects & EFFECT_UNK_0002) {
+            if (xMod < 0) {
+                self->posX.i.hi += col.unkC;
+            } else {
+                self->posX.i.hi += col.unk4;
+            }
+            self->velocityX /= -2;
+        }
+
+        g_api.CheckCollision(
+            self->posX.i.hi, (s16)(self->posY.i.hi - 8), &col, 0);
+        if (col.effects & EFFECT_SOLID) {
+            self->posY.i.hi += col.unk20 + 1;
+            self->velocityY = FIX(1);
+            self->velocityX /= 2;
+            return;
+        }
+        break;
+    case 2:
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+        }
+        break;
+    }
+}
+
+void func_ptr_80170004(Entity* self) {
+    s32 unk;
+
+    switch (self->step) {
+    case 0:
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->facing = (self->facing + 1) & 1;
+        self->flags = FLAG_UNK_08000000;
+        self->zPriority = self->ext.weapon.parent->zPriority - 2;
+        self->unk4C = D_12A000_8017A604;
+        self->unk19 |= 3;
+        self->unk1C = 0;
+        self->unk1A = 0;
+        self->rotPivotY = 0x14;
+        self->posY.i.hi -= 0x14;
+        self->step++;
+        break;
+    case 1:
+        self->unk1A += 4;
+        if (self->unk1A >= 0x100) {
+            self->unk1A = 0x100;
+            self->unk4C = D_12A000_8017A620;
+            self->animFrameIdx = 0;
+            self->animFrameDuration = 0;
+            self->ext.weapon.equipId =
+                self->ext.weapon.parent->ext.weapon.equipId;
+            SetWeaponProperties(self, 0);
+            self->step++;
+        }
+        self->unk1C = self->unk1A;
+        break;
+    case 2:
+        if (self->animFrameDuration == 1) {
+            if ((self->animFrameIdx == 6 || self->animFrameIdx == 0xC ||
+                 self->animFrameIdx == 0x12)) {
+                unk = 0x3E;
+                if (g_api_func_8011AAFC(
+                        self,
+                        ((g_HandId + 1) << 0xC) +
+                            (unk + (self->ext.weapon.unk7E << 0x10)),
+                        0) != NULL) {
+                    self->ext.weapon.unk7E++;
+                }
+            }
+        }
+        if (self->animFrameDuration < 0) {
+            self->unk4C = D_12A000_8017A6BC;
+            self->animFrameIdx = 0;
+            self->animFrameDuration = 0;
+            self->step++;
+        }
+        break;
+    case 3:
+        if (self->unk1A == 0x40) {
+            g_api_func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x46, 0);
+        }
+        if (self->animFrameIdx != 0) {
+            self->unk1A -= 4;
+        }
+        if (self->unk1A < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        self->unk1C = self->unk1A;
+        break;
+    }
+    g_api_UpdateAnim(D_12A000_8017A6DC, NULL);
+    func_12A000_8017AC08();
+}
+
+void func_ptr_80170008(Entity* self) {
+    s16 unk;
+    s32 modX;
+
+    unk = self->params & 0x7F00;
+    unk >>= 8;
+    switch (self->step) {
+    case 0:
+        if (self->ext.weapon.parent->entityId == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->flags = FLAG_UNK_08000000;
+        self->unk19 = 4;
+        self->zPriority = self->ext.weapon.parent->zPriority - 2;
+        self->posY.i.hi -= 0x10;
+        if (self->facing == 0) {
+            modX = -8;
+        } else {
+            modX = 8;
+        }
+        self->posX.i.hi = modX + self->posX.i.hi;
+
+        SetSpeedX(D_12A000_8017A740[unk]);
+        self->velocityY = D_12A000_8017A74C[unk];
+        self->unk4C = D_12A000_8017A6AC;
+        self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
+        SetWeaponProperties(self, 0);
+        g_api_PlaySfx(0x628);
+        self->step++;
+        break;
+    case 1:
+        self->rotAngle -= 0x60;
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        self->velocityY += 0x2800;
+        if (self->hitFlags != 0) {
+            self->animSet = 2;
+            self->palette = 0x8170;
+            self->unk4C = &D_12A000_8017A704;
+            self->unk5A = 0;
+            self->animFrameDuration = 0;
+            self->animFrameIdx = 0;
+            self->unk19 = 0;
+            self->velocityY = -FIX(0.5);
+            self->step++;
+        }
+        break;
+    case 2:
+        self->posY.val += self->velocityY;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    g_api_UpdateAnim(D_12A000_8017A6DC, NULL);
+}
+
+void func_ptr_8017000C(Entity* self) {
+    if (self->step == 0) {
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->palette = self->ext.weapon.parent->palette;
+        self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->zPriority = self->ext.weapon.parent->zPriority + 2;
+        self->unk4C = D_12A000_8017A684;
+        self->blendMode = 0x30;
+        self->posY.i.hi += 0x10;
+        self->step++;
+    } else if (self->animFrameDuration < 0) {
+        DestroyEntity(self);
+    }
+}
 
 void func_ptr_80170010(Entity* self) {}
 

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -172,7 +172,7 @@ void func_ptr_80170004(Entity* self) {
             if ((self->animFrameIdx == 6 || self->animFrameIdx == 0xC ||
                  self->animFrameIdx == 0x12)) {
                 unk = 0x3E;
-                if (g_api_func_8011AAFC(
+                if (g_api.func_8011AAFC(
                         self,
                         ((g_HandId + 1) << 0xC) +
                             (unk + (self->ext.weapon.unk7E << 0x10)),
@@ -190,7 +190,7 @@ void func_ptr_80170004(Entity* self) {
         break;
     case 3:
         if (self->unk1A == 0x40) {
-            g_api_func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x46, 0);
+            g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) | 0x46, 0);
         }
         if (self->animFrameIdx != 0) {
             self->unk1A -= 4;
@@ -202,7 +202,7 @@ void func_ptr_80170004(Entity* self) {
         self->unk1C = self->unk1A;
         break;
     }
-    g_api_UpdateAnim(D_12A000_8017A6DC, NULL);
+    g_api.UpdateAnim(D_12A000_8017A6DC, NULL);
     func_12A000_8017AC08();
 }
 
@@ -237,7 +237,7 @@ void func_ptr_80170008(Entity* self) {
         self->unk4C = D_12A000_8017A6AC;
         self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
         SetWeaponProperties(self, 0);
-        g_api_PlaySfx(0x628);
+        g_api.PlaySfx(0x628);
         self->step++;
         break;
     case 1:
@@ -265,7 +265,7 @@ void func_ptr_80170008(Entity* self) {
         }
         break;
     }
-    g_api_UpdateAnim(D_12A000_8017A6DC, NULL);
+    g_api.UpdateAnim(D_12A000_8017A6DC, NULL);
 }
 
 void func_ptr_8017000C(Entity* self) {


### PR DESCRIPTION
As w_042 is similar to w_040 I decided to decompile them both.

### w_040 - Monster Vial 1

![f_040](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/edbd9d1a-6d23-4081-9537-2642db8b007c)

### w_042 - Monster Vial 3

![f_042](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/02daf207-b291-4d51-86e5-d1e459015529)

### EntityWeaponAttack

`EntityWeaponAttack` is the vial dropping to the ground. When `CheckCollision` detects a collision with the solid pavement, the vial gets immediately destroyed. There is some wild magic happening, which I think it's happening when the code does `g_api.func_8011AAFC(`. That might trigger the function `func_ptr_80170004`, which will summon the vial monster.

### func_ptr_80170004

The state machine of the summon itself. We have `self->unk1A` and `self->unk1C`, which if I recall correctly they indicates ScaleX and ScaleY respectively. `self->unk19 |= 3` will tell to use both horizontal and vertical scaling. When the scaling reaches 100% (or `0x100`) after 64 frames, the summon will get inherit the properties of... `self->ext.weapon.parent->ext.weapon.equipId;`? That is the potential bug that the folks from the SOTN Speedrun server described to me. `g_api.func_8011AAFC` seems to invoke the projectile.

### func_ptr_80170008

This seems to be the projectile function. Again, this is also calling `SetWeaponProperties`, which will copy the projectile attack properties from a dubious source. On `w_040` the logic is pretty simple as it is just keep adding the X coord until something is hit. On `w_042` both X and Y are involved as the thrown bone will form an arch. The thrown bone seems to not check the stage collisions.

### func_ptr_8017000C

I think this is the light effect at the base of the summon when it is still spawning. The function looks so simple I cannot imagine otherwise.
