### PR TITLE
Fix function finder svg filenames

### DIFF
--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -188,6 +188,6 @@ if __name__ == "__main__":
             if results[i] != None:
                 o[4] = results[i]["link"]
                 o[5] = results[i]["percent"]
- 
+
     headers = ["Filename", "Length", "Branches", "Jtbl", "WIP", "%"]
     print(tabulate(output, headers=headers, tablefmt="github"))

--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -160,11 +160,21 @@ if __name__ == "__main__":
             "https://raw.githubusercontent.com/Xeeynamo/sotn-decomp/gh-duplicates"
         )
         for i, o in enumerate(output):
-            function_name = o[0].split("/")[-1].split(".s")[0]
-            svg_path = os.path.join("function_calls", f"{function_name}.svg")
+            filepath_split = o[0].split("/")
+            function_name = filepath_split[-1].split(".s")[0]
+            # Replicate the logic used in analyze_calls to find what svg name
+            # would have used for this function. Note that these don't include "asm" dir
+            # so the filepath indices are off by one.
+            overlay = filepath_split[1]
+            if overlay == "st":
+                overlay = filepath_split[2]
+            if overlay == "weapon":
+                overlay = filepath_split[3]
+            unique_name = ".".join([overlay, function_name])
+
+            svg_path = os.path.join("function_calls", f"{unique_name}.svg")
             if os.path.exists(svg_path):
                 o[0] = f"[{o[0]}]({base_url}/{svg_path})"
-
     if not args.no_fetch:
         # we are mostly waiting on IO so run in parallel
         with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -177,6 +187,5 @@ if __name__ == "__main__":
             if results[i] != None:
                 o[4] = results[i]["link"]
                 o[5] = results[i]["percent"]
-
     headers = ["Filename", "Length", "Branches", "Jtbl", "WIP", "%"]
     print(tabulate(output, headers=headers, tablefmt="github"))

--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -175,6 +175,7 @@ if __name__ == "__main__":
             svg_path = os.path.join("function_calls", f"{unique_name}.svg")
             if os.path.exists(svg_path):
                 o[0] = f"[{o[0]}]({base_url}/{svg_path})"
+
     if not args.no_fetch:
         # we are mostly waiting on IO so run in parallel
         with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -187,5 +188,6 @@ if __name__ == "__main__":
             if results[i] != None:
                 o[4] = results[i]["link"]
                 o[5] = results[i]["percent"]
+ 
     headers = ["Filename", "Length", "Branches", "Jtbl", "WIP", "%"]
     print(tabulate(output, headers=headers, tablefmt="github"))


### PR DESCRIPTION
When `analyze_calls` creates an SVG file, the name of that file consists of the overlay name, then a dot, then the function name. This is intended to ensure that we get a unique name for the file, given that the function name alone will often lead to a duplicate. The function finder was using an incorrect filename-finding logic.

This works on my machine, hopefully it will work in CI too. Unfortunately this is the type of PR which we won't know if it works until fully merging. The logic is fairly straightforward though, so hopefully this performs as intended.