### PR TITLE
PlayerState collider restructure

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1227,7 +1227,7 @@ typedef struct {
 
 typedef struct {
     /* 80072BD0 */ Collider colliders[8];
-    /* 80072CF0 */ s32 D_80072CF0[14][9]; // probably also colliders? can't combine them though
+    /* 80072CF0 */ s32 D_80072CF0[14][9]; // Seems like another collider set
     /* 80072EE8 */ s32 padPressed;
     /* 80072EEC */ s32 padTapped;
     /* 80072EF0 */ s32 padHeld;

--- a/include/game.h
+++ b/include/game.h
@@ -1226,7 +1226,7 @@ typedef struct {
 } FgLayer; /* size=0x8 */
 
 typedef struct {
-    /* 80072BD0 */ s32 D_80072BD0[8][9];
+    /* 80072BD0 */ Collider colliders[8];
     /* 80072CF0 */ s32 D_80072CF0[14][9];
     /* 80072EE8 */ s32 padPressed;
     /* 80072EEC */ s32 padTapped;

--- a/include/game.h
+++ b/include/game.h
@@ -1227,7 +1227,7 @@ typedef struct {
 
 typedef struct {
     /* 80072BD0 */ Collider colliders[8];
-    /* 80072CF0 */ s32 D_80072CF0[14][9];
+    /* 80072CF0 */ s32 D_80072CF0[14][9]; // probably also colliders? can't combine them though
     /* 80072EE8 */ s32 padPressed;
     /* 80072EEC */ s32 padTapped;
     /* 80072EF0 */ s32 padHeld;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -340,11 +340,11 @@ void func_8010BFFC(void) {
             for (i = 0; i < 4; i++) {
                 x = PLAYER.posX.i.hi + D_800ACED0.pairs[i].unk0;
                 y = PLAYER.posY.i.hi + D_800ACED0.pairs[i].unk2;
-                CheckCollision(x, y, (Collider*)&g_Player.D_80072BD0[i][0], 0);
+                CheckCollision(x, y, &g_Player.colliders[i], 0);
             }
-            if ((g_Player.D_80072BD0[1][0] & 0x81) == 1 ||
-                (g_Player.D_80072BD0[2][0] & 0x81) == 1 ||
-                (g_Player.D_80072BD0[3][0] & 0x81) == 1) {
+            if ((g_Player.colliders[1].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[2].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[3].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID) {
                 // I don't know man
                 (*(&PLAYER)).posY.i.hi--;
                 PLAYER.velocityY = 0;
@@ -372,11 +372,11 @@ void func_8010BFFC(void) {
                 }
 #endif
                 CheckCollision(
-                    x, y, (Collider*)&g_Player.D_80072BD0[4 + i][0], 0);
+                    x, y, &g_Player.colliders[4 + i], 0);
             }
-            if ((g_Player.D_80072BD0[5][0] & 0x41) == 1 ||
-                (g_Player.D_80072BD0[6][0] & 0x41) == 1 ||
-                (g_Player.D_80072BD0[7][0] & 0x41) == 1) {
+            if ((g_Player.colliders[5].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[6].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[7].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID) {
                 // I don't know man
                 (*(&PLAYER)).posY.i.hi++;
                 PLAYER.velocityY = 0;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -342,9 +342,12 @@ void func_8010BFFC(void) {
                 y = PLAYER.posY.i.hi + D_800ACED0.pairs[i].unk2;
                 CheckCollision(x, y, &g_Player.colliders[i], 0);
             }
-            if ((g_Player.colliders[1].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
-                (g_Player.colliders[2].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
-                (g_Player.colliders[3].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID) {
+            if ((g_Player.colliders[1].effects &
+                 (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[2].effects &
+                 (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[3].effects &
+                 (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID) {
                 // I don't know man
                 (*(&PLAYER)).posY.i.hi--;
                 PLAYER.velocityY = 0;
@@ -371,12 +374,14 @@ void func_8010BFFC(void) {
                     y += 6;
                 }
 #endif
-                CheckCollision(
-                    x, y, &g_Player.colliders[4 + i], 0);
+                CheckCollision(x, y, &g_Player.colliders[4 + i], 0);
             }
-            if ((g_Player.colliders[5].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
-                (g_Player.colliders[6].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
-                (g_Player.colliders[7].effects & (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID) {
+            if ((g_Player.colliders[5].effects &
+                 (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[6].effects &
+                 (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID ||
+                (g_Player.colliders[7].effects &
+                 (EFFECT_SOLID_FROM_ABOVE + EFFECT_SOLID)) == EFFECT_SOLID) {
                 // I don't know man
                 (*(&PLAYER)).posY.i.hi++;
                 PLAYER.velocityY = 0;

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -189,7 +189,7 @@ void func_801131C4(void) {
     if ((g_Player.padTapped & PAD_CROSS) && !(g_Player.unk46 & PAD_LEFT)) {
         if (g_Player.padPressed & PAD_DOWN) {
             for (i = 0; i < 4; i++) {
-                if ((g_Player.D_80072BD0[i][0] & 0x40)) {
+                if ((g_Player.colliders[i].effects & EFFECT_SOLID_FROM_ABOVE)) {
                     g_Player.D_80072F0E = 8;
                     return;
                 }

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -161,12 +161,14 @@ void func_80116408(void) {
         PLAYER.velocityX = 0;
         if (func_8010E27C() != 0) {
             if (g_Player.padPressed & PAD_RIGHT) {
-                if ((g_Player.colliders[2].effects & (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
+                if ((g_Player.colliders[2].effects &
+                     (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
                     (g_Player.colliders[1].effects & EFFECT_UNK_8000) ||
                     (PLAYER.posX.i.hi > 248)) {
                     SetSpeedX(FIX(3));
                 }
-            } else if ((g_Player.colliders[3].effects & (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
+            } else if ((g_Player.colliders[3].effects &
+                        (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
                        (g_Player.colliders[1].effects & EFFECT_UNK_8000) ||
                        (PLAYER.posX.i.hi < 8)) {
                 SetSpeedX(FIX(3));

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -161,13 +161,13 @@ void func_80116408(void) {
         PLAYER.velocityX = 0;
         if (func_8010E27C() != 0) {
             if (g_Player.padPressed & PAD_RIGHT) {
-                if ((g_Player.D_80072BD0[2][0] & 0x8001) ||
-                    (g_Player.D_80072BD0[1][0] & 0x8000) ||
+                if ((g_Player.colliders[2].effects & (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
+                    (g_Player.colliders[1].effects & EFFECT_UNK_8000) ||
                     (PLAYER.posX.i.hi > 248)) {
                     SetSpeedX(FIX(3));
                 }
-            } else if ((g_Player.D_80072BD0[3][0] & 0x8001) ||
-                       (g_Player.D_80072BD0[1][0] & 0x8000) ||
+            } else if ((g_Player.colliders[3].effects & (EFFECT_UNK_8000 + EFFECT_SOLID)) ||
+                       (g_Player.colliders[1].effects & EFFECT_UNK_8000) ||
                        (PLAYER.posX.i.hi < 8)) {
                 SetSpeedX(FIX(3));
             }

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -416,7 +416,7 @@ void func_8012E550(void) {
     if (g_Player.padTapped & PAD_CROSS) {
         if ((g_Player.padPressed & PAD_DOWN)) {
             for (i = 0; i < 4; i++) {
-                if ((g_Player.D_80072BD0[i][0] & 0x40)) {
+                if ((g_Player.colliders[i].effects & EFFECT_SOLID_FROM_ABOVE)) {
                     g_Player.D_80072F0E = 8;
                     func_8012CED4();
                     PLAYER.animFrameIdx = 4;


### PR DESCRIPTION
A recently decompiled function found that `s32 D_80072BD0[8][9]` was actually an array of Collider. This PR updates that to be correct.

It looks like the struct member right after it should be grouped in to have `colliders[22]` but for whatever reason that doesn't seem to work so I'm leaving it. Given that the struct size matches and everything, we probably have `colliders[8]` and then `colliders2[14]` but without more evidence I don't want to mark this down yet.

Some of these lines come out pretty long like if `((g_Player.colliders[1].effects & (EFFECT_SOLID_FROM_BELOW + EFFECT_SOLID)) == EFFECT_SOLID ||`. Here is what that looks like after I run the formatter:
![image](https://github.com/Xeeynamo/sotn-decomp/assets/15314202/833aa657-9e11-40e6-bbcf-5ec09f768f26)


Personally, I think the original code is a lot more readable since everything is stacked up. You can see the [1][2][3] much more easily than when the lines are interwoven with each other. This isn't the most egregious example of lines being broken apart, but it's not ideal. I think we should seriously talk about what we're going to do about the 80-column limit and how it impacts our work. It seems like people are open to expanding it to 120 columns or something, which would help a lot. Another alternative would be to remove `EFFECT_` from this enum so we just have `SOLID_FROM_BELOW` and `SOLID_` (because right now, the three instances of `EFFECT_` are eating 21 characters right away). We need to either expand the limit, shrink the names, or be okay with our code becoming ugly.

Anyway, if I should just run the formatter and call it good for now, let me know, otherwise we can keep this PR staged as a "once we resolve the column limit, then we put this one in".