### PR TITLE
DRA func_800F5904

### DIFF
--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -451,12 +451,10 @@ bool ScissorSprite(SPRT* sprite, MenuContext* context) {
 }
 
 void func_800F5904(MenuContext* ctx, s32 x, s32 y, s32 w, u32 h, s32 u, s32 v,
-                   s32 unk1, s32 unk2, bool disableTexShade, s32 unk4) {
+                   s32 idx, s32 unk2, bool disableTexShade, s32 unk4) {
     SPRT* sp;
     s32 otIdx;
-    s32 idx;
     u32* ot;
-    idx = unk1;
     ot = g_CurrentBuffer->ot;
     sp = &g_CurrentBuffer->sprite[g_GpuUsage.sp];
     if (D_8013784C == 1) {

--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -450,7 +450,44 @@ bool ScissorSprite(SPRT* sprite, MenuContext* context) {
     return false;
 }
 
-INCLUDE_ASM("dra/nonmatchings/5298C", func_800F5904);
+void func_800F5904(MenuContext* ctx, s32 x, s32 y, s32 w, u32 h, s32 u, s32 v,
+                   s32 unk1, s32 unk2, bool disableTexShade, s32 unk4) {
+    SPRT* sp;
+    s32 otIdx;
+    s32 idx;
+    u32* ot;
+    idx = unk1;
+    ot = g_CurrentBuffer->ot;
+    sp = &g_CurrentBuffer->sprite[g_GpuUsage.sp];
+    if (D_8013784C == 1) {
+        idx = 0x15E;
+    }
+    if (D_8013784C == 2) {
+        idx = 0x15D;
+    }
+    if (ctx != 0) {
+        otIdx = ctx->unk18 + 2;
+    } else {
+        otIdx = 0x1FF;
+    }
+    SetSemiTrans(sp, 0);
+    SetShadeTex(sp, disableTexShade);
+    sp->x0 = (s16)x;
+    sp->y0 = (s16)y;
+    sp->w = (s16)w;
+    sp->h = (s16)h;
+    sp->u0 = (u8)u;
+    sp->v0 = (u8)v;
+    if ((ctx == 0) || (ScissorSprite(sp, ctx) == false)) {
+        sp->r0 = (u8)unk4;
+        sp->g0 = (u8)unk4;
+        sp->b0 = (u8)unk4;
+        sp->clut = D_8003C104[idx];
+        AddPrim(&ot[otIdx], sp);
+        g_GpuUsage.sp++;
+        func_800F53D4(unk2, otIdx);
+    }
+}
 
 void func_800F5A90(void) {
     func_800F5904(NULL, 96, 96, 64, 64, 0, 0, 0, 0x114, 1, 0);

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -735,8 +735,8 @@ void CalcDefense(void);
 bool IsAlucart(void);
 void func_800F53A4(void);
 bool ScissorSprite(SPRT* arg0, MenuContext* arg1);
-void func_800F5904(void*, s32 x, s32 y, s32 w, u32 h, s32 u, s32 v, s32 unk1,
-                   s32 unk2, bool disableTexShade, s32 unk4);
+void func_800F5904(MenuContext* ctx, s32 x, s32 y, s32 w, u32 h, s32 u, s32 v,
+                   s32 unk1, s32 unk2, bool disableTexShade, s32 unk4);
 void DrawMenuSprite(
     MenuContext* context, s32 x, s32 y, s32 width, s32 height, s32 u, s32 v,
     s32 clut, s32 tpage, s32 arg9, s32 colorIntensity, s32 argB);

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -736,7 +736,7 @@ bool IsAlucart(void);
 void func_800F53A4(void);
 bool ScissorSprite(SPRT* arg0, MenuContext* arg1);
 void func_800F5904(MenuContext* ctx, s32 x, s32 y, s32 w, u32 h, s32 u, s32 v,
-                   s32 unk1, s32 unk2, bool disableTexShade, s32 unk4);
+                   s32 idx, s32 unk2, bool disableTexShade, s32 unk4);
 void DrawMenuSprite(
     MenuContext* context, s32 x, s32 y, s32 width, s32 height, s32 u, s32 v,
     s32 clut, s32 tpage, s32 arg9, s32 colorIntensity, s32 argB);


### PR DESCRIPTION
Looks like the function uses a MenuContext as its first argument everytime it is called which is why I changed its type instead of casting it from `void`.