### PR TITLE
Attempt fixing analyze_calls markdown location

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -439,7 +439,8 @@ if __name__ == "__main__":
             with open(f"{output_dir}/index.html", "w") as f:
                 f.write(html)
             markdown = generate_md(functions)
-            with open(f"function_graphs.md", "w") as f:
+            with open(f"{output_dir}/../function_graphs.md", "w") as f:
                 f.write(markdown)
+                print("Markdown written to" + os.path.realpath(f.name))
             print(f"Generated HTML in {time.perf_counter() - timer} seconds")
     print("Exiting.")


### PR DESCRIPTION
Markdown file is currently not being created in the CI. This rearranges how we manage that, and also adds a debugging line which might help. I don't know the nature of the error, but this will attempt to solve it, and if not, hopefully provide some kind of information to suggest why it isn't working.