### PR TITLE
Ci pipeline speedup with cache

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.version == 'us'
         run: make force_extract && ./tools/analyze_calls.py --ultradry
       - name: Remove clutter from build folder
-        run: rm -rf build/$(VERSION)/asm build/$(VERSION)/src build/$(VERSION)/assets
+        run: rm -rf build/${{ matrix.version }}/asm build/${{ matrix.version }}/src build/${{ matrix.version }}/assets
       - name: Export build folder
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -29,7 +29,7 @@ jobs:
           - dependency: pspeu
             version: hd
     # Building and testing cannot work if the repository owner is not Xeeynamo
-    # due to the missing secrets to clone the game's data repository
+    # due to the missing secrets to clone the CI dependencies
     if: github.repository == 'Xeeynamo/sotn-decomp'
     runs-on: ubuntu-latest
     env:
@@ -49,13 +49,25 @@ jobs:
         with:
           ref: ${{ github.ref }}
           submodules: false
-      - name: Clone dependencies
+      - name: Get dependencies
+        uses: actions/cache@v3
+        with:
+          path: 'disks/dependencies'
+          key: sotn-${{ matrix.dependency }}-deps
+      - name: Get dependencies (uncached)
+        if: steps.get-dependencies.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: xeeynamo/sotn-decomp-dependencies
           ref: ${{ matrix.dependency }}
           token: ${{ secrets.SOTN_DECOMP_DEPENDENCIES_TOKEN }}
           path: 'disks/dependencies'
+      - name: Cache dependencies
+        if: steps.get-dependencies.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: 'disks/dependencies'
+          key: sotn-${{ matrix.dependency }}-deps
       - name: Setting up dependencies
         working-directory: disks
         run: |
@@ -81,6 +93,7 @@ jobs:
         with:
           name: build_${{ matrix.version }}
           path: build/${{ matrix.version }}
+
   generate-progress-report:
     strategy:
       matrix:
@@ -103,13 +116,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: false
-      - name: Clone dependencies
-        uses: actions/checkout@v3
+      - name: Get dependencies
+        uses: actions/cache@v3
         with:
-          repository: xeeynamo/sotn-decomp-dependencies
-          ref: ${{ matrix.dependency }}
-          token: ${{ secrets.SOTN_DECOMP_DEPENDENCIES_TOKEN }}
           path: 'disks/dependencies'
+          key: sotn-${{ matrix.dependency }}-deps
       - name: Setting up dependencies
         working-directory: disks
         run: |
@@ -127,6 +138,7 @@ jobs:
           path: build/${{ matrix.version }}
       - name: Generate and send progress report
         run: python3 tools/progress.py --version ${{ matrix.version }}
+
   generate-duplicates-report:
     strategy:
       matrix:
@@ -144,13 +156,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: false
-      - name: Clone dependencies
-        uses: actions/checkout@v3
+      - name: Get dependencies
+        uses: actions/cache@v3
         with:
-          repository: xeeynamo/sotn-decomp-dependencies
-          ref: ${{ matrix.dependency }}
-          token: ${{ secrets.SOTN_DECOMP_DEPENDENCIES_TOKEN }}
           path: 'disks/dependencies'
+          key: sotn-${{ matrix.dependency }}-deps
       - name: Setting up dependencies
         working-directory: disks
         run: |


### PR DESCRIPTION
As suggested by @delta-473, GitHub recently shipped their [caching mechanic for the CI](https://github.com/actions/cache/blob/main/caching-strategies.md). I can think of a few ways it can get used in our advantage:

* Cloning the "dependencies": it should save cloning about 4GB of data to every commit on `master` and about 1.5GB per PR.
* Using this cache instead of artifacts to export the `.map` files to calculate the decomp progress
* Same as above but to the reporting step.

This PR just addresses the first point as it is the heaviest burden of the CI so far and it is what I think a quick win.