### PR TITLE
Decompile w_016 func_ptr_80170004

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -143,7 +143,7 @@ typedef struct {
 } ET_MessageBox;
 
 typedef struct {
-    /* 0x7C */ s16 unk7C;
+    /* 0x7C */ s16 lifetime;
     /* 0x7E */ s16 unk7E;
     /* 0x80 */ s32 unk80;
     /* 0x84 */ s32 unk84;

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -3,7 +3,31 @@
 
 INCLUDE_ASM("weapon/nonmatchings/w_016", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_016", func_ptr_80170004);
+void func_ptr_80170004(Entity* self) {
+
+    if (self->step == 0) {
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->animCurFrame = self->ext.weapon.parent->animCurFrame;
+        self->facingLeft = self->ext.weapon.parent->facingLeft;
+        self->zPriority = PLAYER.zPriority - 4;
+        self->flags = FLAG_UNK_08000000;
+        self->palette = self->ext.weapon.parent->palette;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->ext.weapon.lifetime = 0x16;
+        self->unk19 = 0xC;
+        self->blendMode = 0x10;
+        self->rotAngle = self->ext.weapon.parent->rotAngle;
+        self->unk6C = 0x80;
+        self->step++;
+    }
+    if (--self->ext.weapon.lifetime == 0) {
+        DestroyEntity(self);
+        return;
+    }
+    if (self->unk6C >= 48) {
+        self->unk6C -= 8;
+    }
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_016", func_ptr_80170008);
 


### PR DESCRIPTION
Another one, this applies to:

Bwaka knife
Boomerang
Javelin
Fire boomerang
Iron ball

There is a value that is set to 0x16 on step 0, and then get decremented every frame until it reaches 0, at which point the entity is destroyed. I therefore named this entry in the struct `lifetime`. There may be other weapons that use this entry differently, but for now this is all we know so I think it's reasonable to go with this for now.