### PR TITLE
Make markdown page link to raw version of svg

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -288,7 +288,7 @@ def generate_md(function_list):
             active_overlay = f.overlay
             md_page += f"# {active_overlay}\n"
         dec_symbol = "✅" if f.decompile_status == "True" else "❌"
-        md_page += f"- [{dec_symbol} {f.name}]({f.unique_name}.svg?raw=1)\n"
+        md_page += f"- [{dec_symbol} {f.name}]({output_dir}/{f.unique_name}.svg?raw=1)\n"
     return md_page
 
 
@@ -437,7 +437,7 @@ if __name__ == "__main__":
             with open(f"{output_dir}/index.html", "w") as f:
                 f.write(html)
             markdown = generate_md(functions)
-            with open(f"{output_dir}/function_graphs.md", "w") as f:
+            with open(f"function_graphs.md", "w") as f:
                 f.write(markdown)
             print(f"Generated HTML in {time.perf_counter() - timer} seconds")
     print("Exiting.")

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -288,7 +288,9 @@ def generate_md(function_list):
             active_overlay = f.overlay
             md_page += f"# {active_overlay}\n"
         dec_symbol = "✅" if f.decompile_status == "True" else "❌"
-        md_page += f"- [{dec_symbol} {f.name}]({output_dir}/{f.unique_name}.svg?raw=1)\n"
+        md_page += (
+            f"- [{dec_symbol} {f.name}]({output_dir}/{f.unique_name}.svg?raw=1)\n"
+        )
     return md_page
 
 

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -288,7 +288,7 @@ def generate_md(function_list):
             active_overlay = f.overlay
             md_page += f"# {active_overlay}\n"
         dec_symbol = "✅" if f.decompile_status == "True" else "❌"
-        md_page += f"- [{dec_symbol} {f.name}]({f.unique_name}.svg)\n"
+        md_page += f"- [{dec_symbol} {f.name}]({f.unique_name}.svg?raw=1)\n"
     return md_page
 
 


### PR DESCRIPTION
Small change here, just linking to the raw SVG so it's clickable. The github preview makes the bubbles no longer operate as links.

While we're at it, would it be okay if I moved the function_graphs.md up a directory, so that it sits alongside duplicates.md and functions.txt, rather than being mixed in the function_calls folder with all the svgs?