### PR TITLE
Decompile w_029 func_ptr_80170028

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -145,7 +145,8 @@ typedef struct {
 typedef struct {
     /* 0x7C */ s16 lifetime;
     /* 0x7E */ s16 unk7E;
-    /* 0x80 */ s32 unk80;
+    /* 0x80 */ s16 unk80;
+    /* 0x82 */ s16 unk82;
     /* 0x84 */ s32 unk84;
     /* 0x88 */ s16 childPalette;
     /* 0x8A */ s16 unk8A;

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -32,7 +32,7 @@ void func_ptr_80170028(Entity* self) {
         self->hitboxHeight = 14;
         self->hitboxWidth = 14;
         self->ext.weapon.unk80 = 10;
-        self->step ++;
+        self->step++;
         return;
     }
     if (--self->ext.weapon.unk80 == 0) {

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -21,7 +21,24 @@ INCLUDE_ASM("weapon/nonmatchings/w_029", EntityWeaponShieldSpell);
 
 INCLUDE_ASM("weapon/nonmatchings/w_029", func_ptr_80170024);
 
-INCLUDE_ASM("weapon/nonmatchings/w_029", func_ptr_80170028);
+void func_ptr_80170028(Entity* self) {
+    if (self->ext.weapon.parent->entityId == 0) {
+        DestroyEntity(self);
+        return;
+    }
+    if (self->step == 0) {
+        self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
+        SetWeaponProperties(self, 0);
+        self->hitboxHeight = 14;
+        self->hitboxWidth = 14;
+        self->ext.weapon.unk80 = 10;
+        self->step ++;
+        return;
+    }
+    if (--self->ext.weapon.unk80 == 0) {
+        DestroyEntity(self);
+    }
+}
 
 void WeaponUnused2C(void) {}
 


### PR DESCRIPTION
We're currently trying to resolve some issues with compiling/assembling w_029. This is a function in that weapon which I was able to successfully decompile.

Frustratingly, we named unk7C to lifetime since we saw a different weapon using it this way, but now we see this using unk80 the same way (with a lifetime of 10, decrementing on each run). Not sure what the best way to handle that is, but hopefully we can work out more patterns as we work out the various weapons.