### PR TITLE
Finish EnemyDef struct members

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -892,7 +892,7 @@ typedef struct {
     /* 0x06 */ u16 attack;
     /* 0x08 */ u16 attackElement;
     /* 0x0A */ s16 defense;
-    /* 0x0C */ u16 unkC;
+    /* 0x0C */ u16 hitboxState;
     /* 0x0E */ u16 weaknesses;
     /* 0x10 */ u16 strengths;
     /* 0x12 */ u16 immunes;
@@ -905,7 +905,7 @@ typedef struct {
     /* 0x20 */ u16 uncommonItemDropRate;
     /* 0x22 */ u8 hitboxWidth;
     /* 0x23 */ u8 hitboxHeight;
-    /* 0x24 */ s32 unk24;
+    /* 0x24 */ s32 flags;
 } EnemyDef; /* size=0x28 */
 
 typedef struct {

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -661,10 +661,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -653,10 +653,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -717,10 +717,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -701,10 +701,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -719,10 +719,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/nz0/47958.c
+++ b/src/st/nz0/47958.c
@@ -107,7 +107,7 @@ void EntityBloodSkeleton(Entity* self) {
             if (AnimateEntity(animation, self) == 0) {
                 self->hitPoints = 0;
                 self->hitboxState = 3;
-                self->flags = g_api.enemyDefs[70].unk24 & 0x1FFFFFFF;
+                self->flags = g_api.enemyDefs[70].flags & 0x1FFFFFFF;
                 SetStep(BLOOD_SKELETON_WALK);
             }
         }

--- a/src/st/st0/31CA0.c
+++ b/src/st/st0/31CA0.c
@@ -670,10 +670,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -726,10 +726,10 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->hitPoints = enemyDef->hitPoints;
     g_CurrentEntity->attack = enemyDef->attack;
     g_CurrentEntity->attackElement = enemyDef->attackElement;
-    g_CurrentEntity->hitboxState = enemyDef->unkC;
+    g_CurrentEntity->hitboxState = enemyDef->hitboxState;
     g_CurrentEntity->hitboxWidth = enemyDef->hitboxWidth;
     g_CurrentEntity->hitboxHeight = enemyDef->hitboxHeight;
-    g_CurrentEntity->flags = enemyDef->unk24;
+    g_CurrentEntity->flags = enemyDef->flags;
     g_CurrentEntity->hitboxOffX = 0;
     g_CurrentEntity->hitboxOffY = 0;
     g_CurrentEntity->step_s = 0;


### PR DESCRIPTION
Given that InitializeEntity copies these values from EnemyDef directly into Entity, and we have names for these struct members of Entity, it is reasonable to name the EnemyDef members to match.

Almost all the changes are in InitializeEntity since these struct members are rarely touched. A fairly straightforward find-and-replace.