### PR TITLE
Change analyze_calls to work with removed symbols in `main`

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -142,7 +142,6 @@ def get_sdk_funcs():
 # Many functions in main are not being splatted out yet, so we add them here, like SDK.
 def get_main_funcs():
     functions = []
-    print("getting mains")
     for file in Path("asm/us/main").glob("*.s"):
         with open(file) as f:
             lines = f.readlines()

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -141,16 +141,15 @@ def get_sdk_funcs():
 
 # Many functions in main are not being splatted out yet, so we add them here, like SDK.
 def get_main_funcs():
-    with open(f"config/symbols.us.txt") as f:
-        symbols = f.readlines()
-    index_first_func = next(
-        (i for i, s in enumerate(symbols) if s.startswith("__main")), None
-    )
-    index_last_func = next(
-        (i for i, s in enumerate(symbols) if s.startswith("SpuGetAllKeysStatus")), None
-    )
-    symbols = symbols[index_first_func : index_last_func + 1]
-    return [line.split(" = ")[0] for line in symbols]
+    functions = []
+    print("getting mains")
+    for file in Path("asm/us/main").glob("*.s"):
+        with open(file) as f:
+            lines = f.readlines()
+            for line in lines:
+                if "glabel" in line:
+                    functions.append(line.split()[1])
+    return functions
 
 
 # Functions in gameapi are often strange, especially in the Overlay member.


### PR DESCRIPTION
The classic "it works on my machine" :)

The method we use to gather the functions in `main` (which we do not currently fully process, but need to know about due to them being called in the game's functions) relied on the symbols file being complete. Now that orphan symbols are being removed and things are being moved around, this new method will search for them in a different way.

We look in asm/us/main and collect all files which are in that directory directly (That is, not in a subdirectory). As of now, that is:

asm/us/main/psxsdk_stuff.s
asm/us/main/C464.s
asm/us/main/header.s
asm/us/main/15F4.s

Then, we look for any `glabel` within there. So far, this appears to contain every function called within the game and successfully generate graphs. I can't guarantee that this will work, but I believe it should.

If we're lucky, this will fix the build error on https://github.com/Xeeynamo/sotn-decomp/pull/617