### PR TITLE
Decompile w_029 EntityWeaponAttack

### DIFF
--- a/config/splat.us.weapon.yaml
+++ b/config/splat.us.weapon.yaml
@@ -531,7 +531,7 @@ segments:
       - [0xCF040, animset, w_029_1]
       - [0xCF884, animset, w_029_2]
       - [0xCF884, data, w_029]
-      - [0xCFDBC, .rodata, w_029]
+      - [0xCFD54, .rodata, w_029]
       - [0xCFDD8, c, w_029]
       - [0xD19A0, sbss, w_029]
   - name: f_030

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -47,7 +47,7 @@ void EntityWeaponAttack(Entity* self) {
         unkAC_offset++;
     }
     switch (self->step) {
-    case 0:              
+    case 0:
         SetSpriteBank1(g_Animset);
         if (self->params & 0x8000) {
             self->animSet = -0x7FEE;
@@ -69,11 +69,11 @@ void EntityWeaponAttack(Entity* self) {
             self->step++;
         }
         break;
-    case 2:                               
+    case 2:
         switch (PLAYER.ext.player.unkAC) {
-        case 9:                           
-        case 10:                          
-        case 11:                          
+        case 9:
+        case 10:
+        case 11:
             newUnkAC++;
         case 7:
             newUnkAC++;

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -2,12 +2,143 @@
 // Fire shield, Unknown#213
 #include "weapon_private.h"
 #include "shared.h"
-
+extern s32 D_CF000_8017AC78;
+extern s32 D_CF000_8017ACC0;
 extern u16 D_CF000_8017ACF8[];
 extern u16 D_CF000_8017AD04[];
 extern AnimationFrame D_CF000_8017AD24[];
 
-INCLUDE_ASM("weapon/nonmatchings/w_029", EntityWeaponAttack);
+void EntityWeaponAttack(Entity* self) {
+    s32 newUnkAC;
+    s32 handButton;
+    s32 unkAC_offset;
+
+    newUnkAC = 0;
+    unkAC_offset = 0;
+    if (g_HandId != 0) {
+        handButton = PAD_CIRCLE;
+    } else {
+        handButton = PAD_SQUARE;
+    }
+    if (!(handButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & 0x10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.weapon.lifetime = 128;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == 2) && (PLAYER.step_s != 2)) {
+        unkAC_offset++;
+    }
+    switch (self->step) { /* switch 1 */
+    case 0:               /* switch 1 */
+        SetSpriteBank1(g_Animset);
+        if (self->params & 0x8000) {
+            self->animSet = -0x7FEE;
+            self->ext.weapon.unk80 = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = -0x7FF0;
+            self->ext.weapon.unk80 = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 + FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+    case 1: /* switch 1 */
+        self->ext.weapon.unkAC = unkAC_offset + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:                                /* switch 1 */
+        switch (PLAYER.ext.player.unkAC) { /* switch 2 */
+        case 9:                            /* switch 2 */
+        case 10:                           /* switch 2 */
+        case 11:                           /* switch 2 */
+            newUnkAC++;
+        case 7: /* switch 2 */
+            newUnkAC++;
+        case 8: /* switch 2 */
+            newUnkAC++;
+        case 12: /* switch 2 */
+            newUnkAC++;
+        case 13: /* switch 2 */
+            newUnkAC++;
+        case 24: /* switch 2 */
+        case 25: /* switch 2 */
+            newUnkAC++;
+        case 14: /* switch 2 */
+        case 15: /* switch 2 */
+            newUnkAC++;
+        case 26: /* switch 2 */
+            newUnkAC += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default: /* switch 2 */
+            self->animFrameIdx = 0;
+            newUnkAC = newUnkAC + unkAC_offset;
+            break;
+        }
+        self->ext.weapon.unkAC = newUnkAC;
+        self->animFrameDuration = 2;
+        break;
+    case 3: /* switch 1 */
+        g_Player.unk48 = 0;
+        self->ext.weapon.unkAC = unkAC_offset + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4: /* switch 1 */
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->unk19 |= 4;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotAngle = self->rotAngle + 0x80;
+        if (--self->ext.weapon.lifetime < 16) {
+            self->unk19 |= 0x80;
+        }
+        if (--self->ext.weapon.lifetime == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.func_8010DBFC(&D_CF000_8017AC78, &D_CF000_8017ACC0);
+        if (g_GameTimer % 5 == 0) {
+            g_api.func_8011AAFC(self, ((g_HandId + 1) << 0xC) + 0x38, 0);
+        }
+    }
+    self->palette =
+        self->ext.weapon.unk80 + D_CF000_8017ACF8[g_GameTimer / 2 % 5];
+    self->unk19 = PLAYER.unk19;
+    self->unk1C = PLAYER.unk1C;
+    self->rotPivotY = PLAYER.rotPivotY;
+    return;
+}
 
 void func_ptr_80170004(Entity* self) {
     if (self->ext.weapon.parent->ext.weapon.equipId != 15) {

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -49,12 +49,12 @@ void EntityWeaponAttack(Entity* self) {
     switch (self->step) {
     case 0:
         SetSpriteBank1(g_Animset);
-        if (self->params & 0x8000) {
-            self->animSet = -0x7FEE;
+        if (self->params & ANIMSET_OVL_FLAG) {
+            self->animSet = ANIMSET_OVL(18);
             self->ext.weapon.unk80 = 0x128;
             self->unk5A = 0x66;
         } else {
-            self->animSet = -0x7FF0;
+            self->animSet = ANIMSET_OVL(16);
             self->ext.weapon.unk80 = 0x110;
             self->unk5A = 0x64;
         }

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -46,8 +46,8 @@ void EntityWeaponAttack(Entity* self) {
     if ((PLAYER.step == 2) && (PLAYER.step_s != 2)) {
         unkAC_offset++;
     }
-    switch (self->step) { /* switch 1 */
-    case 0:               /* switch 1 */
+    switch (self->step) {
+    case 0:              
         SetSpriteBank1(g_Animset);
         if (self->params & 0x8000) {
             self->animSet = -0x7FEE;
@@ -63,37 +63,37 @@ void EntityWeaponAttack(Entity* self) {
         g_Player.unk48 = 1;
         SetWeaponProperties(self, 0);
         self->step++;
-    case 1: /* switch 1 */
+    case 1:
         self->ext.weapon.unkAC = unkAC_offset + 10;
         if (self->animFrameDuration < 0) {
             self->step++;
         }
         break;
-    case 2:                                /* switch 1 */
-        switch (PLAYER.ext.player.unkAC) { /* switch 2 */
-        case 9:                            /* switch 2 */
-        case 10:                           /* switch 2 */
-        case 11:                           /* switch 2 */
+    case 2:                               
+        switch (PLAYER.ext.player.unkAC) {
+        case 9:                           
+        case 10:                          
+        case 11:                          
             newUnkAC++;
-        case 7: /* switch 2 */
+        case 7:
             newUnkAC++;
-        case 8: /* switch 2 */
+        case 8:
             newUnkAC++;
-        case 12: /* switch 2 */
+        case 12:
             newUnkAC++;
-        case 13: /* switch 2 */
+        case 13:
             newUnkAC++;
-        case 24: /* switch 2 */
-        case 25: /* switch 2 */
+        case 24:
+        case 25:
             newUnkAC++;
-        case 14: /* switch 2 */
-        case 15: /* switch 2 */
+        case 14:
+        case 15:
             newUnkAC++;
-        case 26: /* switch 2 */
+        case 26:
             newUnkAC += 2;
             self->animFrameIdx = PLAYER.animFrameIdx;
             break;
-        default: /* switch 2 */
+        default:
             self->animFrameIdx = 0;
             newUnkAC = newUnkAC + unkAC_offset;
             break;
@@ -101,7 +101,7 @@ void EntityWeaponAttack(Entity* self) {
         self->ext.weapon.unkAC = newUnkAC;
         self->animFrameDuration = 2;
         break;
-    case 3: /* switch 1 */
+    case 3:
         g_Player.unk48 = 0;
         self->ext.weapon.unkAC = unkAC_offset + 12;
         if (self->animFrameDuration < 0) {
@@ -109,7 +109,7 @@ void EntityWeaponAttack(Entity* self) {
             return;
         }
         break;
-    case 4: /* switch 1 */
+    case 4:
         self->hitboxState = 0;
         g_Player.unk48 = 0;
         self->unk19 |= 4;


### PR DESCRIPTION
Continuing to finish out w_029 now that we have g_GameTimer % 5 figured out.

There is a very unfortunate thing here. We are using `self->ext.weapon.lifetime`, but EntityWeaponShieldSpell just had a whole mess about 7C and 7D and needing to create ext.weapon29. Clearly, weapon29 references this location as both a s16, and as two u8's. I really don't know what to make of that. Happy to adjust things here if we want to handle that differently, but for now this seems to work. It will be cool if we can get this strange weapon fully decompiled.