### PR TITLE
Change all instances of facing to facingLeft

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -290,7 +290,7 @@ typedef struct ET_Succubus {
     /* 0x7C */ char pad_7C[0x4];
     /* 0x80 */ s16 timer;
     /* 0x82 */ char pad_82[0x2];
-    /* 0x84 */ u8 facing;
+    /* 0x84 */ u8 facingLeft;
     /* 0x85 */ u8 unk85;
     /* 0x86 */ u8 nextAttack;
     /* 0x87 */ u8 unk87;

--- a/include/game.h
+++ b/include/game.h
@@ -519,7 +519,7 @@ typedef struct Entity {
     /* 0x10 */ u16 hitboxOffX;
 #endif
     /* 0x12 */ s16 hitboxOffY;
-    /* 0x14 */ u16 facing;
+    /* 0x14 */ u16 facingLeft;
     /* 0x16 */ u16 palette;
     /* 0x18 */ s8 blendMode;
     /* 0x19 */ u8 unk19;

--- a/src/dra/62D70.c
+++ b/src/dra/62D70.c
@@ -225,7 +225,7 @@ void DrawEntitiesHitbox(s32 blendMode) {
 
         y = (u16)entity->posY.i.hi + (u16)g_backbufferY;
         x = (u16)entity->posX.i.hi + (u16)g_backbufferX;
-        if (entity->facing) {
+        if (entity->facingLeft) {
             x -= entity->hitboxOffX;
         } else {
             x += entity->hitboxOffX;
@@ -259,7 +259,7 @@ void DrawEntitiesHitbox(s32 blendMode) {
 
         y = (u16)entity->posY.i.hi + (u16)g_backbufferY;
         x = (u16)entity->posX.i.hi + (u16)g_backbufferX;
-        if (entity->facing) {
+        if (entity->facingLeft) {
             x -= entity->hitboxOffX;
         } else {
             x += entity->hitboxOffX;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -16,7 +16,7 @@ void func_80109328(void) {
     if (*player_unk1E == 0x800 && PLAYER.step == 8) {
         PLAYER.rotAngle = 0;
         PLAYER.animCurFrame = 0x9D;
-        PLAYER.facing = (PLAYER.facing + 1) & 1;
+        PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
     }
 
     if (g_Player.D_80072F16 != 0) {
@@ -48,7 +48,7 @@ void func_80109594(void) {
     PLAYER.posY.val = 0x200000;
     PLAYER.animSet = ANIMSET_DRA(1);
     PLAYER.palette = 0x8100;
-    PLAYER.facing = 0;
+    PLAYER.facingLeft = 0;
     PLAYER.unk1A = 0x100;
     PLAYER.unk1C = 0x100;
     PLAYER.zPriority = (u16)g_zEntityCenter.S16.unk0;

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -59,7 +59,7 @@ void func_8010D59C(void) {
             prim->y0 = PLAYER.posY.i.hi;
             prim->x1 = PLAYER.animCurFrame;
             prim->y1 = 0;
-            prim->x2 = PLAYER.facing;
+            prim->x2 = PLAYER.facingLeft;
             prim->y2 = PLAYER.palette;
         }
         prim = prim->next;
@@ -278,7 +278,7 @@ s32 func_8010E27C(void) {
         return 0;
     }
 
-    facing = &PLAYER.facing;
+    facing = &PLAYER.facingLeft;
     if (*facing == 1) {
         if (g_Player.padPressed & PAD_RIGHT) {
             *facing = 0;
@@ -314,7 +314,7 @@ s32 func_8010E334(s32 xStart, s32 xEnd) {
 
 // Sets velocity based on an input speed, and the existing facing value
 void SetSpeedX(s32 speed) {
-    if (g_CurrentEntity->facing == 1) {
+    if (g_CurrentEntity->facingLeft == 1) {
         speed = -speed;
     }
     g_CurrentEntity->velocityX = speed;

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -181,7 +181,7 @@ void func_80113148(void) {
 INCLUDE_ASM("dra/nonmatchings/72BB0", func_801131C4);
 
 void func_801139CC(s32 arg0) {
-    s32 move = PLAYER.facing != 0 ? -3 : 3;
+    s32 move = PLAYER.facingLeft != 0 ? -3 : 3;
 
     PLAYER.posY.i.hi -= 22;
     PLAYER.posX.i.hi = move + PLAYER.posX.i.hi;

--- a/src/dra/73AAC.c
+++ b/src/dra/73AAC.c
@@ -23,7 +23,7 @@ void func_80113AAC(void) {
                 PLAYER.rotPivotY = 2;
                 PLAYER.rotPivotX = 0;
                 PLAYER.unk19 |= 4;
-                PLAYER.facing = (PLAYER.facing + 1) & 1;
+                PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
                 func_8010DA48(0x2B);
             } else {
                 PLAYER.step_s = 3;
@@ -56,7 +56,7 @@ void func_80113AAC(void) {
             PLAYER.rotAngle = 0;
             PLAYER.step_s = 4;
             PLAYER.unk19 &= 0xFB;
-            PLAYER.facing = (PLAYER.facing + 1) & 1;
+            PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
         }
         break;
 
@@ -140,13 +140,13 @@ void func_80113F7C(void) {
     s32 var_a0;
     s32 var_a2;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         var_a2 = -entity->hitboxOffX;
     } else {
         var_a2 = entity->hitboxOffX;
     }
 
-    if (PLAYER.facing != 0) {
+    if (PLAYER.facingLeft != 0) {
         var_a0 = -PLAYER.hitboxOffX;
     } else {
         var_a0 = PLAYER.hitboxOffX;

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -753,7 +753,7 @@ Entity* func_8011AAFC(Entity* self, u32 flags, s32 arg2) {
     entity->ext.generic.unk8C.entityPtr = self;
     entity->posX.val = self->posX.val;
     entity->posY.val = self->posY.val;
-    entity->facing = self->facing;
+    entity->facingLeft = self->facingLeft;
     entity->zPriority = self->zPriority;
     entity->params = flags & 0xFFF;
     if (flags & 0x5000) {
@@ -794,7 +794,7 @@ void EntityUnarmedAttack(Entity* entity) {
     entity->posX.val = PLAYER.posX.val;
     entity->posY.val = PLAYER.posY.val;
     paramsTopBit = entity->params >> 0xF;
-    entity->facing = PLAYER.facing;
+    entity->facingLeft = PLAYER.facingLeft;
     temp_s1 = &D_800AD53C[(entity->params >> 6) & 0x1FC];
 
     if (PLAYER.ext.generic.unkAC < temp_s1->ACshift ||
@@ -836,7 +836,7 @@ void func_8011B334(Entity* entity) {
     }
 
     entity->flags = FLAG_UNK_20000 | FLAG_UNK_40000;
-    entity->facing = PLAYER.facing;
+    entity->facingLeft = PLAYER.facingLeft;
     entity->posY.i.hi = PLAYER.posY.i.hi;
     entity->posX.i.hi = PLAYER.posX.i.hi;
     g_Player.unk44 &= ~0x80;
@@ -866,7 +866,7 @@ void func_8011B480(Entity* entity) {
         DestroyEntity(entity);
     } else {
         entity->flags = FLAG_UNK_20000 | FLAG_UNK_40000;
-        entity->facing = PLAYER.facing;
+        entity->facingLeft = PLAYER.facingLeft;
         entity->posY.i.hi = PLAYER.posY.i.hi;
         entity->posX.i.hi = PLAYER.posX.i.hi;
         if (entity->step == 0) {
@@ -1024,7 +1024,7 @@ void UnknownEntId49(Entity* self) {
         self->animCurFrame = 7;
         self->unk5A = PLAYER.unk5A;
         self->palette = PLAYER.palette;
-        self->facing = PLAYER.facing;
+        self->facingLeft = PLAYER.facingLeft;
         self->zPriority = PLAYER.zPriority;
         self->flags = 0x04060000;
         self->step++;
@@ -1102,7 +1102,7 @@ void func_80123F78(Entity* entity) {
         entity->blendMode = 0x30;
         entity->palette = 0x815F;
         entity->zPriority = PLAYER.zPriority - 2;
-        entity->facing = PLAYER.facing;
+        entity->facingLeft = PLAYER.facingLeft;
         do { // TODO: !FAKE
         } while (0);
         D_80097F4A = 0x80;
@@ -1271,7 +1271,7 @@ void func_80124A8C(Entity* entity) {
         entity->palette = 0x819F;
         entity->unk4C = &D_800AE294;
         entity->flags = FLAG_UNK_100000;
-        entity->facing = 0;
+        entity->facingLeft = 0;
         entity->posY.i.hi -= 16;
         entity->posX.val += entity->velocityX << 5;
         entity->step++;
@@ -1514,7 +1514,7 @@ void func_801274DC(Entity* entity) {
         entity->animSet = ANIMSET_DRA(9);
         entity->unk4C = &D_800B0798;
         entity->zPriority = PLAYER.zPriority + 2;
-        entity->facing = (PLAYER.facing + 1) & 1;
+        entity->facingLeft = (PLAYER.facingLeft + 1) & 1;
         SetSpeedX(D_800B0830[entity->params]);
         entity->velocityY = D_800B083C[entity->params];
         entity->ext.generic.unk7C.s = 0x14;
@@ -1569,7 +1569,7 @@ void func_80127840(Entity* entity) {
         entity->unk4C = &D_800B07C8;
         entity->unk19 |= 4;
         entity->zPriority = PLAYER.zPriority + 2;
-        entity->facing = (PLAYER.facing + 1) & 1;
+        entity->facingLeft = (PLAYER.facingLeft + 1) & 1;
         SetSpeedX(-0x10);
         func_8011A328(entity, 2);
         entity->hitboxWidth = 8;
@@ -1602,7 +1602,7 @@ void EntityExpandingCircle(Entity* entity) {
     POLY_GT4* poly;
     s32 primIndex;
 
-    if (PLAYER.facing == 0) {
+    if (PLAYER.facingLeft == 0) {
         entity->posX.i.hi = PLAYER.posX.i.hi - 10;
     } else {
         entity->posX.i.hi = PLAYER.posX.i.hi + 10;
@@ -1958,8 +1958,8 @@ void func_8012CB0C(void) {
 
 void func_8012CB4C(void) {
     PLAYER.step_s = 2;
-    if ((PLAYER.facing != 0 && g_Player.padPressed & PAD_RIGHT) ||
-        (PLAYER.facing == 0 && g_Player.padPressed & PAD_LEFT)) {
+    if ((PLAYER.facingLeft != 0 && g_Player.padPressed & PAD_RIGHT) ||
+        (PLAYER.facingLeft == 0 && g_Player.padPressed & PAD_LEFT)) {
         func_8010DA48(0xE1);
         D_800B0914 = 0;
         D_8013842C = 0;
@@ -2077,7 +2077,7 @@ void func_8012D178(void) {
         func_8012CFA8();
     } else {
 #if defined(VERSION_US)
-        if (PLAYER.facing != 0) {
+        if (PLAYER.facingLeft != 0) {
             var_v0 = g_Player.padPressed & PAD_LEFT;
         } else {
             var_v0 = g_Player.padPressed & PAD_RIGHT;

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -41,7 +41,7 @@ void func_8012D3E8(void) {
             return;
         }
         if (PLAYER.animFrameIdx == 2 && PLAYER.animFrameDuration == 1) {
-            PLAYER.facing = (PLAYER.facing + 1) & 1;
+            PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
         }
         SetSpeedX(FIX(-1));
         return;
@@ -52,8 +52,8 @@ void func_8012D3E8(void) {
             return;
         }
         SetSpeedX(FIX(1));
-        if ((PLAYER.facing && (directionsPressed & PAD_RIGHT)) ||
-            (!PLAYER.facing && (directionsPressed & PAD_LEFT))) {
+        if ((PLAYER.facingLeft && (directionsPressed & PAD_RIGHT)) ||
+            (!PLAYER.facingLeft && (directionsPressed & PAD_LEFT))) {
             D_800B0914 = 0;
             func_8010DA48(0xE1);
         }
@@ -117,7 +117,7 @@ void func_8012D3E8(void) {
             return;
         }
 
-        if (PLAYER.facing) {
+        if (PLAYER.facingLeft) {
             if (((g_Player.unk04 & 0xF001) == 1) &&
                 ((D_80138438 & 0xF001) == 0xC001)) {
                 func_8012CCE4();
@@ -151,8 +151,8 @@ void func_8012D3E8(void) {
         if (ABS(PLAYER.velocityX) > FIX(1)) {
             func_8010E1EC(0x2000);
         }
-        if ((PLAYER.facing && (directionsPressed & PAD_RIGHT)) ||
-            (!PLAYER.facing && (directionsPressed & PAD_LEFT))) {
+        if ((PLAYER.facingLeft && (directionsPressed & PAD_RIGHT)) ||
+            (!PLAYER.facingLeft && (directionsPressed & PAD_LEFT))) {
             D_800B0914 = 0;
             func_8010DA48(0xE1);
         }
@@ -170,8 +170,8 @@ void func_8012D3E8(void) {
         if (PLAYER.animFrameDuration >= 0) {
             return;
         }
-        if (((g_Player.padPressed & PAD_RIGHT) && !PLAYER.facing) ||
-            ((g_Player.padPressed & PAD_LEFT) && PLAYER.facing)) {
+        if (((g_Player.padPressed & PAD_RIGHT) && !PLAYER.facingLeft) ||
+            ((g_Player.padPressed & PAD_LEFT) && PLAYER.facingLeft)) {
             func_8010DA48(0xE2);
             D_800B0914 = 2;
             if (ABS(PLAYER.velocityX) < FIX(2)) {
@@ -193,8 +193,8 @@ void func_8012DBBC(void) {
         func_8012CCE4();
         return;
     }
-    if ((PLAYER.facing != 0 && !(g_Player.padPressed & PAD_LEFT)) ||
-        (PLAYER.facing == 0 && !(g_Player.padPressed & PAD_RIGHT))) {
+    if ((PLAYER.facingLeft != 0 && !(g_Player.padPressed & PAD_LEFT)) ||
+        (PLAYER.facingLeft == 0 && !(g_Player.padPressed & PAD_RIGHT))) {
         func_8010E1EC(FIX(4.0 / 128));
     }
     if (g_Player.pl_vram_flag & 1) {
@@ -291,8 +291,8 @@ void func_8012E040(void) {
     s32 xOffset;
 
     var_s0 = 1;
-    if ((PLAYER.facing != 0 && !(g_Player.padPressed & PAD_LEFT)) ||
-        (PLAYER.facing == 0 && !(g_Player.padPressed & PAD_RIGHT))) {
+    if ((PLAYER.facingLeft != 0 && !(g_Player.padPressed & PAD_LEFT)) ||
+        (PLAYER.facingLeft == 0 && !(g_Player.padPressed & PAD_RIGHT))) {
         var_s0 = 0;
         func_8010E1EC(FIX(16.0 / 128));
     }
@@ -320,7 +320,7 @@ void func_8012E040(void) {
     }
     if ((PLAYER.velocityY < FIX(-1)) && (g_Player.pl_vram_flag & 2)) {
         if (PLAYER.velocityY < FIX(-5)) {
-            if (PLAYER.facing != 0) {
+            if (PLAYER.facingLeft != 0) {
                 xOffset = -3;
             } else {
                 xOffset = 3;
@@ -378,8 +378,8 @@ void func_8012E040(void) {
         if (ABS(PLAYER.velocityX) < FIX(1)) {
             D_800B0914 = 1;
         }
-        if ((PLAYER.facing != 0 && (g_Player.padPressed & PAD_RIGHT)) ||
-            (PLAYER.facing == 0 && (g_Player.padPressed & PAD_LEFT))) {
+        if ((PLAYER.facingLeft != 0 && (g_Player.padPressed & PAD_RIGHT)) ||
+            (PLAYER.facingLeft == 0 && (g_Player.padPressed & PAD_LEFT))) {
             func_8010E27C();
             D_800B0914 = 1;
             SetSpeedX(FIX(1));
@@ -503,11 +503,11 @@ void func_8012ED30(void) {
         PLAYER.velocityY = 0;
     }
     if (g_Player.padPressed & PAD_RIGHT) {
-        PLAYER.facing = 0;
+        PLAYER.facingLeft = 0;
         PLAYER.velocityX = FIX(0.5);
     }
     if (g_Player.padPressed & PAD_LEFT) {
-        PLAYER.facing = 1;
+        PLAYER.facingLeft = 1;
         PLAYER.velocityX = FIX(-0.5);
     }
     // If you're not pressing any of right, left, or up
@@ -659,10 +659,10 @@ void func_8013136C(Entity* entity) {
         entity->step++;
     }
     entity->animCurFrame = 80;
-    entity->facing = PLAYER.facing;
+    entity->facingLeft = PLAYER.facingLeft;
     entity->posX.val = g_Entities[UNK_ENTITY_13].posX.val; // D_800741CC
     entity->posY.val = g_Entities[UNK_ENTITY_13].posY.val; // D_800741D0
-    if (PLAYER.facing == 0) {
+    if (PLAYER.facingLeft == 0) {
         entity->zPriority = PLAYER.zPriority - 5;
         entity->posX.i.hi += 8;
     } else {
@@ -684,7 +684,7 @@ void func_8013136C(Entity* entity) {
     case 0:
         if (D_800B0914 == 1) {
             entity->posY.i.hi -= 2;
-            if (PLAYER.facing == 0) {
+            if (PLAYER.facingLeft == 0) {
                 entity->posX.i.hi -= 8;
             } else {
                 entity->posX.i.hi += 8;
@@ -700,14 +700,14 @@ void func_8013136C(Entity* entity) {
         case 0:
             if (PLAYER.animCurFrame == 33) {
                 entity->animCurFrame = 81;
-                if (PLAYER.facing == 0) {
+                if (PLAYER.facingLeft == 0) {
                     entity->posX.i.hi += 3;
                 } else {
                     entity->posX.i.hi += 6;
                 }
             }
             if (PLAYER.animCurFrame == 34) {
-                if (PLAYER.facing == 0) {
+                if (PLAYER.facingLeft == 0) {
                     entity->posX.i.hi += 3;
                 } else {
                     entity->posX.i.hi += 13;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -154,7 +154,7 @@ bool func_8015885C(void) {
 void func_80158B04(s32 arg0) {
     s32 var_s0;
 
-    if (PLAYER.facing != 0) {
+    if (PLAYER.facingLeft != 0) {
         var_s0 = -3;
     } else {
         var_s0 = 3;
@@ -184,7 +184,7 @@ void func_80158BFC(void) {
         if (D_8015459C != 0) {
             D_8015459C--;
         } else if (D_80097448[0] >= 49) {
-            if (PLAYER.facing != 0) {
+            if (PLAYER.facingLeft != 0) {
                 var_s0 = -4;
             } else {
                 var_s0 = 4;
@@ -343,13 +343,13 @@ void func_80159C04(void) {
     s32 var_a0;
     s32 var_a2;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         var_a2 = -entity->hitboxOffX;
     } else {
         var_a2 = entity->hitboxOffX;
     }
 
-    if (PLAYER.facing != 0) {
+    if (PLAYER.facingLeft != 0) {
         var_a0 = -PLAYER.hitboxOffX;
     } else {
         var_a0 = PLAYER.hitboxOffX;

--- a/src/ric/1FCD0.c
+++ b/src/ric/1FCD0.c
@@ -69,7 +69,7 @@ void func_8015BE84(void) {
     if (g_Player.pl_vram_flag & 1) {
         g_CurrentEntity->velocityX /= 2;
         func_801606BC(g_CurrentEntity, 0, 0);
-        PLAYER.facing = (PLAYER.facing + 1) & 1;
+        PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
         func_8015CCC8(3, PLAYER.velocityX);
         g_api.PlaySfx(0x64B);
         return;
@@ -86,7 +86,7 @@ void func_8015BE84(void) {
         if ((PLAYER.velocityX > (s32)0xFFFD0000) ||
             (g_Player.pl_vram_flag & 8)) {
             PLAYER.velocityX /= 2;
-            PLAYER.facing = (PLAYER.facing + 1) & 1;
+            PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
             func_8015C920(&D_80155788);
             g_Player.unk44 = 0xA;
             PLAYER.step_s = 2;
@@ -100,7 +100,7 @@ void func_8015BE84(void) {
         }
         if ((PLAYER.velocityX <= 0x2FFFF) || (g_Player.pl_vram_flag & 4)) {
             PLAYER.velocityX /= 2;
-            PLAYER.facing = (PLAYER.facing + 1) & 1;
+            PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
             func_8015C920(&D_80155788);
             g_Player.unk44 = 0xA;
             PLAYER.step_s = 2;

--- a/src/ric/202A8.c
+++ b/src/ric/202A8.c
@@ -13,7 +13,7 @@ void func_8015C2A8(void) {
     switch (PLAYER.step_s) {
     case 0:
         if (g_Player.padPressed & (PAD_LEFT | PAD_RIGHT)) {
-            if (PLAYER.facing == 0) {
+            if (PLAYER.facingLeft == 0) {
                 temp = g_Player.padPressed & PAD_RIGHT;
             } else {
                 temp = g_Player.padPressed & PAD_LEFT;

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -38,9 +38,9 @@ s32 func_8015C9CC(void) {
         return 0;
     }
 
-    if (PLAYER.facing == 1) {
+    if (PLAYER.facingLeft == 1) {
         if (g_Player.padPressed & PAD_RIGHT) {
-            PLAYER.facing = 0;
+            PLAYER.facingLeft = 0;
             g_Player.unk4C = 1;
             return -1;
         } else if (g_Player.padPressed & PAD_LEFT) {
@@ -51,7 +51,7 @@ s32 func_8015C9CC(void) {
             return 1;
         }
         if (g_Player.padPressed & PAD_LEFT) {
-            PLAYER.facing = 1;
+            PLAYER.facingLeft = 1;
             g_Player.unk4C = 1;
             return -1;
         }
@@ -60,7 +60,7 @@ s32 func_8015C9CC(void) {
 }
 
 void func_8015CA84(s32 speed) {
-    if (g_CurrentEntity->facing == 1)
+    if (g_CurrentEntity->facingLeft == 1)
         speed = -speed;
     g_CurrentEntity->velocityX = speed;
 }

--- a/src/ric/22380.c
+++ b/src/ric/22380.c
@@ -189,7 +189,7 @@ Entity* func_801606BC(Entity* srcEntity, u32 arg1, s32 arg2) {
         entity->ext.generic.unk8C.entityPtr = srcEntity;
         entity->posX.val = srcEntity->posX.val;
         entity->posY.val = srcEntity->posY.val;
-        entity->facing = srcEntity->facing;
+        entity->facingLeft = srcEntity->facingLeft;
         entity->zPriority = srcEntity->zPriority;
         entity->params = arg1 & 0xFFF;
         entity->ext.generic.unkA0 = (arg1 >> 8) & 0xFF00;
@@ -211,7 +211,7 @@ void func_80160C38(Entity* entity) {
     } else {
         entity->posX.i.hi = PLAYER.posX.i.hi;
         entity->posY.i.hi = PLAYER.posY.i.hi;
-        entity->facing = PLAYER.facing;
+        entity->facingLeft = PLAYER.facingLeft;
         if (entity->step == 0) {
             entity->flags = FLAG_UNK_20000 | FLAG_UNK_40000 | FLAG_UNK_04000000;
             entity->hitboxOffX = 0x14;
@@ -240,7 +240,7 @@ void func_80160D2C(Entity* self) {
     }
     self->posX.i.hi = PLAYER.posX.i.hi;
     self->posY.i.hi = PLAYER.posY.i.hi;
-    self->facing = PLAYER.facing;
+    self->facingLeft = PLAYER.facingLeft;
 
     if (self->step == 0) {
         self->flags = FLAG_UNK_20000 | FLAG_UNK_40000 | FLAG_UNK_04000000;
@@ -274,7 +274,7 @@ void func_80160E4C(Entity* self) {
     } else {
         self->posX.i.hi = PLAYER.posX.i.hi;
         self->posY.i.hi = PLAYER.posY.i.hi;
-        self->facing = PLAYER.facing;
+        self->facingLeft = PLAYER.facingLeft;
         if (self->step == 0) {
             self->flags = FLAG_UNK_20000 | FLAG_UNK_40000 | FLAG_UNK_04000000;
             self->hitboxHeight = 20;
@@ -298,7 +298,7 @@ void func_80160F0C(Entity* self) {
     }
     self->posX.i.hi = PLAYER.posX.i.hi;
     self->posY.i.hi = PLAYER.posY.i.hi;
-    self->facing = PLAYER.facing;
+    self->facingLeft = PLAYER.facingLeft;
     if (self->step == 0) {
         self->flags = FLAG_UNK_20000 | FLAG_UNK_40000 | FLAG_UNK_04000000;
         self->hitboxOffX = 0xC;

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -5,7 +5,7 @@ void func_80162C84(Entity* entity) {
     case 0:
         entity->flags =
             0x100000 | FLAG_UNK_04000000 | FLAG_UNK_10000 | FLAG_UNK_08000000;
-        entity->facing = 1;
+        entity->facingLeft = 1;
         entity->unk5A = 0x66;
         entity->zPriority = PLAYER.zPriority - 8;
         entity->palette = 0x8149;
@@ -254,7 +254,7 @@ void func_8016779C(Entity* entity) {
         return;
     }
 
-    entity->facing = PLAYER.facing;
+    entity->facingLeft = PLAYER.facingLeft;
     if (entity->step == 0) {
         entity->flags = FLAG_UNK_20000 | FLAG_UNK_40000 | FLAG_UNK_04000000 |
                         FLAG_UNK_10000;
@@ -265,18 +265,18 @@ void func_8016779C(Entity* entity) {
     }
 
     if (PLAYER.step == 2) {
-        if (PLAYER.facing != 0) {
+        if (PLAYER.facingLeft != 0) {
             entity->animCurFrame = D_80155CCC[D_80175080];
         } else {
             entity->animCurFrame = D_80155CB8[D_80175080];
         }
     } else if (PLAYER.step == 0) {
-        if (PLAYER.facing != 0) {
+        if (PLAYER.facingLeft != 0) {
             entity->animCurFrame = D_80155CF4[D_80175080];
         } else {
             entity->animCurFrame = D_80155CE0[D_80175080];
         }
-    } else if (PLAYER.facing != 0) {
+    } else if (PLAYER.facingLeft != 0) {
         entity->animCurFrame = D_80155D1C[D_80175080];
     } else {
         entity->animCurFrame = D_80155D08[D_80175080];
@@ -416,7 +416,7 @@ void func_80169D74(Entity* entity) {
         entity->unk5A = 0x66;
         entity->palette = 0x81B0;
         entity->blendMode = 0x10;
-        entity->facing = PLAYER.facing;
+        entity->facingLeft = PLAYER.facingLeft;
         entity->zPriority = PLAYER.zPriority;
         entity->unk19 = 4;
         entity->rotAngle = 0xC00;
@@ -516,7 +516,7 @@ void func_8016D328(Entity* entity) {
                 entity->ext.generic.unk8C.entityPtr->ext.generic.unk84.unk;
             entity->posY.val =
                 entity->ext.generic.unk8C.entityPtr->ext.generic.unk88.unk;
-            entity->facing = entity->ext.generic.unk8C.entityPtr->ext.generic
+            entity->facingLeft = entity->ext.generic.unk8C.entityPtr->ext.generic
                                  .unk8C.modeU16.unk0;
             entity->ext.generic.unkB0 = 0x18;
             func_8015FAB8(entity);

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -516,8 +516,8 @@ void func_8016D328(Entity* entity) {
                 entity->ext.generic.unk8C.entityPtr->ext.generic.unk84.unk;
             entity->posY.val =
                 entity->ext.generic.unk8C.entityPtr->ext.generic.unk88.unk;
-            entity->facingLeft = entity->ext.generic.unk8C.entityPtr->ext.generic
-                                 .unk8C.modeU16.unk0;
+            entity->facingLeft = entity->ext.generic.unk8C.entityPtr->ext
+                                     .generic.unk8C.modeU16.unk0;
             entity->ext.generic.unkB0 = 0x18;
             func_8015FAB8(entity);
             entity->unk5A = 0x79;

--- a/src/servant/tt_000/10E8.c
+++ b/src/servant/tt_000/10E8.c
@@ -106,7 +106,7 @@ Entity* func_8017110C(Entity* self) {
             }
         }
 
-        if ((self->facing ? entityX < selfX : selfX < entityX) != 0) {
+        if ((self->facingLeft ? entityX < selfX : selfX < entityX) != 0) {
             continue;
         }
         if (e->hitPoints >= 0x7000) {
@@ -196,7 +196,7 @@ init_entity:
     DestroyEntity(entity);
     entity->entityId = 0xDA;
     entity->zPriority = self->zPriority;
-    entity->facing = self->facing;
+    entity->facingLeft = self->facingLeft;
     entity->flags = FLAG_UNK_04000000;
     entity->posX.val = self->posX.val;
     entity->posY.val = self->posY.val;
@@ -223,9 +223,9 @@ void func_8017160C(s32 amount, s32 entityId) {
             entity->entityId = entityId;
             entity->animSet = ANIMSET_OVL(20);
             entity->zPriority = g_Entities[0].zPriority - 2;
-            facing = (g_Entities[0].facing + 1) & 1;
+            facing = (g_Entities[0].facingLeft + 1) & 1;
             entity->params = i + 1;
-            entity->facing = facing;
+            entity->facingLeft = facing;
         }
         *((s16*)(&entity->ext.generic.unkAC)) = g_Camera.posX.i.hi;
         *((s16*)(&entity->ext.generic.unkAE)) = g_Camera.posY.i.hi;
@@ -245,7 +245,7 @@ void func_8017170C(Entity* entity, s32 frameIndex) {
         return;
     }
     index = frameIndex - 1;
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         x = entity->posX.i.hi + 2;
     } else {
         x = entity->posX.i.hi - 16;
@@ -277,7 +277,7 @@ void func_801718A0(Entity* entity) {
     s32 x;
 
     frame = 2;
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         x = entity->posX.i.hi + 2;
     } else {
         x = entity->posX.i.hi - 16;
@@ -345,7 +345,7 @@ void func_801719E0(Entity* self) {
                 }
             } else {
                 for (i = 0; i < 16; i++) {
-                    if (PLAYER.facing) {
+                    if (PLAYER.facingLeft) {
                         D_80174C3C[self->ext.fam.unk82][i].x =
                             PLAYER.posX.i.hi +
                             ((self->ext.fam.unk82 + 1) * 0x10) +
@@ -360,7 +360,7 @@ void func_801719E0(Entity* self) {
                     D_80174C3C[self->ext.fam.unk82][i].y =
                         PLAYER.posY.i.hi + self->ext.fam.cameraY;
                 }
-                self->posX.i.hi = PLAYER.facing ? 0x180 : -0x80;
+                self->posX.i.hi = PLAYER.facingLeft ? 0x180 : -0x80;
                 self->posY.i.hi = rand() % 256;
             }
             self->ext.fam.unkA8 = 0;
@@ -390,7 +390,7 @@ void func_801719E0(Entity* self) {
             self->ext.fam.cameraY = g_Camera.posY.i.hi;
 
             for (i = 0; i < 16; i++) {
-                if (PLAYER.facing) {
+                if (PLAYER.facingLeft) {
                     D_80174C3C[self->ext.fam.unk82][i].x =
                         PLAYER.posX.i.hi + ((self->ext.fam.unk82 + 1) * 0x10) +
                         self->ext.fam.cameraX;
@@ -456,7 +456,7 @@ void func_80171ED4(s32 arg0) {
     e->animSet = ANIMSET_OVL(20);
     e->params = 0;
     e->zPriority = PLAYER.zPriority - 2;
-    e->facing = (PLAYER.facing + 1) & 1;
+    e->facingLeft = (PLAYER.facingLeft + 1) & 1;
     e->posX.val = PLAYER.posX.val;
     e->posY.val = PLAYER.posY.val;
     if (arg0 == 1) {
@@ -475,7 +475,7 @@ void func_80171ED4(s32 arg0) {
             e->posX.val = x;
             e->posY.val = 0xA00000;
         } else {
-            if (PLAYER.facing == 0) {
+            if (PLAYER.facingLeft == 0) {
                 e->posX.val = PLAYER.posX.val - 0x120000;
             } else {
                 e->posX.val = PLAYER.posX.val + 0x120000;
@@ -863,7 +863,7 @@ init_entity:
     DestroyEntity(entity);
     entity->entityId = entityId;
     entity->zPriority = entityParent->zPriority;
-    entity->facing = entityParent->facing;
+    entity->facingLeft = entityParent->facingLeft;
     entity->flags = FLAG_UNK_04000000;
     entity->posX.val = entityParent->posX.val;
     entity->posY.val = entityParent->posY.val;

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -811,7 +811,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -121,7 +121,7 @@ void func_8018DB18(Entity* self) {
 
         temp = (Random() & 30) + 8;
         self->ext.generic.unk80.modeS16.unk0 = temp;
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->ext.generic.unk80.modeS16.unk0 = -temp;
         }
 
@@ -617,7 +617,7 @@ void EntityPlatform(Entity* self) {
             D_8009748E[0]--;
         } else {
             g_api.PlaySfx(0x64F);
-            if (player->facing == 0) {
+            if (player->facingLeft == 0) {
                 g_Player.D_80072EF4 = 0x8000;
             }
             D_8019D424 |= 4;

--- a/src/st/dre/13B3C.c
+++ b/src/st/dre/13B3C.c
@@ -35,7 +35,7 @@ void EntitySuccubusPetal(Entity* self) {
         self->animCurFrame = temp_s2 + 64;
 
         angle = ((Random() & 0x1F) * 16) + 0xC0;
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             angle = 0x800 - angle;
         } else {
             angle = angle;
@@ -71,7 +71,7 @@ void EntitySuccubusWingOverlay(Entity* entity) {
     entity->posX.i.hi = entity[-1].posX.i.hi;
     entity->animCurFrame = 0;
     entity->posY.i.hi = entity[-1].posY.i.hi;
-    entity->facing = entity[-1].facing;
+    entity->facingLeft = entity[-1].facingLeft;
 
     if (entity[-1].animCurFrame == 50) {
         entity->animCurFrame = 62;
@@ -125,7 +125,7 @@ void EntitySuccubusClone(Entity* self) {
         MoveEntity();
         newEntity = self->ext.succubus.real;
         self->animCurFrame = newEntity->animCurFrame;
-        self->facing = newEntity->facing;
+        self->facingLeft = newEntity->facingLeft;
         if (--self->ext.succubus.timer == 0) {
             self->hitboxState = 3;
             SetStep(2);
@@ -135,7 +135,7 @@ void EntitySuccubusClone(Entity* self) {
     case 2:
         newEntity = self->ext.succubus.real;
         self->animCurFrame = newEntity->animCurFrame;
-        self->facing = newEntity->facing;
+        self->facingLeft = newEntity->facingLeft;
         if (newEntity->ext.succubus.unk85 != 0) {
             self->ext.succubus.timer = (self->params * 48) + 1;
             SetStep(3);
@@ -302,7 +302,7 @@ void EntitySuccubusWingSpike(Entity* self) {
         self->unk19 |= 1;
         self->unk1A = 0x100;
         CreateEntityFromEntity(E_SUCCUBUS_WING_SPIKE_TIP, self, &self[1]);
-        self[1].facing = self->facing;
+        self[1].facingLeft = self->facingLeft;
         self[1].params = self->params;
         self[1].rotAngle = self->rotAngle;
 
@@ -334,7 +334,7 @@ void EntitySuccubusWingSpike(Entity* self) {
 
     var_s0 = self->rotAngle;
     temp_s2 = (self->unk1A * 0xB) >> 6;
-    if (self->facing == 0) {
+    if (self->facingLeft == 0) {
         var_s0 = 0x800 - var_s0;
     }
 

--- a/src/st/dre/13E18.c
+++ b/src/st/dre/13E18.c
@@ -40,7 +40,7 @@ void EntityUnkId1C(Entity* self) {
         MoveEntity();
         newEntity = self->ext.generic.unk9C;
         self->animCurFrame = newEntity->animCurFrame;
-        self->facing = newEntity->facing;
+        self->facingLeft = newEntity->facingLeft;
         if (--self->ext.generic.unk80.modeS16.unk0 == 0) {
             self->hitboxState = 3;
             SetStep(2);
@@ -50,7 +50,7 @@ void EntityUnkId1C(Entity* self) {
     case 2:
         newEntity = self->ext.generic.unk9C;
         self->animCurFrame = newEntity->animCurFrame;
-        self->facing = newEntity->facing;
+        self->facingLeft = newEntity->facingLeft;
         if (newEntity->ext.generic.unk84.U8.unk1 != 0) {
             self->ext.generic.unk80.modeS16.unk0 = (self->params * 0x30) + 1;
             SetStep(3);

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -869,7 +869,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -112,7 +112,7 @@ void EntitySuccubus(Entity* self) {
 
     case SUCCUBUS_CS_1: // Disguised as Lisa
         if (D_8003BDEC[SeenCutscene] || (g_DemoMode != Demo_None)) {
-            self->facing = 0;
+            self->facingLeft = 0;
             self->posX.i.hi = 416 - g_Camera.posX.i.hi;
             self->posY.i.hi = 175 - g_Camera.posY.i.hi;
             SetStep(SUCCUBUS_CS_4);
@@ -171,7 +171,7 @@ void EntitySuccubus(Entity* self) {
         if ((D_801A3ED4 == 0) || (self->step_s == 0)) {
             switch (self->step_s) {
             case 0:
-                self->facing = 0;
+                self->facingLeft = 0;
                 self->posX.i.hi = 416 - g_Camera.posX.i.hi;
                 self->posY.i.hi = 175 - g_Camera.posY.i.hi;
                 self->step_s++;
@@ -287,11 +287,11 @@ void EntitySuccubus(Entity* self) {
                 SetSubStep(SUCCUBUS_DYING_ANIM_1);
                 posX = self->posX.i.hi + g_Camera.posX.i.hi;
                 if (posX < 80) {
-                    D_801816C4 = self->facing = 1;
+                    D_801816C4 = self->facingLeft = 1;
                 } else if (posX > 432) {
-                    D_801816C4 = self->facing = 0;
+                    D_801816C4 = self->facingLeft = 0;
                 } else {
-                    D_801816C4 = self->facing = (GetSideToPlayer() & 1) ^ 1;
+                    D_801816C4 = self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
                 }
                 D_801A3F84 |= 2;
             }
@@ -350,7 +350,7 @@ void EntitySuccubus(Entity* self) {
                     self->ext.succubus.nextAttack = SUCCUBUS_CLONE_ATTACK;
                 }
             }
-            self->ext.succubus.facing = 0;
+            self->ext.succubus.facingLeft = 0;
             self->step_s++;
 
         case SUCCUBUS_FLY_1:
@@ -368,7 +368,7 @@ void EntitySuccubus(Entity* self) {
                 self->velocityY = FIX(0.75);
             }
 
-            if (self->facing != self->ext.succubus.facing) {
+            if (self->facingLeft != self->ext.succubus.facingLeft) {
                 self->velocityX += FIX(0.09375);
                 if (self->velocityX >= FIX(1.375)) {
                     self->velocityX = FIX(1.375);
@@ -387,21 +387,21 @@ void EntitySuccubus(Entity* self) {
             }
 
             temp = GetDistanceToPlayerX();
-            if (self->ext.succubus.facing == 0) {
+            if (self->ext.succubus.facingLeft == 0) {
                 if (temp < posX) {
-                    self->ext.succubus.facing ^= 1;
+                    self->ext.succubus.facingLeft ^= 1;
                 }
-                if (self->ext.succubus.facing != 0) {
+                if (self->ext.succubus.facingLeft != 0) {
                     if (posX < temp) {
-                        self->ext.succubus.facing ^= 1;
+                        self->ext.succubus.facingLeft ^= 1;
                     }
                 }
             } else if (posX < temp) {
-                self->ext.succubus.facing ^= 1;
+                self->ext.succubus.facingLeft ^= 1;
             }
 
             sideToPlayer = ((GetSideToPlayer() & 1) ^ 1);
-            if (self->facing != sideToPlayer) {
+            if (self->facingLeft != sideToPlayer) {
                 if (temp > 16) {
                     self->ext.succubus.nextStep = SUCCUBUS_CLONE_ATTACK;
                     SetStep(SUCCUBUS_NEXT_ACTION_CHECK);
@@ -409,11 +409,11 @@ void EntitySuccubus(Entity* self) {
             }
 
             posX = self->posX.i.hi + g_Camera.posX.i.hi;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX = 512 - posX;
             }
             if (posX > 416) {
-                self->ext.succubus.facing = 0;
+                self->ext.succubus.facingLeft = 0;
                 self->ext.succubus.timer = 96;
                 self->step_s++;
             }
@@ -435,7 +435,7 @@ void EntitySuccubus(Entity* self) {
             break;
 
         case SUCCUBUS_FLY_2:
-            if (self->facing != self->ext.succubus.facing) {
+            if (self->facingLeft != self->ext.succubus.facingLeft) {
                 self->velocityX += FIX(0.09375);
                 if (self->velocityX >= FIX(1.375)) {
                     self->velocityX = FIX(1.375);
@@ -460,7 +460,7 @@ void EntitySuccubus(Entity* self) {
 
     case SUCCUBUS_FACE_PLAYER:
         if (self->step_s == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
         }
 
@@ -488,7 +488,7 @@ void EntitySuccubus(Entity* self) {
     case SUCCUBUS_PETAL_ATTACK:
         switch (self->step_s) {
         case SUCCUBUS_PETAL_ATTACK_SETUP:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             if (g_Player.unk0C & PLAYER_STATUS_CURSE) {
                 self->ext.succubus.unk87 = false;
             } else {
@@ -510,7 +510,7 @@ void EntitySuccubus(Entity* self) {
                 entity = AllocEntity(&g_Entities[160], &g_Entities[192]);
                 if (entity != NULL) {
                     CreateEntityFromEntity(E_SUCCUBUS_PETAL, self, entity);
-                    entity->facing = self->facing;
+                    entity->facingLeft = self->facingLeft;
                     entity->zPriority = self->zPriority - 1;
                 }
             }
@@ -545,7 +545,7 @@ void EntitySuccubus(Entity* self) {
         case SUCCUBUS_CHARGE_FLY_TOWARDS_PLAYER:
             entity = &PLAYER;
             posX = entity->posX.i.hi - self->posX.i.hi;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX -= 16;
             } else {
                 posX += 16;
@@ -557,7 +557,7 @@ void EntitySuccubus(Entity* self) {
             self->velocityY = (rsin(angle) << 0x11) >> 0xC;
             posX = self->velocityX;
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX = -posX;
             }
             if (posX > 0) {
@@ -567,7 +567,7 @@ void EntitySuccubus(Entity* self) {
             MoveEntity();
 
             posX = PLAYER.posX.i.hi - self->posX.i.hi;
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 posX = -posX;
             }
             posX -= 4;
@@ -607,7 +607,7 @@ void EntitySuccubus(Entity* self) {
         case SUCCUBUS_CHARGE_AT_PLAYER_POSITION:
             entity = &PLAYER;
             posX = entity->posX.i.hi;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX -= 16;
             } else {
                 posX += 16;
@@ -630,7 +630,7 @@ void EntitySuccubus(Entity* self) {
             if (--self->ext.succubus.timer == 0) {
                 g_Player.unk60 = 0;
                 self->hitboxState = 3;
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     self->velocityX = FIX(-4);
                 } else {
                     self->velocityX = FIX(4);
@@ -656,7 +656,7 @@ void EntitySuccubus(Entity* self) {
     case SUCCUBUS_TAUNT:
         if (self->step_s == 0) {
             self->ext.succubus.timer = 80;
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
             if (self->ext.succubus.unk87) {
                 func_801A046C(NA_VO_SU_DELICIOUS);
@@ -817,7 +817,7 @@ void EntitySuccubus(Entity* self) {
         switch (self->step_s) {
         case SUCCUBUS_SPIKE_ATTACK_CREATE_SPIKES:
             entity = &g_Entities[96];
-            self->facing = 0;
+            self->facingLeft = 0;
             self->ext.succubus.unk85 = false;
             D_80180668 = 0;
             for (facing = 0; facing < 2; facing++) {
@@ -832,7 +832,7 @@ void EntitySuccubus(Entity* self) {
                         entity->posX.i.hi += 4;
                     }
                     entity->posY.i.hi -= 27;
-                    entity->facing = facing;
+                    entity->facingLeft = facing;
                 }
             }
             self->step_s++;

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -858,7 +858,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -15,7 +15,7 @@ void EntityCavernDoorVase(Entity* arg0) {
         InitializeEntity(D_80180B00);
         arg0->animSet = temp_s0->animSet;
         arg0->zPriority = temp_s0->zPriority;
-        arg0->facing = temp_s0->unk4.U8.unk0;
+        arg0->facingLeft = temp_s0->unk4.U8.unk0;
         arg0->unk5A = temp_s0->unk4.U8.unk1;
         arg0->palette = temp_s0->palette;
         arg0->unk19 = temp_s0->unk8;
@@ -1189,7 +1189,7 @@ void EntityMermanRockRightSide(Entity* self) {
                     newEntity->params = *params++;
                     newEntity->velocityX = (Random() << 8) + 0x8000;
                     newEntity->velocityY = -Random() * 0x100;
-                    newEntity->facing = 1;
+                    newEntity->facingLeft = 1;
                     newEntity->posY.i.hi += -16 + (i * 16);
                 }
             }
@@ -1468,7 +1468,7 @@ void EntityFallingRock(Entity* self) {
         self->velocityX = rnd * rcos(rndAngle);
         self->velocityY = rnd * rsin(rndAngle);
         if (self->velocityX > 0) {
-            self->facing = 1;
+            self->facingLeft = 1;
         }
         break;
 
@@ -1563,7 +1563,7 @@ void EntityUnkId29(Entity* self) {
         InitializeEntity(D_80180B18);
         self->zPriority = 0x2A;
         self->flags &= ~FLAG_UNK_08000000;
-        self->facing = Random() & 1;
+        self->facingLeft = Random() & 1;
         g_api.func_80134714(0x665, 0x40, (self->posX.i.hi >> 0x4) - 8);
     }
     if (AnimateEntity(D_80181390, self) == 0) {

--- a/src/st/no3/3FF00.c
+++ b/src/st/no3/3FF00.c
@@ -689,7 +689,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
         if (self->params & 0xF0) {
             self->palette = 0x819F;
             self->blendMode = 0x10;
-            self->facing = 1;
+            self->facingLeft = 1;
         }
         break;
 
@@ -777,7 +777,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
         if (self->step_s == 0) {
             rnd = Random();
             self->velocityY = FIX(-0.75);
-            self->facing = rnd & 1;
+            self->facingLeft = rnd & 1;
             self->unk1A = 0xC0;
             self->unk19 |= 1;
             self->step_s++;

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -926,7 +926,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -668,7 +668,7 @@ void func_801CF58C(Entity* self) {
 void func_801CF5E0(Entity* self) {
     s16 temp_v0;
 
-    if (self->facing == GetSideToPlayer()) {
+    if (self->facingLeft == GetSideToPlayer()) {
         SetStep(5);
         return;
     }
@@ -683,14 +683,14 @@ void func_801CF5E0(Entity* self) {
 
     if (temp_v0 > 16) {
         SetStep(3);
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->ext.generic.unk7C.S8.unk0 = 0;
         } else {
             self->ext.generic.unk7C.S8.unk0 = 1;
         }
     } else if (temp_v0 < -16) {
         SetStep(3);
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->ext.generic.unk7C.S8.unk0 = 1;
         } else {
             self->ext.generic.unk7C.S8.unk0 = 0;
@@ -1588,7 +1588,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     if (entity->step == 0) {
         InitializeEntity(D_80180B54);
         entity->animCurFrame = 0;
-        if (entity->facing != 0) {
+        if (entity->facingLeft != 0) {
             entity->velocityX = FIX(2);
             return;
         }
@@ -1835,7 +1835,7 @@ void EntityMermanFireball(Entity* self) {
         self->animCurFrame = 0;
         self->hitboxHeight = 3;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = 0x10000 | 0x8000; // LINT_IGNORE
         } else {
             self->velocityX = 0xFFFE0000 | 0x8000; // LINT_IGNORE
@@ -1904,7 +1904,7 @@ void func_801D59D0(void) {
 
     if (g_CurrentEntity->ext.generic.unk7C.U8.unk0 == 0) {
         if (GetDistanceToPlayerX() < 64) {
-            if (g_CurrentEntity->facing != (GetSideToPlayer() & 1)) {
+            if (g_CurrentEntity->facingLeft != (GetSideToPlayer() & 1)) {
                 SetStep(4);
             }
         }
@@ -1935,7 +1935,7 @@ void EntityBoneScimitarParts(Entity* entity) {
     entity->unk19 = 4;
     entity->animCurFrame = *(u8*)&entity->params + 16;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         entity->velocityX = -entity->velocityX;
     }
 

--- a/src/st/no3/56264.c
+++ b/src/st/no3/56264.c
@@ -33,9 +33,9 @@ void EntityBat(Entity* entity) {
 
     case 2:
         if (AnimateEntity(D_80183C60, entity) == 0) {
-            entity->facing = (GetSideToPlayer() & 1) ^ 1;
+            entity->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             entity->velocityY = FIX(0.875);
-            if (entity->facing != 0) {
+            if (entity->facingLeft != 0) {
                 entity->velocityX = FIX(0.25);
             } else {
                 entity->velocityX = FIX(-0.25);
@@ -50,7 +50,7 @@ void EntityBat(Entity* entity) {
         AnimateEntity(D_80183C44, entity);
         MoveEntity();
         if (GetDistanceToPlayerY() < 0x20) {
-            if (entity->facing == 0) {
+            if (entity->facingLeft == 0) {
                 entity->velocityX = FIX(-1);
             } else {
                 entity->velocityX = FIX(1);

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -37,7 +37,7 @@ void EntityZombie(Entity* self) {
 
     case 1:
         if (func_801C5074(&D_80183CAC) & 1) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step++;
         }
         break;
@@ -55,7 +55,7 @@ void EntityZombie(Entity* self) {
     case 3:
         AnimateEntity(D_80183C7C, self);
         temp_a0 = func_801C52EC(&D_80183CBC);
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = FIX(0.5);
         } else {
             self->velocityX = FIX(-0.5);

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -13,7 +13,7 @@ void func_801B246C(Entity* self) {
         InitializeEntity(D_80180A90);
         self->animSet = temp_s0->animSet;
         self->zPriority = temp_s0->zPriority;
-        self->facing = temp_s0->unk4.U8.unk0;
+        self->facingLeft = temp_s0->unk4.U8.unk0;
         self->unk5A = temp_s0->unk4.U8.unk1;
         self->palette = temp_s0->palette;
         self->unk19 = temp_s0->unk8;
@@ -1131,7 +1131,7 @@ void EntityMermanRockRightSide(Entity* self) {
                     newEntity->params = *params++;
                     newEntity->velocityX = (Random() << 8) + 0x8000;
                     newEntity->velocityY = -Random() * 0x100;
-                    newEntity->facing = 1;
+                    newEntity->facingLeft = 1;
                     newEntity->posY.i.hi += -16 + (i * 16);
                 }
             }
@@ -1407,7 +1407,7 @@ void EntityFallingRock(Entity* self) {
         self->velocityX = rnd * rcos(rndAngle);
         self->velocityY = rnd * rsin(rndAngle);
         if (self->velocityX > 0) {
-            self->facing = 1;
+            self->facingLeft = 1;
         }
         break;
 
@@ -1438,7 +1438,7 @@ void func_801B5DE8(Entity* self) {
         InitializeEntity(D_80180AA8);
         self->zPriority = 0x2A;
         self->flags &= ~FLAG_UNK_08000000;
-        self->facing = Random() & 1;
+        self->facingLeft = Random() & 1;
         g_api.func_80134714(0x665, 0x40, (self->posX.i.hi >> 0x4) - 8);
     }
     if (AnimateEntity(D_80181214, self) == 0) {

--- a/src/st/np3/365FC.c
+++ b/src/st/np3/365FC.c
@@ -31,7 +31,7 @@ void func_801B65FC(Entity* self) {
         if (self->params & 0xF0) {
             self->palette = 0x819F;
             self->blendMode = 0x10;
-            self->facing = 1;
+            self->facingLeft = 1;
         }
         break;
 
@@ -119,7 +119,7 @@ void func_801B65FC(Entity* self) {
         if (self->step_s == 0) {
             rnd = Random();
             self->velocityY = FIX(-0.75);
-            self->facing = rnd & 1;
+            self->facingLeft = rnd & 1;
             self->unk1A = 0xC0;
             self->unk19 |= 1;
             self->step_s++;

--- a/src/st/np3/36990.c
+++ b/src/st/np3/36990.c
@@ -165,7 +165,7 @@ void EntitySlogra(Entity* self) {
             return;
         }
         InitializeEntity(D_80180B44);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         CreateEntityFromCurrentEntity(E_SLOGRA_SPEAR, &self[1]);
 
     case SLOGRA_FLOOR_ALIGN:
@@ -189,7 +189,7 @@ void EntitySlogra(Entity* self) {
 
     case SLOGRA_WALKING_WITH_SPEAR:
         if (self->step_s == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             if (self->ext.GS_Props.attackMode != 0) {
                 self->ext.GS_Props.flag = 1;
             } else {
@@ -199,8 +199,8 @@ void EntitySlogra(Entity* self) {
             self->step_s++;
         }
         AnimateEntity(D_801812E8, self);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
-        if (self->facing != self->ext.GS_Props.flag) {
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
+        if (self->facingLeft != self->ext.GS_Props.flag) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -254,7 +254,7 @@ void EntitySlogra(Entity* self) {
     case SLOGRA_SPEAR_FIRE:
         switch (self->step_s) {
         case SLOGRA_FIRE_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
 
         case SLOGRA_FIRE_PROJECTILE:
@@ -264,13 +264,13 @@ void EntitySlogra(Entity* self) {
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(
                         E_SLOGRA_SPEAR_PROJECTILE, self, newEntity);
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi += 68;
                     } else {
                         newEntity->posX.i.hi -= 68;
                     }
                     newEntity->posY.i.hi -= 6;
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                     newEntity->zPriority = self->zPriority + 1;
                 }
                 SetSubStep(SLOGRA_FIRE_COOLDOWN);
@@ -327,15 +327,15 @@ void EntitySlogra(Entity* self) {
 
     case SLOGRA_WALKING_WITHOUT_SPEAR:
         if (self->step_s == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.flag = 1;
             self->ext.GS_Props.timer = 128;
             self->step_s++;
         }
 
         AnimateEntity(D_80181370, self);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
-        if (self->facing != self->ext.GS_Props.flag) {
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
+        if (self->facingLeft != self->ext.GS_Props.flag) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -500,7 +500,7 @@ void EntitySlograSpear(Entity* self) {
         InitializeEntity(D_80180B50);
 
     case 1:
-        self->facing = self[-1].facing;
+        self->facingLeft = self[-1].facingLeft;
         self->posX.i.hi = self[-1].posX.i.hi;
         self->posY.i.hi = self[-1].posY.i.hi;
         hitbox = D_80181454;
@@ -519,7 +519,7 @@ void EntitySlograSpear(Entity* self) {
         case 0:
             self->unk19 = 4;
             self->hitboxState = 0;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = FIX(-2.25);
             } else {
                 self->velocityX = FIX(2.25);
@@ -557,7 +557,7 @@ void EntitySlograSpearProjectile(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(D_80180B5C);
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-4);
         } else {
             self->velocityX = FIX(4);
@@ -627,7 +627,7 @@ void EntityGaibon(Entity* self) {
             return;
         }
         InitializeEntity(D_80180B68);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         CreateEntityFromCurrentEntity(0x52, &self[1]);
         self[1].zPriority = self->zPriority + 4;
         SetStep(GAIBON_IDLE);
@@ -646,7 +646,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_FLY_TOWARDS_PLAYER:
         switch (self->step_s) {
         case GAIBON_FLY_TOWARDS_PLAYER_BEGIN:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.angle =
                 ratan2((PLAYER.posY.i.hi - 32) - self->posY.i.hi,
                        PLAYER.posX.i.hi - self->posX.i.hi);
@@ -675,7 +675,7 @@ void EntityGaibon(Entity* self) {
             if (self->animFrameIdx == 1 && self->animFrameDuration == 0) {
                 func_801C2598(NA_SE_EN_GAIBON_FLAP_WINGS);
             }
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.timer--;
             if (self->ext.GS_Props.timer == 0) {
                 self->step_s++;
@@ -700,7 +700,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_FLY_SHOOT_FIREBALLS:
         switch (self->step_s) {
         case GAIBON_FLY_SHOOT_FIREBALLS_BEGIN:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             newEntity = &PLAYER;
             temp_s3 = newEntity->posX.i.hi;
             if (GetSideToPlayer() & 1) {
@@ -749,7 +749,7 @@ void EntityGaibon(Entity* self) {
                         E_GAIBON_SMALL_FIREBALL, self, newEntity);
                     func_801C2598(NA_SE_EN_GAIBON_SMALL_FIREBALL);
                     newEntity->posY.i.hi -= 2;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
@@ -826,7 +826,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_SHOOT_FROM_GROUND:
         switch (self->step_s) {
         case GAIBON_SHOOT_FROM_GROUND_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
 
         case GAIBON_SHOOT_FROM_GROUND_FACE_SETUP:
@@ -854,7 +854,7 @@ void EntityGaibon(Entity* self) {
                     }
 
                     newEntity->posY.i.hi -= 6;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0;
                         newEntity->posX.i.hi += 16;
                     } else {
@@ -888,7 +888,7 @@ void EntityGaibon(Entity* self) {
                     CreateEntityFromEntity(
                         E_GAIBON_BIG_FIREBALL, self, newEntity);
                     newEntity->posY.i.hi -= 2;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
@@ -899,7 +899,7 @@ void EntityGaibon(Entity* self) {
                 }
             }
             self->velocityY = FIX(-2);
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = FIX(-2);
             } else {
                 self->velocityX = FIX(2);
@@ -927,9 +927,9 @@ void EntityGaibon(Entity* self) {
         switch (self->step_s) {
         case GAIBON_PICKUP_SLOGRA_SETUP:
             if (SLOGRA.posX.i.hi - self->posX.i.hi > 0) {
-                self->facing = 1;
+                self->facingLeft = 1;
             } else {
-                self->facing = 0;
+                self->facingLeft = 0;
             }
             self->ext.GS_Props.speed = 0;
             self->step_s++;
@@ -1057,9 +1057,9 @@ void EntityGaibon(Entity* self) {
         switch (self->step_s) {
         case GAIBON_RETREAT_FACE_SLOGRA:
             if ((SLOGRA.posX.i.hi - self->posX.i.hi) > 0) {
-                self->facing = 1;
+                self->facingLeft = 1;
             } else {
-                self->facing = 0;
+                self->facingLeft = 0;
             }
             self->ext.GS_Props.speed = 0;
             D_8003BDEC[RetreatedInEntrance] |= 1;
@@ -1180,7 +1180,7 @@ void func_801B8CC0(Entity* self) {
     }
 
     prevEntity = &self[-1];
-    self->facing = prevEntity->facing;
+    self->facingLeft = prevEntity->facingLeft;
     self->palette = prevEntity->palette;
     self->posX.i.hi = prevEntity->posX.i.hi;
     self->posY.i.hi = prevEntity->posY.i.hi;

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -907,7 +907,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/np3/44DCC.c
+++ b/src/st/np3/44DCC.c
@@ -717,7 +717,7 @@ void EntityMerman2(Entity* self) {
             self->step_s++;
         }
         if (AnimateEntity(D_8018229C, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
         MoveEntity();
         posX = self->posX.i.hi;
@@ -771,7 +771,7 @@ void EntityMerman2(Entity* self) {
                 prim->v2 = v0;
                 prim->v3 = v0;
 
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     s16 posX = self->posX.i.hi;
                     prim->x0 = posX + 15;
                     prim->x1 = posX - 17;
@@ -830,7 +830,7 @@ void EntityMerman2(Entity* self) {
                 self->hitboxHeight = 8;
                 self->rotAngle -= 0x80;
             } else {
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     s16 posX = self->posX.i.hi;
                     prim->x0 = posX + 15;
                     prim->x1 = posX - 17;
@@ -898,7 +898,7 @@ void EntityMerman2(Entity* self) {
             break;
 
         case MERMAN2_WALKING_TO_PLAYER_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.merman2.timer = D_80182244[Random() & 3];
             self->step_s++;
             break;
@@ -907,9 +907,9 @@ void EntityMerman2(Entity* self) {
             AnimateEntity(D_80182270, self);
             colRes = func_801BCB5C(&D_80182268);
             if (colRes == 0xFF) {
-                self->facing ^= 1;
+                self->facingLeft ^= 1;
             }
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(-0.375);
             } else {
                 self->velocityX = FIX(0.375);
@@ -945,7 +945,7 @@ void EntityMerman2(Entity* self) {
     case MERMAN2_SPIT_FIRE:
         switch (self->step_s) {
         case MERMAN2_SPIT_FIRE_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
             return;
 
@@ -957,20 +957,20 @@ void EntityMerman2(Entity* self) {
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x34, self, newEntity);
                     newEntity->posY.i.hi -= 12;
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                 }
                 newEntity2 = &D_8007A958[64];
                 for (offset = 0; i < 3; i++, offset += 8) {
                     newEntity = AllocEntity(newEntity2, &newEntity2[32]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x36, self, newEntity);
-                        if (self->facing != 0) {
+                        if (self->facingLeft != 0) {
                             newEntity->posX.i.hi += 8 + offset;
                         } else {
                             newEntity->posX.i.hi += -8 - offset;
                         }
                         newEntity->posY.i.hi -= 12;
-                        newEntity->facing = self->facing;
+                        newEntity->facingLeft = self->facingLeft;
                         if (i == 0) {
                             newEntity->params = 1;
                         }
@@ -979,7 +979,7 @@ void EntityMerman2(Entity* self) {
                 self->ext.merman2.rotation = 1;
                 self->rotAngle = 0;
                 self->unk19 |= 4;
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     self->velocityX = FIX(-6);
                 } else {
                     self->velocityX = FIX(6);
@@ -995,7 +995,7 @@ void EntityMerman2(Entity* self) {
                 self->ext.merman2.rotation *= 2;
             }
             if (self->velocityX != 0) {
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     self->velocityX += FIX(0.1875);
                 } else {
                     self->velocityX -= FIX(0.1875);
@@ -1003,7 +1003,7 @@ void EntityMerman2(Entity* self) {
             }
             posX = self->posX.i.hi;
             posY = self->posY.i.hi + 8;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX -= 20;
             } else {
                 posX += 20;
@@ -1016,7 +1016,7 @@ void EntityMerman2(Entity* self) {
             self->velocityY -= FIX(0.125);
 
             if (func_801BC8E4(&D_80182248) & 1) {
-                if (self->facing == 0) {
+                if (self->facingLeft == 0) {
                     self->velocityX = FIX(2.5);
                 } else {
                     self->velocityX = ~0x27FFF;
@@ -1034,7 +1034,7 @@ void EntityMerman2(Entity* self) {
         case 3:
             posY = self->posY.i.hi + 8;
             posX = self->posX.i.hi;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX -= 20;
             } else {
                 posX += 20;
@@ -1096,7 +1096,7 @@ void EntityMerman2(Entity* self) {
                 if (self->params & 1) {
                     prim->clut = 0x293;
                 }
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     u32 u1 = 0x1C8;
                     prim->u0 = 0xF0;
                     prim->u1 = u1;
@@ -1117,7 +1117,7 @@ void EntityMerman2(Entity* self) {
                 *(s16*)&prim->next->r2 = 0x28;
                 *(s16*)&prim->next->b2 = 0x30;
                 prim->next->b3 = 0x80;
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     prim->next->x1 = self->posX.i.hi - 3;
                 } else {
                     prim->next->x1 = self->posX.i.hi + 3;
@@ -1131,7 +1131,7 @@ void EntityMerman2(Entity* self) {
             func_801BC8E4(&D_80182258);
             prim = self->ext.merman2.prim;
             self->velocityY -= FIX(0.1875);
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 prim->next->x1 = self->posX.i.hi - 3;
             } else {
                 prim->next->x1 = self->posX.i.hi + 3;
@@ -1147,7 +1147,7 @@ void EntityMerman2(Entity* self) {
                     newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x37, self, newEntity);
-                        newEntity->facing = self->facing;
+                        newEntity->facingLeft = self->facingLeft;
                         newEntity->params = prim->clut;
                         newEntity->zPriority = self->zPriority;
                     }
@@ -1231,7 +1231,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     if (entity->step == 0) {
         InitializeEntity(D_80180AC0);
         entity->animCurFrame = 0;
-        if (entity->facing != 0) {
+        if (entity->facingLeft != 0) {
             entity->velocityX = FIX(2);
             return;
         }

--- a/src/st/np3/48238.c
+++ b/src/st/np3/48238.c
@@ -116,7 +116,7 @@ void EntityMerman(Entity* self) {
             self->step_s++;
         }
         if (AnimateEntity(D_801823D0, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
         MoveEntity();
         camY = g_Camera.posY.i.hi;
@@ -219,8 +219,8 @@ void EntityMerman(Entity* self) {
     case MERMAN_WALKING_TOWARDS_PLAYER:
         switch (self->step_s) {
         case MERMAN_WALKING_TOWARDS_START:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
-            if (self->facing == 0) {
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(-0.375);
             } else {
                 self->velocityX = FIX(0.375);
@@ -233,9 +233,9 @@ void EntityMerman(Entity* self) {
             AnimateEntity(D_80182394, self);
             colRet = func_801BCB5C(&D_8018238C);
             if (colRet == 0xFF) {
-                self->facing ^= 1;
+                self->facingLeft ^= 1;
             }
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(-0.375);
             } else {
                 self->velocityX = FIX(0.375);
@@ -260,7 +260,7 @@ void EntityMerman(Entity* self) {
     case MERMAN_SPIT_FIRE:
         switch (self->step_s) {
         case MERMAN_SPIT_FIRE_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
             break;
 
@@ -273,13 +273,13 @@ void EntityMerman(Entity* self) {
                 newEntity = AllocEntity(D_8007A958, &D_8007A958[32]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x3A, self, newEntity);
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi += 12;
                     } else {
                         newEntity->posX.i.hi -= 12;
                     }
                     newEntity->posY.i.hi -= 10;
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                 }
             }
         }
@@ -294,7 +294,7 @@ void EntityMerman(Entity* self) {
             break;
 
         case MERMAN_LUNGE_SETUP:
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = ~0x27FFF;
             } else {
                 self->velocityX = FIX(2.5);
@@ -311,7 +311,7 @@ void EntityMerman(Entity* self) {
         case MERMAN_LUNGE_TOWARDS_PLAYER:
             posY = self->posY.i.hi + 8;
             posX = self->posX.i.hi;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 posX += 24;
             } else {
                 posX -= 24;
@@ -321,7 +321,7 @@ void EntityMerman(Entity* self) {
                 self->velocityX = 0;
             }
             func_801C0B20(&D_8018236C);
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX -= FIX(0.03125);
             } else {
                 self->velocityX += FIX(0.03125);
@@ -421,7 +421,7 @@ void func_801C8DF0(Entity* self) {
         self->animCurFrame = 0;
         self->hitboxHeight = 3;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = FIX(1.5);
         } else {
             self->velocityX = ~0x17FFF;

--- a/src/st/np3/490E8.c
+++ b/src/st/np3/490E8.c
@@ -37,7 +37,7 @@ void func_801C90E8(void) {
     }
     if ((g_CurrentEntity->ext.generic.unk7C.U8.unk0) == 0) {
         if (GetDistanceToPlayerX() < 64) {
-            if (g_CurrentEntity->facing != (GetSideToPlayer() & 1)) {
+            if (g_CurrentEntity->facingLeft != (GetSideToPlayer() & 1)) {
                 SetStep(BONE_SCIMITAR_ATTACK);
             }
         }
@@ -84,9 +84,9 @@ void EntityBoneScimitar(Entity* self) {
 
     case BONE_SCIMITAR_WALK_TOWARDS_PLAYER:
         if (AnimateEntity(D_80182464, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
-        self->ext.generic.unk80.modeS8.unk0 = self->facing;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft;
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
             self->velocityX = FIX(-0.5);
@@ -102,9 +102,9 @@ void EntityBoneScimitar(Entity* self) {
 
     case BONE_SCIMITAR_WALK_AWAY_FROM_PLAYER:
         if (AnimateEntity(D_80182474, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
-        self->ext.generic.unk80.modeS8.unk0 = self->facing ^ 1;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft ^ 1;
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
             self->velocityX = FIX(-0.5);
@@ -188,9 +188,9 @@ void EntityBoneScimitar(Entity* self) {
         break;
 
     case BONE_SCIMITAR_SPECIAL:
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         func_801BCB5C(&D_80182540);
-        if (((((u32)self->velocityX) >> 0x1F) ^ self->facing) != 0) {
+        if (((((u32)self->velocityX) >> 0x1F) ^ self->facingLeft) != 0) {
             AnimateEntity(D_80182464, self);
         } else {
             AnimateEntity(D_80182474, self);
@@ -232,11 +232,11 @@ void EntityBoneScimitar(Entity* self) {
                 break;
             }
             CreateEntityFromCurrentEntity(E_BONE_SCIMITAR_HEAD, newEntity);
-            newEntity->facing = self->facing;
+            newEntity->facingLeft = self->facingLeft;
             newEntity->params = i;
             newEntity->ext.generic.unk88.S8.unk0 = D_801824C8[i];
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 newEntity->posX.i.hi -= D_80182508[i];
             } else {
                 newEntity->posX.i.hi += D_80182508[i];
@@ -284,7 +284,7 @@ void EntityBoneScimitarParts(Entity* entity) {
     entity->unk19 = 4;
     entity->animCurFrame = *(u8*)&entity->params + 16;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         entity->velocityX = -entity->velocityX;
     }
 

--- a/src/st/np3/4997C.c
+++ b/src/st/np3/4997C.c
@@ -32,9 +32,9 @@ void EntityBat(Entity* entity) {
 
     case 2:
         if (AnimateEntity(D_80182570, entity) == 0) {
-            entity->facing = (GetSideToPlayer() & 1) ^ 1;
+            entity->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             entity->velocityY = FIX(0.875);
-            if (entity->facing != 0) {
+            if (entity->facingLeft != 0) {
                 entity->velocityX = FIX(0.25);
             } else {
                 entity->velocityX = FIX(-0.25);
@@ -49,7 +49,7 @@ void EntityBat(Entity* entity) {
         AnimateEntity(D_80182554, entity);
         MoveEntity();
         if (GetDistanceToPlayerY() < 0x20) {
-            if (entity->facing == 0) {
+            if (entity->facingLeft == 0) {
                 entity->velocityX = FIX(-1);
             } else {
                 entity->velocityX = FIX(1);

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -37,7 +37,7 @@ void EntityZombie(Entity* self) {
 
     case 1:
         if (func_801BC8E4(D_801825BC) & 1) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step++;
         }
         break;
@@ -55,7 +55,7 @@ void EntityZombie(Entity* self) {
     case 3:
         AnimateEntity(D_8018258C, self);
         temp_a0 = func_801BCB5C(&D_801825CC);
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = FIX(0.5);
         } else {
             self->velocityX = FIX(-0.5);

--- a/src/st/np3/49F98.c
+++ b/src/st/np3/49F98.c
@@ -60,7 +60,7 @@ void EntityBloodSplatter(Entity* self) {
             *(u16*)&prim->next->b2 = 0x10;
             *(s32*)&prim->next->r1 = -0x6000;
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 *(s32*)&prim->next->u0 = 0xA000;
                 prim->next->tpage = 0x200;
                 prim->next->x1 = prim->next->x1 + 4;
@@ -93,7 +93,7 @@ void EntityBloodSplatter(Entity* self) {
             *(u16*)&prim->next->b2 = 0x10;
             prim->next->b3 = 0x80;
             *(s32*)&prim->next->r1 = -0x8000;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 *(s32*)&prim->next->u0 = 0xC000;
                 *(s16*)&prim->next->tpage = 0x200;
             } else {
@@ -123,7 +123,7 @@ void EntityBloodSplatter(Entity* self) {
         prim2 = prim->next;
         *(s32*)&prim2->r1 += 0xC00;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             prim->next->tpage += 0x18;
         } else {
             prim->next->tpage = prim->next->tpage - 0x18;
@@ -180,7 +180,7 @@ void func_801CA498(Primitive* prim) {
         prim->next->x1 = g_CurrentEntity->posX.i.hi;
         prim->next->y0 = g_CurrentEntity->posY.i.hi;
 
-        if (g_CurrentEntity->facing != 0) {
+        if (g_CurrentEntity->facingLeft != 0) {
             prim->next->x1 -= 8;
         } else {
             prim->next->x1 += 8;
@@ -250,7 +250,7 @@ void EntityBloodyZombie(Entity* self) {
         AnimateEntity(D_801825EC, self);
         func_801BCB5C(D_801825E4);
 
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-0.375);
         } else {
             self->velocityX = FIX(0.375);
@@ -258,14 +258,14 @@ void EntityBloodyZombie(Entity* self) {
 
         if (--self->ext.generic.unk80.modeS16.unk0 == 0) {
             self->ext.generic.unk80.modeS16.unk0 = 128;
-            self->facing ^= 1;
+            self->facingLeft ^= 1;
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x49, self, newEntity);
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi += 16;
                 } else {
                     newEntity->posX.i.hi -= 16;
@@ -274,19 +274,19 @@ void EntityBloodyZombie(Entity* self) {
             }
         }
         facing = GetSideToPlayer() & 1;
-        if (PLAYER.facing == facing && GetDistanceToPlayerX() < 128) {
-            self->facing = facing ^ 1;
+        if (PLAYER.facingLeft == facing && GetDistanceToPlayerX() < 128) {
+            self->facingLeft = facing ^ 1;
             SetStep(BLOODY_ZOMBIE_CHASE);
         }
         break;
 
     case BLOODY_ZOMBIE_CHASE:
         if (AnimateEntity(D_8018267C, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
         func_801BCB5C(D_801825E4);
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -296,7 +296,7 @@ void EntityBloodyZombie(Entity* self) {
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x49, self, newEntity);
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi += 18;
                 } else {
                     newEntity->posX.i.hi -= 18;
@@ -326,7 +326,7 @@ void EntityBloodyZombie(Entity* self) {
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x4A, self, newEntity);
-                newEntity->facing = GetSideToPlayer() & 1;
+                newEntity->facingLeft = GetSideToPlayer() & 1;
             }
             self->step_s++;
         }
@@ -357,8 +357,8 @@ void EntityBloodyZombie(Entity* self) {
                 newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x4A, self, newEntity);
-                    newEntity->facing = self->ext.generic.unk84.U8.unk0;
-                    if (self->facing != 0) {
+                    newEntity->facingLeft = self->ext.generic.unk84.U8.unk0;
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi -= 4;
                     } else {
                         newEntity->posX.i.hi += 4;
@@ -400,7 +400,7 @@ void EntityBloodyZombie(Entity* self) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;
                 newEntity->posY.i.hi += 16;
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi -= 8;
                 } else {
                     newEntity->posX.i.hi += 8;

--- a/src/st/np3/4B018.c
+++ b/src/st/np3/4B018.c
@@ -14,7 +14,7 @@ void func_801CD540(Entity* self) {
         InitializeEntity(D_80180B20);
     }
 
-    self->facing = self[-1].facing;
+    self->facingLeft = self[-1].facingLeft;
     self->posX.i.hi = self[-1].posX.i.hi;
     self->posY.i.hi = self[-1].posY.i.hi;
     hitbox = D_80182914;
@@ -63,7 +63,7 @@ void func_801CD734() {
 }
 
 void func_801CD78C(Entity* src, s32 speed, s16 angle, Entity* dst) {
-    if (g_CurrentEntity->facing != 0) {
+    if (g_CurrentEntity->facingLeft != 0) {
         angle = -angle;
     }
 
@@ -78,7 +78,7 @@ void func_801CD83C(Entity* self) {
     s16 angle = self->ext.GH_Props.unk9C;
     Entity* src;
 
-    if (g_CurrentEntity->facing != 0) {
+    if (g_CurrentEntity->facingLeft != 0) {
         angle = -angle;
     }
 
@@ -97,7 +97,7 @@ void func_801CD91C(Entity* self) {
     s16 angle = self->ext.GH_Props.unk9C;
     Entity* src;
 
-    if (g_CurrentEntity->facing != 0) {
+    if (g_CurrentEntity->facingLeft != 0) {
         angle = -angle;
     }
     src = self->ext.GH_Props.unkA0;
@@ -232,13 +232,13 @@ void func_801CE04C(Entity* entity, Collider* collider) {
         var_s0 = 1;
         if (collider->effects & 0x8000) {
             if (collider->effects & 0x4000) {
-                if (g_CurrentEntity->facing != 0) {
+                if (g_CurrentEntity->facingLeft != 0) {
                     var_s0 = 4;
                 } else {
                     var_s0 = 2;
                 }
             } else {
-                if (g_CurrentEntity->facing != 0) {
+                if (g_CurrentEntity->facingLeft != 0) {
                     var_s0 = 2;
                 } else {
                     var_s0 = 4;
@@ -351,7 +351,7 @@ s32 func_801CE4CC(Entity* self) {
     }
 
     x = self->posX.i.hi - PLAYER.posX.i.hi;
-    if (g_CurrentEntity->facing != 0) {
+    if (g_CurrentEntity->facingLeft != 0) {
         x = -x;
     }
 
@@ -366,11 +366,11 @@ s32 func_801CE4CC(Entity* self) {
         entity = g_CurrentEntity + 13;
     }
 
-    if (func_801CE120(entity, g_CurrentEntity->facing) != 0) {
+    if (func_801CE120(entity, g_CurrentEntity->facingLeft) != 0) {
         func_801CE1E8(7);
         return;
     }
-    if (func_801CE120(entity, g_CurrentEntity->facing ^ 1) != 0) {
+    if (func_801CE120(entity, g_CurrentEntity->facingLeft ^ 1) != 0) {
         func_801CE1E8(5);
         return;
     }

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -192,7 +192,7 @@ void EntityGurkhaSword(Entity* self) {
         break;
 
     case 2:
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-8);
         } else {
             self->velocityX = FIX(8);
@@ -208,7 +208,7 @@ void EntityGurkhaSword(Entity* self) {
         self->hitboxOffX = (u32)rsin(self->rotAngle) >> 8;
         self->hitboxOffY = -(rcos(angle) * 16) >> 0xC;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX -= FIX(0.25);
         } else {
             self->velocityX += FIX(0.25);
@@ -336,7 +336,7 @@ s32 func_801D0B78(void) {
         break;
     }
 
-    if (g_CurrentEntity->facing != ((GetSideToPlayer() & 1) ^ 1)) {
+    if (g_CurrentEntity->facingLeft != ((GetSideToPlayer() & 1) ^ 1)) {
         ret = 12;
     }
     return ret;
@@ -400,7 +400,7 @@ void EntityBladeSword(Entity* self) {
         break;
 
     case 8:
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-8.0);
         } else {
             self->velocityX = FIX(8.0);
@@ -431,7 +431,7 @@ void EntityBladeSword(Entity* self) {
     }
 
     angle = self->rotAngle;
-    if (self->facing != 0) {
+    if (self->facingLeft != 0) {
         angle = -angle;
     }
 

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -381,7 +381,7 @@ void func_801B19A0(Entity* self) {
         self->velocityX = rnd * rcos(rnd2);
         self->velocityY = rnd * rsin(rnd2);
         if (self->velocityX < 0) {
-            self->facing = 1;
+            self->facingLeft = 1;
         }
 
     case 1:
@@ -1428,7 +1428,7 @@ void func_801B3C38(Entity* self) {
         if (self->params & 0xF0) {
             self->palette = 0x819F;
             self->blendMode = 0x10;
-            self->facing = 1;
+            self->facingLeft = 1;
         }
         break;
 
@@ -1516,7 +1516,7 @@ void func_801B3C38(Entity* self) {
         if (self->step_s == 0) {
             rnd = Random();
             self->velocityY = FIX(-0.75);
-            self->facing = rnd & 1;
+            self->facingLeft = rnd & 1;
             self->unk1A = 0xC0;
             self->unk19 |= 1;
             self->step_s++;

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -276,7 +276,7 @@ void EntitySlogra(Entity* self) {
 
     case SLOGRA_WALKING_WITH_SPEAR:
         if (self->step_s == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             if (self->ext.GS_Props.attackMode != 0) { // shoot projectile ?
                 self->ext.GS_Props.flag = 1;
             } else {
@@ -286,9 +286,9 @@ void EntitySlogra(Entity* self) {
             self->step_s++;
         }
         AnimateEntity(D_80181074, self);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
 
-        if (self->facing != self->ext.GS_Props.flag) {
+        if (self->facingLeft != self->ext.GS_Props.flag) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -342,7 +342,7 @@ void EntitySlogra(Entity* self) {
     case SLOGRA_SPEAR_FIRE:
         switch (self->step_s) {
         case SLOGRA_FIRE_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
 
         case SLOGRA_FIRE_PROJECTILE:
@@ -352,13 +352,13 @@ void EntitySlogra(Entity* self) {
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(
                         E_SLOGRA_SPEAR_PROJECTILE, self, newEntity);
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi += 68;
                     } else {
                         newEntity->posX.i.hi -= 68;
                     }
                     newEntity->posY.i.hi -= 6;
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                     newEntity->zPriority = self->zPriority + 1;
                 }
                 SetSubStep(SLOGRA_FIRE_COOLDOWN);
@@ -437,15 +437,15 @@ void EntitySlogra(Entity* self) {
 
     case SLOGRA_WALKING_WITHOUT_SPEAR:
         if (self->step_s == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.flag = 1;
             self->ext.GS_Props.timer = 128;
             self->step_s++;
         }
         AnimateEntity(D_801810FC, self);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
 
-        if (!(self->facing == self->ext.GS_Props.flag)) {
+        if (!(self->facingLeft == self->ext.GS_Props.flag)) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -604,7 +604,7 @@ void EntitySlograSpear(Entity* self) {
         InitializeEntity(D_80180D18);
 
     case 1:
-        self->facing = self[-1].facing;
+        self->facingLeft = self[-1].facingLeft;
         self->posX.i.hi = self[-1].posX.i.hi;
         self->posY.i.hi = self[-1].posY.i.hi;
         hitbox = D_801811E0;
@@ -623,7 +623,7 @@ void EntitySlograSpear(Entity* self) {
         case 0:
             self->unk19 = 4;
             self->hitboxState = 0;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = FIX(-2.25);
             } else {
                 self->velocityX = FIX(2.25);
@@ -661,7 +661,7 @@ void EntitySlograSpearProjectile(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(D_80180D24);
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-4);
         } else {
             self->velocityX = FIX(4);
@@ -744,7 +744,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_FLY_TOWARDS_PLAYER:
         switch (self->step_s) {
         case GAIBON_FLY_TOWARDS_PLAYER_BEGIN:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.angle =
                 ratan2((PLAYER.posY.i.hi - 32) - self->posY.i.hi,
                        PLAYER.posX.i.hi - self->posX.i.hi);
@@ -773,7 +773,7 @@ void EntityGaibon(Entity* self) {
             if (self->animFrameIdx == 1 && self->animFrameDuration == 0) {
                 func_801C29B0(NA_SE_EN_GAIBON_FLAP_WINGS);
             }
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.GS_Props.timer--;
             if (self->ext.GS_Props.timer == 0) {
                 self->step_s++;
@@ -797,7 +797,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_FLY_SHOOT_FIREBALLS:
         switch (self->step_s) {
         case GAIBON_FLY_SHOOT_FIREBALLS_BEGIN:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             newEntity = &PLAYER;
             var_s3 = newEntity->posX.i.hi;
             if (GetSideToPlayer() & 1) {
@@ -846,7 +846,7 @@ void EntityGaibon(Entity* self) {
                         E_GAIBON_SMALL_FIREBALL, self, newEntity);
                     func_801C29B0(NA_SE_EN_GAIBON_SMALL_FIREBALL);
                     newEntity->posY.i.hi -= 2;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
@@ -915,7 +915,7 @@ void EntityGaibon(Entity* self) {
     case GAIBON_SHOOT_FROM_GROUND:
         switch (self->step_s) {
         case GAIBON_SHOOT_FROM_GROUND_FACE_PLAYER:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->step_s++;
 
         case GAIBON_SHOOT_FROM_GROUND_FACE_SETUP:
@@ -942,7 +942,7 @@ void EntityGaibon(Entity* self) {
                         func_801C29B0(NA_SE_EN_GAIBON_BIG_FIREBALL);
                     }
                     newEntity->posY.i.hi -= 6;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0;
                         newEntity->posX.i.hi += 16;
                     } else {
@@ -975,7 +975,7 @@ void EntityGaibon(Entity* self) {
                         E_GAIBON_BIG_FIREBALL, self, newEntity);
                     func_801C29B0(NA_SE_EN_GAIBON_BIG_FIREBALL);
                     newEntity->posY.i.hi -= 2;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->unk1E = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
@@ -986,7 +986,7 @@ void EntityGaibon(Entity* self) {
                 }
             }
             self->velocityY = FIX(-2);
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = FIX(-2);
             } else {
                 self->velocityX = FIX(2);
@@ -1009,9 +1009,9 @@ void EntityGaibon(Entity* self) {
         switch (self->step_s) {
         case GAIBON_PICKUP_SLOGRA_SETUP:
             if (SLOGRA.posX.i.hi - self->posX.i.hi > 0) {
-                self->facing = 1;
+                self->facingLeft = 1;
             } else {
-                self->facing = 0;
+                self->facingLeft = 0;
             }
             self->ext.GS_Props.speed = 0;
             self->step_s++;
@@ -1239,7 +1239,7 @@ void func_801B69E8(Entity* self) {
     }
 
     prevEntity = &self[-1];
-    self->facing = prevEntity->facing;
+    self->facingLeft = prevEntity->facingLeft;
     self->palette = prevEntity->palette;
     self->posX.i.hi = prevEntity->posX.i.hi;
     self->posY.i.hi = prevEntity->posY.i.hi;

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -927,7 +927,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/nz0/43708.c
+++ b/src/st/nz0/43708.c
@@ -38,7 +38,7 @@ void func_801C3708(void) {
 
     if (g_CurrentEntity->ext.generic.unk7C.U8.unk0 == 0) {
         if (GetDistanceToPlayerX() < 64) {
-            if (g_CurrentEntity->facing != (GetSideToPlayer() & 1)) {
+            if (g_CurrentEntity->facingLeft != (GetSideToPlayer() & 1)) {
                 SetStep(BONE_SCIMITAR_ATTACK);
             }
         }
@@ -85,9 +85,9 @@ void EntityBoneScimitar(Entity* self) {
 
     case BONE_SCIMITAR_WALK_TOWARDS_PLAYER:
         if (AnimateEntity(D_80182090, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
-        self->ext.generic.unk80.modeS8.unk0 = self->facing;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft;
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
             self->velocityX = FIX(-0.5);
@@ -103,9 +103,9 @@ void EntityBoneScimitar(Entity* self) {
 
     case BONE_SCIMITAR_WALK_AWAY_FROM_PLAYER:
         if (AnimateEntity(D_801820A0, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
-        self->ext.generic.unk80.modeS8.unk0 = self->facing ^ 1;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft ^ 1;
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
             self->velocityX = FIX(-0.5);
@@ -189,9 +189,9 @@ void EntityBoneScimitar(Entity* self) {
         break;
 
     case BONE_SCIMITAR_SPECIAL:
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         func_801BCF74(&D_8018216C);
-        if (((((u32)self->velocityX) >> 0x1F) ^ self->facing) != 0) {
+        if (((((u32)self->velocityX) >> 0x1F) ^ self->facingLeft) != 0) {
             AnimateEntity(D_80182090, self);
         } else {
             AnimateEntity(D_801820A0, self);
@@ -233,11 +233,11 @@ void EntityBoneScimitar(Entity* self) {
                 break;
             }
             CreateEntityFromCurrentEntity(E_BONE_SCIMITAR_HEAD, newEntity);
-            newEntity->facing = self->facing;
+            newEntity->facingLeft = self->facingLeft;
             newEntity->params = i;
             newEntity->ext.generic.unk88.S8.unk0 = D_801820F4[i];
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 newEntity->posX.i.hi -= D_80182134[i];
             } else {
                 newEntity->posX.i.hi += D_80182134[i];
@@ -285,7 +285,7 @@ void EntityBoneScimitarParts(Entity* entity) {
     entity->unk19 = 4;
     entity->animCurFrame = *(u8*)&entity->params + 16;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         entity->velocityX = -entity->velocityX;
     }
 

--- a/src/st/nz0/43F9C.c
+++ b/src/st/nz0/43F9C.c
@@ -93,21 +93,21 @@ void EntityAxeKnight(Entity* self) {
     switch (self->step) {
     case AXE_KNIGHT_INIT:
         InitializeEntity(D_80180C64);
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         self->hitboxOffY = 10;
         self->ext.generic.unk7C.S8.unk1 = 0;
         self->ext.generic.unk80.modeS16.unk2 = 512;
 
     case AXE_KNIGHT_IDLE:
         if (func_801BCCFC(&D_80182188) & 1) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             SetStep(AXE_KNIGHT_WALK_TOWARDS_PLAYER);
         }
         break;
 
     case AXE_KNIGHT_WALK_TOWARDS_PLAYER:
         if (self->step_s == 0) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(-0.1875);
             } else {
                 self->velocityX = FIX(0.1875);
@@ -117,11 +117,11 @@ void EntityAxeKnight(Entity* self) {
 
         animStatus = AnimateEntity(D_80182210, self);
         if (self->animFrameDuration == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
 
         if (animStatus == 0) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(-0.1875);
             } else {
                 self->velocityX = FIX(0.1875);
@@ -133,12 +133,12 @@ void EntityAxeKnight(Entity* self) {
         }
 
         if ((self->animFrameIdx == 1) || (self->animFrameIdx == 4)) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX -= 0x300;
             } else {
                 self->velocityX += 0x300;
             }
-        } else if (self->facing != 0) {
+        } else if (self->facingLeft != 0) {
             self->velocityX -= 0x300;
         } else {
             self->velocityX += 0x300;
@@ -153,7 +153,7 @@ void EntityAxeKnight(Entity* self) {
 
     case AXE_KNIGHT_WALK_AWAY_FROM_PLAYER:
         if (self->step_s == 0) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(0.1875);
             } else {
                 self->velocityX = FIX(-0.1875);
@@ -163,10 +163,10 @@ void EntityAxeKnight(Entity* self) {
 
         animStatus = AnimateEntity(D_80182210, self);
         if (self->animFrameDuration == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
         if (animStatus == 0) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = FIX(0.1875);
             } else {
                 self->velocityX = FIX(-0.1875);
@@ -179,12 +179,12 @@ void EntityAxeKnight(Entity* self) {
         }
 
         if ((self->animFrameIdx == 1) || (self->animFrameIdx == 4)) {
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX += 0x200;
             } else {
                 self->velocityX -= 0x200;
             }
-        } else if (self->facing != 0) {
+        } else if (self->facingLeft != 0) {
             self->velocityX += 0x200;
         } else {
             self->velocityX -= 0x200;
@@ -213,9 +213,9 @@ void EntityAxeKnight(Entity* self) {
             newEntity = AllocEntity(D_8007A958, &D_8007A958[32]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(E_AXE_KNIGHT_AXE, newEntity);
-                newEntity->facing = self->facing;
+                newEntity->facingLeft = self->facingLeft;
                 newEntity->posY.i.hi -= 12;
-                if (newEntity->facing != 0) {
+                if (newEntity->facingLeft != 0) {
                     newEntity->posX.i.hi += 8;
                 } else {
                     newEntity->posX.i.hi -= 8;
@@ -232,10 +232,10 @@ void EntityAxeKnight(Entity* self) {
                 newEntity = AllocEntity(D_8007A958, &D_8007A958[32]);
                 if (newEntity != NULL) {
                     CreateEntityFromCurrentEntity(E_AXE_KNIGHT_AXE, newEntity);
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                     newEntity->params = 1;
                     newEntity->posY.i.hi += 12;
-                    if (newEntity->facing != 0) {
+                    if (newEntity->facingLeft != 0) {
                         newEntity->posX.i.hi += 8;
                     } else {
                         newEntity->posX.i.hi -= 8;
@@ -265,10 +265,10 @@ void EntityAxeKnight(Entity* self) {
             newEntity = AllocEntity(D_8007A958, &D_8007A958[32]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(E_AXE_KNIGHT_AXE, newEntity);
-                newEntity->facing = self->facing;
+                newEntity->facingLeft = self->facingLeft;
                 newEntity->params = 2;
                 newEntity->posY.i.hi -= 40;
-                if (newEntity->facing != 0) {
+                if (newEntity->facingLeft != 0) {
                     newEntity->posX.i.hi += 16;
                 } else {
                     newEntity->posX.i.hi -= 16;
@@ -338,7 +338,7 @@ void EntityAxeKnightThrowingAxe(Entity* entity) {
         entity->velocityY = D_801822C8[entity->params];
         velocityX = D_801822BC[entity->params];
 
-        if (entity->facing == 0) {
+        if (entity->facingLeft == 0) {
             entity->velocityX = -velocityX;
         } else {
             entity->velocityX = velocityX;
@@ -355,7 +355,7 @@ void EntityAxeKnightThrowingAxe(Entity* entity) {
     case 1:
         EntityAxeKnightRotateAxe();
         if ((u16)entity->ext.generic.unk7C.s < 0x20) {
-            if (entity->facing != 0) {
+            if (entity->facingLeft != 0) {
                 entity->velocityX -= FIX(0.125);
             } else {
                 entity->velocityX += FIX(0.125);

--- a/src/st/nz0/44EAC.c
+++ b/src/st/nz0/44EAC.c
@@ -60,7 +60,7 @@ void EntityBloodSplatter(Entity* self) {
             *(u16*)&prim->next->b2 = 0x10;
             *(s32*)&prim->next->r1 = -0x6000;
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 *(s32*)&prim->next->u0 = 0xA000;
                 prim->next->tpage = 0x200;
                 prim->next->x1 = prim->next->x1 + 4;
@@ -93,7 +93,7 @@ void EntityBloodSplatter(Entity* self) {
             *(u16*)&prim->next->b2 = 0x10;
             prim->next->b3 = 0x80;
             *(s32*)&prim->next->r1 = -0x8000;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 *(s32*)&prim->next->u0 = 0xC000;
                 *(s16*)&prim->next->tpage = 0x200;
             } else {
@@ -123,7 +123,7 @@ void EntityBloodSplatter(Entity* self) {
         prim2 = prim->next;
         *(s32*)&prim2->r1 += 0xC00;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             prim->next->tpage += 0x18;
         } else {
             prim->next->tpage = prim->next->tpage - 0x18;
@@ -180,7 +180,7 @@ void func_801C53AC(Primitive* prim) {
         prim->next->x1 = g_CurrentEntity->posX.i.hi;
         prim->next->y0 = g_CurrentEntity->posY.i.hi;
 
-        if (g_CurrentEntity->facing != 0) {
+        if (g_CurrentEntity->facingLeft != 0) {
             prim->next->x1 -= 8;
         } else {
             prim->next->x1 += 8;
@@ -250,7 +250,7 @@ void EntityBloodyZombie(Entity* self) {
         AnimateEntity(D_801822EC, self);
         func_801BCF74(D_801822E4);
 
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-0.375);
         } else {
             self->velocityX = FIX(0.375);
@@ -258,14 +258,14 @@ void EntityBloodyZombie(Entity* self) {
 
         if (--self->ext.generic.unk80.modeS16.unk0 == 0) {
             self->ext.generic.unk80.modeS16.unk0 = 128;
-            self->facing ^= 1;
+            self->facingLeft ^= 1;
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2C, self, newEntity);
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi += 16;
                 } else {
                     newEntity->posX.i.hi -= 16;
@@ -274,19 +274,19 @@ void EntityBloodyZombie(Entity* self) {
             }
         }
         facing = GetSideToPlayer() & 1;
-        if (PLAYER.facing == facing && GetDistanceToPlayerX() < 128) {
-            self->facing = facing ^ 1;
+        if (PLAYER.facingLeft == facing && GetDistanceToPlayerX() < 128) {
+            self->facingLeft = facing ^ 1;
             SetStep(BLOODY_ZOMBIE_CHASE);
         }
         break;
 
     case BLOODY_ZOMBIE_CHASE:
         if (AnimateEntity(D_8018237C, self) == 0) {
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
         }
         func_801BCF74(D_801822E4);
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             self->velocityX = FIX(0.75);
         } else {
             self->velocityX = FIX(-0.75);
@@ -296,7 +296,7 @@ void EntityBloodyZombie(Entity* self) {
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2C, self, newEntity);
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi += 18;
                 } else {
                     newEntity->posX.i.hi -= 18;
@@ -326,7 +326,7 @@ void EntityBloodyZombie(Entity* self) {
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2D, self, newEntity);
-                newEntity->facing = GetSideToPlayer() & 1;
+                newEntity->facingLeft = GetSideToPlayer() & 1;
             }
             self->step_s++;
         }
@@ -357,8 +357,8 @@ void EntityBloodyZombie(Entity* self) {
                 newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x2D, self, newEntity);
-                    newEntity->facing = self->ext.generic.unk84.U8.unk0;
-                    if (self->facing != 0) {
+                    newEntity->facingLeft = self->ext.generic.unk84.U8.unk0;
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi -= 4;
                     } else {
                         newEntity->posX.i.hi += 4;
@@ -400,7 +400,7 @@ void EntityBloodyZombie(Entity* self) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;
                 newEntity->posY.i.hi += 16;
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi -= 8;
                 } else {
                     newEntity->posX.i.hi += 8;

--- a/src/st/nz0/45F2C.c
+++ b/src/st/nz0/45F2C.c
@@ -43,8 +43,8 @@ void EntitySkeleton(Entity* self) {
         break;
 
     case SKELETON_WALK_TOWARDS_PLAYER:
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
-        self->ext.generic.unk80.modeS8.unk0 = self->facing;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft;
         AnimateEntity(D_801823DC, self);
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
@@ -60,8 +60,8 @@ void EntitySkeleton(Entity* self) {
         break;
 
     case SKELETON_WALK_AWAY_FROM_PLAYER:
-        self->facing = (GetSideToPlayer() & 1) ^ 1;
-        self->ext.generic.unk80.modeS8.unk0 = self->facing ^ 1;
+        self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
+        self->ext.generic.unk80.modeS8.unk0 = self->facingLeft ^ 1;
         AnimateEntity(D_801823EC, self);
 
         if (self->ext.generic.unk80.modeS8.unk0 == 0) {
@@ -93,13 +93,13 @@ void EntitySkeleton(Entity* self) {
                 if (newEntity != NULL) { // Spawn bone
                     func_801C29B0(NA_SE_EN_SKELETON_THROW_BONE);
                     CreateEntityFromCurrentEntity(0x2F, newEntity);
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi -= 8;
                     } else {
                         newEntity->posX.i.hi += 8;
                     }
                     newEntity->posY.i.hi -= 16;
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                 }
             }
         }
@@ -153,10 +153,10 @@ void EntitySkeleton(Entity* self) {
             newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(0x30, newEntity);
-                newEntity->facing = self->facing;
+                newEntity->facingLeft = self->facingLeft;
                 newEntity->params = i;
                 newEntity->ext.generic.unk88.S8.unk0 = D_80182430[i];
-                if (self->facing != 0) {
+                if (self->facingLeft != 0) {
                     newEntity->posX.i.hi -= D_80182468[i];
                 } else {
                     newEntity->posX.i.hi += D_80182468[i];
@@ -194,7 +194,7 @@ void func_801C6494(Entity* entity) { // From skeleton death explosion
     entity->unk19 = 4;
     entity->animCurFrame = entity->params + 15;
 
-    if (entity->facing != 0) {
+    if (entity->facingLeft != 0) {
         entity->velocityX = -entity->velocityX;
     }
 }
@@ -223,7 +223,7 @@ void func_801C6574(Entity* entity) { // Bone Projectile from Skeleton
         xDistanceToPlayer /= 32;
         xDistanceToPlayer = CLAMP_MAX(xDistanceToPlayer, 7);
         velocityX = D_80182488[xDistanceToPlayer];
-        xDistanceToPlayer = entity->facing;
+        xDistanceToPlayer = entity->facingLeft;
 
         if (xDistanceToPlayer > 0) {
             velocityX = -velocityX;
@@ -246,7 +246,7 @@ void func_801C6678(Entity* entity) { // From Skeleton
         return;
     }
 
-    entity->facing = entity[-1].facing;
+    entity->facingLeft = entity[-1].facingLeft;
     entity->zPriority = entity[-1].zPriority - 1;
     entity->animCurFrame = entity[-1].animCurFrame;
     entity->posX.i.hi = entity[-1].posX.i.hi;

--- a/src/st/nz0/4672C.c
+++ b/src/st/nz0/4672C.c
@@ -20,7 +20,7 @@ void EntitySpittleBone(Entity* self) {
         self->unk19 = 4;
         self->rotAngle = 0;
         self->flags &= ~(FLAG_UNK_2000 | 0x200);
-        self->facing = self->params;
+        self->facingLeft = self->params;
         break;
 
     case 1:
@@ -28,9 +28,9 @@ void EntitySpittleBone(Entity* self) {
             newEntity = &self[1];
             self->ext.spittleBone.unk7C = 0;
             CreateEntityFromEntity(E_ROTATE_SPITTLEBONE, self, newEntity);
-            newEntity->facing = self->facing;
+            newEntity->facingLeft = self->facingLeft;
             newEntity->ext.spittleBone.unk7C = self->ext.spittleBone.unk7C;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = FIX(1);
                 newEntity->posX.i.hi += 16;
             } else {
@@ -71,7 +71,7 @@ void EntitySpittleBone(Entity* self) {
             newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 func_801C1780(E_SPITTLEBONE, self, newEntity);
-                newEntity->facing = self->facing;
+                newEntity->facingLeft = self->facingLeft;
                 newEntity->flags = FLAG_UNK_2000 | FLAG_UNK_08000000 |
                                    FLAG_DESTROY_IF_BARELY_OUT_OF_CAMERA |
                                    FLAG_DESTROY_IF_OUT_OF_CAMERA;
@@ -143,7 +143,7 @@ void EntityRotateSpittlebone(Entity* self) {
                 rotAngle = D_801824DC[temp4 & 3];
             }
 
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 rotAngle = -rotAngle;
             }
 
@@ -189,7 +189,7 @@ void EntitySpittleBoneSpit(Entity* self) {
     case 1:
         entity = self->ext.spittleBone.unk84;
         if ((entity->rotAngle & 0xFFF) == 0x800) {
-            if (entity->facing != 0) {
+            if (entity->facingLeft != 0) {
                 self->posX.i.hi = entity->posX.i.hi - 3;
             } else {
                 self->posX.i.hi = entity->posX.i.hi + 3;

--- a/src/st/nz0/47048.c
+++ b/src/st/nz0/47048.c
@@ -90,7 +90,7 @@ void EntitySubWeaponContainer(Entity* self) {
                 newEntity->posY.i.hi += glassPieceTBL->posY;
                 newEntity->ext.generic.unk84.S16.unk0 = glassPieceTBL->posX;
                 newEntity->params = glassPieceTBL->params;
-                newEntity->facing = glassPieceTBL->facing;
+                newEntity->facingLeft = glassPieceTBL->facingLeft;
                 newEntity->ext.generic.unk84.S16.unk2 = self->params;
             }
             glassPieceTBL++;
@@ -166,13 +166,13 @@ void func_801C7538(Entity* entity) {
         entity->velocityY += FIX(0.125);
 
         if (entity->velocityX != 0) {
-            if (entity->facing == 0) {
+            if (entity->facingLeft == 0) {
                 new_var = (u16)entity->rotAngle - 16;
                 var_v0 = new_var;
             } else {
                 var_v0 = entity->rotAngle + 16;
             }
-        } else if (entity->facing != 0) {
+        } else if (entity->facingLeft != 0) {
             var_v0 = entity->rotAngle - 16;
         } else {
             var_v0 = entity->rotAngle + 16;

--- a/src/st/nz0/47958.c
+++ b/src/st/nz0/47958.c
@@ -25,7 +25,7 @@ void EntityBloodSkeleton(Entity* self) {
     switch (self->step) {
     case BLOOD_SKELETON_INIT:
         InitializeEntity(D_80180C40);
-        self->facing = (u32)Random() % 2;
+        self->facingLeft = (u32)Random() % 2;
         self->animCurFrame = 1;
         self->flags &= 0x1FFFFFFF;
         self->palette += self->params;
@@ -40,7 +40,7 @@ void EntityBloodSkeleton(Entity* self) {
 
     case BLOOD_SKELETON_WALK:
         if (self->animFrameDuration == 0) {
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->posX.i.hi += D_80182624[self->animFrameIdx];
             } else {
                 self->posX.i.hi -= D_80182624[self->animFrameIdx];
@@ -49,11 +49,11 @@ void EntityBloodSkeleton(Entity* self) {
 
         if ((AnimateEntity(D_80182610, self) == 0) &&
             (GetDistanceToPlayerY() < 48) && (Random() % 4) == 0) {
-            self->facing = GetSideToPlayer() % 2 == 0;
+            self->facingLeft = GetSideToPlayer() % 2 == 0;
         }
 
-        if ((u8)func_801C070C(&D_801826AC, self->facing) != 2) {
-            self->facing ^= 1;
+        if ((u8)func_801C070C(&D_801826AC, self->facingLeft) != 2) {
+            self->facingLeft ^= 1;
         }
         break;
 

--- a/src/st/nz0/nz0.h
+++ b/src/st/nz0/nz0.h
@@ -303,7 +303,7 @@ typedef struct SubWpnContDebris {
     u16 posX;
     u16 posY;
     u16 params;
-    u16 facing;
+    u16 facingLeft;
 } SubWpnContDebris;
 
 extern SubWpnContDebris D_80182584[ENTITY_SUBWPNCONT_DEBRIS_COUNT];

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -454,7 +454,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/sel/3410C.c
+++ b/src/st/sel/3410C.c
@@ -510,7 +510,7 @@ void func_801B54C8(void) {
     if (e->step == 0) {
         e->animSet = ANIMSET_OVL(2);
         e->animCurFrame = 38;
-        e->facing = 1;
+        e->facingLeft = 1;
         e->unk5A = 0xF;
         e->ext.generic.unk80.modeS32 = 0x780000;
         e->posY.i.hi = 158;
@@ -531,7 +531,7 @@ void func_801B5548(void) {
         e->posY.i.hi = 158;
         e->zPriority = 0xC0;
         e->palette = 0x8210;
-        e->facing = 0;
+        e->facingLeft = 0;
         e->step = 1;
     }
 }

--- a/src/st/sel/3585C.c
+++ b/src/st/sel/3585C.c
@@ -51,7 +51,7 @@ void func_801B585C(u16 arg0) {
         break;
 
     case 5:
-        e->facing = 1;
+        e->facingLeft = 1;
         if (!(AnimateEntity(D_80180528, e) & 0xFF)) {
             func_801B4B9C(e, 6);
         }
@@ -113,7 +113,7 @@ void func_801B5A7C(void) {
                 D_800737D4 = 0;
             } while (0);
             g_Entities[5].animFrameDuration = 0;
-            g_Entities[5].facing = 1;
+            g_Entities[5].facingLeft = 1;
             e->step++;
             break;
 

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -108,7 +108,7 @@ void func_801A805C(Entity* self) {
         if (self->unk44 != 0) {
             params_ = params - 2;
             if (params_ < 2) {
-                self->facing = GetSideToPlayer() & 1;
+                self->facingLeft = GetSideToPlayer() & 1;
                 posY = self->posY.i.hi - 40;
 
                 if (params == 2) {
@@ -129,7 +129,7 @@ void func_801A805C(Entity* self) {
                         CreateEntityFromEntity(E_ID_26, self, newEntity);
                         newEntity->posY.i.hi = posY;
                         newEntity->params = *paramsPtr;
-                        newEntity->facing = self->facing;
+                        newEntity->facingLeft = self->facingLeft;
                     }
                     newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                     if (newEntity != NULL) {
@@ -216,7 +216,7 @@ void func_801A8328(Entity* self) {
             prim->blendMode = 2;
             velX = ((Random() & 7) << 0xC) + 0x8000;
             self->velocityX = velX;
-            if (self->facing == 0) {
+            if (self->facingLeft == 0) {
                 self->velocityX = -velX;
             }
             self->velocityY = ((Random() & 7) << 0xC) - 0x8000;
@@ -233,7 +233,7 @@ void func_801A8328(Entity* self) {
         prim->next->x1 = self->posX.i.hi;
         prim->next->y0 = self->posY.i.hi;
 
-        if (self->facing != 0) {
+        if (self->facingLeft != 0) {
             prim->next->tpage += 0x10;
         } else {
             prim->next->tpage -= 0x10;

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -45,7 +45,7 @@ void EntityDracula(Entity* self) {
         self->animCurFrame = 0x4F;
         self->ext.dracula.unkA1 = 1;
         self->hitboxState = 0;
-        self->facing = 1;
+        self->facingLeft = 1;
         CreateEntityFromCurrentEntity(0x1D, &self[1]);
         self[1].zPriority = self->zPriority + 1;
 
@@ -96,7 +96,7 @@ void EntityDracula(Entity* self) {
                 newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x1F, self, newEntity);
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                     newEntity->posX.i.hi -= 8;
                     newEntity->posY.i.hi -= 24;
                 }
@@ -160,7 +160,7 @@ void EntityDracula(Entity* self) {
             if (self->ext.dracula.unkA0 != 0) {
                 g_api.PlaySfx(NA_SE_VO_DR_TAUNT_1);
                 self->animCurFrame = 1;
-                self->facing = (GetSideToPlayer() & 1) ^ 1;
+                self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
                 self->ext.dracula.unkA0 = 0;
             }
             if (self->ext.dracula.unk9C != 0xFF) {
@@ -170,7 +170,7 @@ void EntityDracula(Entity* self) {
             break;
 
         case 3:
-            self->facing = (GetSideToPlayer() & 1) ^ 1;
+            self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.dracula.unkA2 = (self->ext.dracula.unkA2 + 1) & 3;
             self->hitboxState = 3;
             if (self->ext.dracula.unkA2 == 0) {
@@ -204,10 +204,10 @@ void EntityDracula(Entity* self) {
                 newEntity = AllocEntity(&g_Entities[160], &g_Entities[192]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x1B, self, newEntity);
-                    newEntity->facing = self->facing;
+                    newEntity->facingLeft = self->facingLeft;
                     newEntity->zPriority = self->zPriority + 1;
                     newEntity->params = i;
-                    if (self->facing != 0) {
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi -= 24;
                     } else {
                         newEntity->posX.i.hi += 24;
@@ -242,8 +242,8 @@ void EntityDracula(Entity* self) {
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x1C, self, newEntity);
                     index = self->step_s - 1;
-                    newEntity->facing = self->facing;
-                    if (self->facing != 0) {
+                    newEntity->facingLeft = self->facingLeft;
+                    if (self->facingLeft != 0) {
                         newEntity->posX.i.hi += D_80180A58[index].x;
                     } else {
                         newEntity->posX.i.hi -= D_80180A58[index].x;
@@ -430,9 +430,9 @@ void EntityDracula(Entity* self) {
                 prim = prim->next;
             }
             CreateEntityFromCurrentEntity(0x2B, &self[2]);
-            self[2].facing = self->facing;
+            self[2].facingLeft = self->facingLeft;
             CreateEntityFromCurrentEntity(0x20, &self[5]);
-            self[5].facing = self->facing;
+            self[5].facingLeft = self->facingLeft;
             self[5].posY.i.hi += 2;
             self->step_s++;
             break;
@@ -495,7 +495,7 @@ void EntityDraculaBody(Entity* self) {
         self->hitboxHeight = 34;
         break;
     case 1:
-        self->facing = self[-1].facing;
+        self->facingLeft = self[-1].facingLeft;
         self->posX.i.hi = self[-1].posX.i.hi;
         self->posY.i.hi = self[-1].posY.i.hi;
         self->hitboxState = self[-1].hitboxState & 0xFFFD;
@@ -526,7 +526,7 @@ void EntityDraculaFireball(Entity* self) {
     case 0:
         InitializeEntity(D_801805EC);
 
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             self->velocityX = FIX(-2);
         } else {
             self->velocityX = FIX(2);
@@ -590,7 +590,7 @@ void EntityDraculaMeteorball(Entity* entity) {
             speedX = 0xE00;
         }
 
-        if (entity->facing != 0) {
+        if (entity->facingLeft != 0) {
             entity->velocityX += speedX;
         } else {
             entity->velocityX -= speedX;
@@ -721,7 +721,7 @@ void EntityDraculaMegaFireball(Entity* self) {
             self->unk1A = 0x80;
             self->unk19 |= 7;
             self->rotAngle = 0x1C0 - angle;
-            if (self->facing != 0) {
+            if (self->facingLeft != 0) {
                 self->velocityX = rcos(angle) * 0x60;
             } else {
                 self->velocityX = -(rcos(angle) * 0x60);

--- a/src/st/st0/31CA0.c
+++ b/src/st/st0/31CA0.c
@@ -869,7 +869,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -934,7 +934,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
         g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
-        if (player->facing != 1) {
+        if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;
         }

--- a/src/weapon/shared.h
+++ b/src/weapon/shared.h
@@ -108,7 +108,7 @@ void DecelerateY(s32 amount) {
 }
 
 void SetSpeedX(s32 speed) {
-    if (g_CurrentEntity->facing == 1) {
+    if (g_CurrentEntity->facingLeft == 1) {
         speed = -speed;
     }
     g_CurrentEntity->velocityX = speed;

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -188,7 +188,7 @@ void EntityWeaponAttack(Entity* self) {
 
     self->posX.val = g_Entities->posX.val;
     self->posY.val = PLAYER.posY.val;
-    self->facing = PLAYER.facing;
+    self->facingLeft = PLAYER.facingLeft;
     mask = 0x17F;
     sndEvent = &g_SoundEvents[(self->params >> 8) & mask];
 

--- a/src/weapon/w_004.c
+++ b/src/weapon/w_004.c
@@ -9,7 +9,7 @@ void EntityWeaponAttack(Entity* self) {
 
     self->posX.val = g_Entities->posX.val;
     self->posY.val = PLAYER.posY.val;
-    self->facing = PLAYER.facing;
+    self->facingLeft = PLAYER.facingLeft;
     mask = 0x17F;
     sndEvent = &D_20000_8017B2F4[(self->params >> 8) & mask];
 

--- a/src/weapon/w_015.c
+++ b/src/weapon/w_015.c
@@ -7,7 +7,7 @@ void func_ptr_80170004(Entity* self) {
     if (self->step == 0) {
         self->animSet = self->ext.weapon.parent->animSet;
         self->animCurFrame = self->ext.weapon.parent->animCurFrame;
-        self->facing = self->ext.weapon.parent->facing;
+        self->facingLeft = self->ext.weapon.parent->facingLeft;
         self->zPriority = self->ext.weapon.parent->zPriority - 2;
         self->flags = FLAG_UNK_08000000;
         self->palette = self->ext.weapon.parent->palette;

--- a/src/weapon/w_040.c
+++ b/src/weapon/w_040.c
@@ -44,7 +44,7 @@ void EntityWeaponAttack(Entity* self) {
         }
 
         self->zPriority = PLAYER.zPriority + 2;
-        self->facing = PLAYER.facing;
+        self->facingLeft = PLAYER.facingLeft;
         self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
         self->unk4C = D_11C000_8017A804;
         self->posY.i.hi -= 4;
@@ -112,7 +112,7 @@ void func_ptr_80170004(Entity* self) {
         self->animSet = self->ext.weapon.parent->animSet;
         self->unk5A = self->ext.weapon.parent->unk5A;
         self->palette = self->ext.weapon.parent->palette;
-        self->facing = (self->facing + 1) & 1;
+        self->facingLeft = (self->facingLeft + 1) & 1;
         self->flags = FLAG_UNK_08000000;
         self->zPriority = self->ext.weapon.parent->zPriority - 2;
         self->unk4C = D_11C000_8017A724;
@@ -188,7 +188,7 @@ void func_ptr_80170008(Entity* self) {
         self->unk4C = D_11C000_8017A724;
         self->posY.i.hi -= 0xA;
         var_a1 = 0x18;
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             var_a1 = -0x18;
         }
         self->posX.i.hi = var_a1 + self->posX.i.hi;

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -72,7 +72,7 @@ void EntityWeaponAttack(Entity* self) {
         }
 
         self->zPriority = PLAYER.zPriority + 2;
-        self->facing = PLAYER.facing;
+        self->facingLeft = PLAYER.facingLeft;
         self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
         self->unk4C = D_12A000_8017A6B4;
         self->posY.i.hi -= 4;
@@ -142,7 +142,7 @@ void func_ptr_80170004(Entity* self) {
         self->animSet = self->ext.weapon.parent->animSet;
         self->unk5A = self->ext.weapon.parent->unk5A;
         self->palette = self->ext.weapon.parent->palette;
-        self->facing = (self->facing + 1) & 1;
+        self->facingLeft = (self->facingLeft + 1) & 1;
         self->flags = FLAG_UNK_08000000;
         self->zPriority = self->ext.weapon.parent->zPriority - 2;
         self->unk4C = D_12A000_8017A604;
@@ -225,7 +225,7 @@ void func_ptr_80170008(Entity* self) {
         self->unk19 = 4;
         self->zPriority = self->ext.weapon.parent->zPriority - 2;
         self->posY.i.hi -= 0x10;
-        if (self->facing == 0) {
+        if (self->facingLeft == 0) {
             modX = -8;
         } else {
             modX = 8;


### PR DESCRIPTION
A recent discussion on Discord determined that we should change the "facing" variable to "facingLeft", so that it will be clear in all cases what is being tested. For example, in lines like `if (PLAYER.facing == 0 && (g_Player.padPressed & PAD_LEFT)`, the fact that it says facingLeft makes it clear that the player is pressing in the opposite direction they are facing (because facingLeft is 0, or false, and they are pressing left). This makes it obvious that this is some kind of slow-down or turn-around routine, rather than speeding up or walking forward.

This was done with a direct find-and-replace of all instances of `.facing` and `->facing` for `.facingLeft` and `->facingLeft`, followed by changing the struct members in their .h files. I don't think anything else got caught in the crossfire here.