### PR TITLE
Turn Entity.unk6D into an array

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -561,10 +561,7 @@ typedef struct Entity {
     /* 0x68 */ s16 unk68;
     /* 0x6A */ u16 hitEffect;
     /* 0x6C */ u8 unk6C;
-    /* 0x6D */ s8 unk6D;
-    /* 0x6E */ s16 unk6E;
-    /* 0x70 */ s32 unk70;
-    /* 0x74 */ s32 unk74;
+    /* 0x6D */ u8 unk6D[11];
     /* 0x78 */ s32 unk78;
     /* 0x7C */ Ext ext;
 } Entity; // size = 0xBC

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -798,10 +798,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80180F1C[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/dre/11A64.c
+++ b/src/st/dre/11A64.c
@@ -38,7 +38,7 @@ void func_80191B44(Entity* entity) {
     u16 temp_s1 = entity->params;
     u16 phi_v1;
     u16 unk;
-    entity->unk6D = 0;
+    entity->unk6D[0] = 0;
 
     if (entity->step != 0) {
         switch (temp_s1) {

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -856,10 +856,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_801810E0[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/mad/139E0.c
+++ b/src/st/mad/139E0.c
@@ -28,7 +28,7 @@ void EntityPrizeDrop(Entity* self) {
         }
     }
     self->palette = 0;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
 

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -844,10 +844,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80180D4C[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -36,7 +36,7 @@ void EntityUnkId12(Entity* entity) {
     u16 phi_v1;
     u16 unk;
 
-    entity->unk6D = 0;
+    entity->unk6D[0] = 0;
 
     if (entity->step != 0) {
         switch (temp_s1) {

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -913,10 +913,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80182424[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/no3/46684.c
+++ b/src/st/no3/46684.c
@@ -16,7 +16,7 @@ void EntityPrizeDrop(Entity* self) {
         self->step = 5;
     }
     self->palette = 0;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
     switch (self->step) {

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -33,7 +33,7 @@ void func_801B2540(Entity* entity) {
     u16 phi_v1;
     u16 unk;
 
-    entity->unk6D = 0;
+    entity->unk6D[0] = 0;
 
     if (entity->step != 0) {
         switch (temp_s1) {

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -894,10 +894,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80181DB0[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/np3/3DEF4.c
+++ b/src/st/np3/3DEF4.c
@@ -20,7 +20,7 @@ void EntityPrizeDrop(Entity* self) {
         self->step = 5;
     }
     self->palette = 0;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
     switch (self->step) {

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -914,10 +914,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80181CD8[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/nz0/3E30C.c
+++ b/src/st/nz0/3E30C.c
@@ -19,7 +19,7 @@ void EntityPrizeDrop(Entity* self) {
         self->step = 5;
     }
     self->palette = 0;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
     switch (self->step) {

--- a/src/st/replace_breakable_with_item_drop.h
+++ b/src/st/replace_breakable_with_item_drop.h
@@ -24,6 +24,6 @@ void ReplaceBreakableWithItemDrop(Entity* self) {
     }
 
     self->params = params;
-    self->unk6D = 0x10;
+    self->unk6D[0] = 0x10;
     self->step = 0;
 }

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -441,10 +441,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80180DF4[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/st0/31CA0.c
+++ b/src/st/st0/31CA0.c
@@ -855,10 +855,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80181CDC[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -23,7 +23,7 @@ void EntityPrizeDrop(Entity* self) {
         }
     }
     self->palette = 0x100;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
 

--- a/src/st/wrp/6FD0.c
+++ b/src/st/wrp/6FD0.c
@@ -1104,7 +1104,7 @@ void func_801870B0(Entity* entity) {
     u16 temp_s1 = entity->params;
     u16 phi_v1;
     u16 unk;
-    entity->unk6D = 0;
+    entity->unk6D[0] = 0;
 
     if (entity->step != 0) {
         switch (temp_s1) {

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -921,10 +921,10 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
     if (subWeapon == g_Status.subWeapon) {
         subWeapon = 1;
-        g_CurrentEntity->unk6D = 0x10;
+        g_CurrentEntity->unk6D[0] = 0x10;
     } else {
         subWeapon = D_80180DF4[subWeapon];
-        g_CurrentEntity->unk6D = 0x60;
+        g_CurrentEntity->unk6D[0] = 0x60;
     }
 
     if (subWeapon != 0) {

--- a/src/st/wrp/D020.c
+++ b/src/st/wrp/D020.c
@@ -26,7 +26,7 @@ void EntityPrizeDrop(Entity* self) {
         self->step = 5;
     }
     self->palette = 0;
-    if ((u8)self->unk6D >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
+    if ((u8)self->unk6D[0] >= 0x18 && !(D_8003C8C4 & 2) && self->params != 1) {
         self->palette = 0x815F;
     }
     switch (self->step) {


### PR DESCRIPTION
I have been working on the TestCollisions function. Scratch for reference is here. https://decomp.me/scratch/gAkz5

We have a line (currently line 75, but that may move) that does `if (iterEnt1->unk6D[i] != 0) {`, treating an entity's unk6D items as an array. The codebase currently does not use the unk6E, unk70, or unk74 members, so that's promising. The fact that the for loop goes up to 11 indicates that the size of this array should be 11, which agrees with the other members that were previously in the Entity struct.

Other functions have referenced unk6D, those accesses need to be changed to unk6D[0] now that unk6D is an array.

I am hoping to have TestCollisions matching soon. This change will be necessary to merge that, so I wanted to get this in as its own thing to reduce how much impact TestCollisions itself will have on the project as a whole.



