### PR TITLE
Change func_800FE97C to use preexisting DamageParam struct

### DIFF
--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -309,13 +309,6 @@ typedef struct {
     /* 0x0E */ s16 unk0E;
 } RelicDesc;
 
-typedef struct {
-    /* 0x0 */ u32 unk0;
-    /* 0x4 */ u32 unk4;
-    /* 0x8 */ s32 damageTaken;
-    /* 0xC */ s32 unkC;
-} Unkstruct_800FE97C;
-
 typedef struct Unkstruct_801C7954 {
     /* 0x00 */ u16 x1;
     /* 0x02 */ u16 x0;

--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -524,13 +524,13 @@ void AddHearts(s32 value) {
 }
 
 // Note: Arg3 is unused, but is given in the call from func_80113D7C
-s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
+s32 func_800FE97C(DamageParam* arg0, s32 arg1, s32 arg2, s32 arg3) {
     s32 ret;
     s32 itemCount;
 
     func_800F53A4();
     arg0->unk0 = arg1 & ~0x1F;
-    arg0->unk4 = arg1 & 0x1F;
+    arg0->damageKind = arg1 & 0x1F;
     if (g_Status.defenseElement & arg0->unk0) {
         arg2 *= 2;
     }
@@ -562,7 +562,7 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
     //  with arg2 doubled. Item description says "Big HP restore" so makes
     //  sense
     if (CheckEquipmentItemCount(ITEM_CAT_EYE_CIRCLET, HEAD_TYPE) != 0 &&
-        arg0->unk4 == 7) {
+        arg0->damageKind == 7) {
         arg2 *= 2;
         if (arg2 < 1) {
             arg2 = 1;
@@ -599,7 +599,7 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
             arg0->damageTaken = 0;
         }
         ret = 7;
-    } else if (arg0->unk4 == 6) {
+    } else if (arg0->damageKind == 6) {
         if (D_8003C8C4 == ((D_8003C8C4 / 10) * 0xA)) {
             arg0->damageTaken = 1;
         } else {
@@ -607,7 +607,7 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
         }
         ret = 9;
     } else {
-        if (arg0->unk4 < 16) {
+        if (arg0->damageKind < 16) {
             arg0->damageTaken = arg2 - g_Status.defenseEquip;
         } else {
             arg0->damageTaken = g_Status.hpMax / 8;
@@ -623,23 +623,23 @@ s32 func_800FE97C(Unkstruct_800FE97C* arg0, s32 arg1, s32 arg2, s32 arg3) {
             }
         }
         if (arg0->damageTaken > 0) {
-            if (arg0->unk4 < 2) {
+            if (arg0->damageKind < 2) {
                 if ((arg0->damageTaken * 2) >= g_Status.hpMax) {
-                    arg0->unk4 = 4;
+                    arg0->damageKind = 4;
                 } else if ((arg2 * 50) >= g_Status.hpMax) {
-                    arg0->unk4 = 3;
+                    arg0->damageKind = 3;
                 } else {
-                    arg0->unk4 = 2;
+                    arg0->damageKind = 2;
                 }
             }
             ret = 3;
         } else {
             if ((g_Status.defenseEquip > 99) && !(arg0->unk0 & 0x180) &&
                 !(g_Player_unk0C & 0x80)) {
-                arg0->unk4 = 0;
+                arg0->damageKind = 0;
                 ret = 1;
             } else {
-                arg0->unk4 = 2;
+                arg0->damageKind = 2;
                 ret = 3;
             }
             arg0->damageTaken = 1;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -234,7 +234,8 @@ typedef struct {
 typedef struct {
     u32 unk0;
     u32 damageKind;
-    u32 unk8;
+    s32 damageTaken;
+    s32 unkC
 } DamageParam;
 
 typedef struct {
@@ -775,7 +776,7 @@ void LearnSpell(s32 spellId);
 void func_800FDE00(void);
 s32 func_800FE3C4(SubweaponDef* subwpn, s32 subweaponId, bool useHearts);
 void GetEquipProperties(s32 handId, Equipment* res, s32 equipId);
-s32 func_800FE97C(Unkstruct_800FE97C*, s32, s32, s32);
+s32 func_800FE97C(DamageParam*, s32, s32, s32);
 s32 func_800FEEA4(s32, s32);
 void func_800FF0A0(s32 arg0);
 void func_80102CD8(s32);

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -235,7 +235,7 @@ typedef struct {
     u32 unk0;
     u32 damageKind;
     s32 damageTaken;
-    s32 unkC
+    s32 unkC;
 } DamageParam;
 
 typedef struct {


### PR DESCRIPTION
A while ago, I decompiled func_800FE97C, creating Unkstruct_800FE97C for its primary parameter.

It turns out that EntityAlucard calls both AlucardHandleDamage and Unkstruct_800FE97C with the same argument, and furthermore, AlucardHandleDamage has already had a struct made for it called DamageParam.

Therefore, I am deprecating the UnkStruct, merging the known struct members, and changing everything to use DamageParam going forward.

I think we're still a long way from decompiling EntityAlucard, but I am going to start trying to learn some hints from it going forward. This is the first of those.