### PR TITLE
Change `li` macro; decompile w_029 func_ptr_80170004

### DIFF
--- a/include/macro.inc
+++ b/include/macro.inc
@@ -15,6 +15,9 @@
   ori \reg, $0, \num & 0xFFFF
 .elseif \num > 0xFFFF
   lui \reg, %hi(\num)
+  .if \num & 0xFFFF
+    ori \reg, \reg, \num & 0xFFFF
+  .endif
 .elseif \num > 0
   ori \reg, $0, \num & 0xFFFF
 .elseif \num == -0x8000
@@ -22,7 +25,10 @@
 .elseif \num > -0x8000
   addiu \reg, $0, \num
 .else
-  lui \reg, %hi(\num)
+  lui \reg, (\num>>16) & 0xFFFF
+  .if \num & 0xFFFF
+    ori \reg, \reg, \num & 0xFFFF
+  .endif
 .endif
 .endm
 

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -3,9 +3,38 @@
 #include "weapon_private.h"
 #include "shared.h"
 
+extern u16 D_CF000_8017AD04[];
+
 INCLUDE_ASM("weapon/nonmatchings/w_029", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_029", func_ptr_80170004);
+void func_ptr_80170004(Entity* self) {
+    if (self->ext.weapon.parent->ext.weapon.equipId != 15) {
+        DestroyEntity(self);
+        return;
+    }
+    if (self->step == 0) {
+        self->animSet = self->ext.weapon.parent->animSet;
+        self->zPriority = self->ext.weapon.parent->zPriority + 4;
+        self->unk5A = self->ext.weapon.parent->unk5A;
+        self->ext.weapon.unk80 = self->ext.weapon.parent->ext.weapon.unk80;
+        self->animCurFrame = self->ext.weapon.parent->animCurFrame;
+        self->flags = 0x08000000;
+        self->unk19 = 0x18;
+        self->unk6C = 0x80;
+        self->ext.weapon.unk7E = 0x14;
+        self->step++;
+    } else {
+        if (self->unk6C >= 7) {
+            self->unk6C -= 7;
+        }
+
+        if (--self->ext.weapon.unk7E == 0) {
+            DestroyEntity(self);
+            return;
+        }
+    }
+    self->palette = self->ext.weapon.unk80 + D_CF000_8017AD04[g_GameTimer/2 %5];
+}
 
 void func_ptr_80170008(Entity* self) {}
 

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -33,7 +33,8 @@ void func_ptr_80170004(Entity* self) {
             return;
         }
     }
-    self->palette = self->ext.weapon.unk80 + D_CF000_8017AD04[g_GameTimer/2 %5];
+    self->palette =
+        self->ext.weapon.unk80 + D_CF000_8017AD04[g_GameTimer / 2 % 5];
 }
 
 void func_ptr_80170008(Entity* self) {}


### PR DESCRIPTION
This was a huge pain to get working, but we got it. With a lot of help from @Xeeynamo and @mkst , we figured out that there was a weird edge case with the li macro and loading large values. That is now fixed.

The value we need to load is 0xCCCCCCCD. There were two issues associated with the macro's parsing of this value, relating to the fact that the assembler treats all values as signed, which causes issues both in the if statements, and in the behavior of the %hi. Of the two changes in the macro, only the lower one is strictly needed for this case, but I added the upper case too, since i expect we will run into it at one point or another.

Anyway, this works! Yay!