### PR TITLE
Generate markdown directory to function graphs

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -272,6 +272,29 @@ def generate_html(function_list):
     html += "</body></html>"
     return html
 
+# Create a markdown file pointing us toward all the different function graphs
+def generate_md(function_list):
+    sorted_funcs = sorted(
+        [f for f in function_list if f.overlay != "mad"],
+        key=lambda x: (x.overlay, x.name),
+    )
+    active_overlay = ""
+    # Sort all functions into overlays, with the name as tiebreaker to sort within overlays
+    sorted_funcs = sorted(
+        [f for f in function_list if f.overlay != "mad"],
+        key=lambda x: (x.overlay, x.name),
+    )
+    md_page = ''
+    active_overlay = ""
+    # Now iterate through all functions, creating links to their SVG files.
+    for f in sorted_funcs:
+        # When the overlay changes, add a heading.
+        if f.overlay != active_overlay:
+            active_overlay = f.overlay
+            md_page += f"# {active_overlay}\n"
+        dec_symbol = "✅" if f.decompile_status == "True" else "❌"
+        md_page += f'- [{dec_symbol} {f.name}]({f.unique_name}.svg)\n'
+    return md_page
 
 # This represents calls that we can't connect to a real C function. This includes SDK functions, or calls where
 # it is unclear what actual function is being called.
@@ -417,5 +440,8 @@ if __name__ == "__main__":
             html = generate_html(functions)
             with open(f"{output_dir}/index.html", "w") as f:
                 f.write(html)
+            markdown = generate_md(functions)
+            with open(f"{output_dir}/function_graphs.md", "w") as f:
+                f.write(markdown)
             print(f"Generated HTML in {time.perf_counter() - timer} seconds")
     print("Exiting.")

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -278,12 +278,6 @@ def generate_md(function_list):
         [f for f in function_list if f.overlay != "mad"],
         key=lambda x: (x.overlay, x.name),
     )
-    active_overlay = ""
-    # Sort all functions into overlays, with the name as tiebreaker to sort within overlays
-    sorted_funcs = sorted(
-        [f for f in function_list if f.overlay != "mad"],
-        key=lambda x: (x.overlay, x.name),
-    )
     md_page = ''
     active_overlay = ""
     # Now iterate through all functions, creating links to their SVG files.

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -272,13 +272,14 @@ def generate_html(function_list):
     html += "</body></html>"
     return html
 
+
 # Create a markdown file pointing us toward all the different function graphs
 def generate_md(function_list):
     sorted_funcs = sorted(
         [f for f in function_list if f.overlay != "mad"],
         key=lambda x: (x.overlay, x.name),
     )
-    md_page = ''
+    md_page = ""
     active_overlay = ""
     # Now iterate through all functions, creating links to their SVG files.
     for f in sorted_funcs:
@@ -287,8 +288,9 @@ def generate_md(function_list):
             active_overlay = f.overlay
             md_page += f"# {active_overlay}\n"
         dec_symbol = "✅" if f.decompile_status == "True" else "❌"
-        md_page += f'- [{dec_symbol} {f.name}]({f.unique_name}.svg)\n'
+        md_page += f"- [{dec_symbol} {f.name}]({f.unique_name}.svg)\n"
     return md_page
+
 
 # This represents calls that we can't connect to a real C function. This includes SDK functions, or calls where
 # it is unclear what actual function is being called.


### PR DESCRIPTION
When we generate all the function graphs in analyze_calls, we generate an HTML file which contains links to all of them. Example here: https://github.com/Xeeynamo/sotn-decomp/blob/gh-duplicates/function_calls/index.html Unbeknownst to me, Github does not allow you to view it as a rendered HTML page. You can only view it as raw text. There are workarounds like https://htmlpreview.github.io/?https://github.com/Xeeynamo/sotn-decomp/blob/gh-duplicates/function_calls/index.html but that's a bit clumsy and you can't get to it directly from the repo.

On the other hand, we have Markdown pages like https://github.com/Xeeynamo/sotn-decomp/blob/gh-duplicates/functions.md which render nicely and are usable from Github directly.

This attempts to generate a Markdown page which should be effectively indistinguishable from the formatting of the existing HTML. Once it's merged, we should be able to look at the output markdown file, and if we are happy with it, I will remove the HTML generation, and from then on this will be Markdown-only.