### PR TITLE
Decompile DRA CheckSoulStealInput

### DIFF
--- a/config/splat.hd.dra.yaml
+++ b/config/splat.hd.dra.yaml
@@ -84,7 +84,6 @@ segments:
       - [0x40EDC, rodata] # jtbl_800E0EDC
       - [0x40FA8, .rodata, 6D59C] # func_8010EDB8
       - [0x41224, .rodata, 704D8] # jtbl_800E1224
-      - [0x4129C, rodata] # jtbl_800E129C
       - [0x412BC, rodata]
       - [0x412DC, .rodata, 71830]
       - [0x4132C, .rodata, 71830] # jtbl_800E132C

--- a/config/splat.us.dra.yaml
+++ b/config/splat.us.dra.yaml
@@ -97,7 +97,6 @@ segments:
       - [0x40E48, rodata] # EntityAlucard jump table
       - [0x4108C, .rodata, 6D59C] # func_8010EDB8
       - [0x41308, .rodata, 704D8] # func_80110968
-      - [0x41380, rodata] # func_801112AC
       - [0x413A0, rodata]
       - [0x413C0, .rodata, 71830]
       - [0x41410, .rodata, 71830] # func_801120B4

--- a/config/symbols.hd.dra.txt
+++ b/config/symbols.hd.dra.txt
@@ -802,6 +802,7 @@ g_WasFacingLeft3 = 0x80137B98;
 g_WasFacingLeft4 = 0x80137B9C;
 g_WasFacingLeft5 = 0x80137BA0;
 g_WasFacingLeft6 = 0x80137BA4;
+g_WasFacingLeft7 = 0x80137BA8;
 D_80137FE0 = 0x80137BAC;
 D_80137FE4 = 0x80137BB0;
 D_80137FE8 = 0x80137BB4;

--- a/config/symbols.us.dra.txt
+++ b/config/symbols.us.dra.txt
@@ -953,6 +953,7 @@ g_WasFacingLeft3 = 0x80137FC8;
 g_WasFacingLeft4 = 0x80137FCC;
 g_WasFacingLeft5 = 0x80137FD0;
 g_WasFacingLeft6 = 0x80137FD4;
+g_WasFacingLeft7 = 0x80137FD8;
 g_WingSmashButtonCounter = 0x80137FF4;
 g_WingSmashButtonTimer = 0x80137FF8;
 g_WingSmashTimer = 0x80137FFC;

--- a/src/dra/704D8.c
+++ b/src/dra/704D8.c
@@ -560,6 +560,9 @@ bool CheckSoulStealInput(void) {
             break;
         }
         if (g_Player.padTapped == PAD_RIGHT) {
+            // @bug - Most spells use a 20-frame button timing. Soul Steal uses
+            // 24. It appears that this spot was forgotten, meaning Soul Steal
+            // is easier if you start facing right than left!
             g_ButtonCombo[COMBO_SOUL_STEAL].timer = 20;
             g_WasFacingLeft7 = 1;
             g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;

--- a/src/dra/704D8.c
+++ b/src/dra/704D8.c
@@ -527,6 +527,121 @@ bool CheckTetraSpiritInput(void) {
     return 0;
 }
 
-INCLUDE_ASM("dra/nonmatchings/704D8", func_801112AC);
+bool CheckSoulStealInput(void) {
+    s32 directionsPressed;
+    s32 forward;
+    s32 down_forward;
+    s32 backward;
+    s32 down_backward;
+    s32 down;
+
+    directionsPressed =
+        g_Player.padPressed & (PAD_UP | PAD_RIGHT | PAD_DOWN | PAD_LEFT);
+    if (!g_WasFacingLeft7) {
+        down_forward = PAD_DOWN + PAD_RIGHT;
+        forward = PAD_RIGHT;
+        backward = PAD_LEFT;
+        down_backward = PAD_DOWN + PAD_LEFT;
+    } else {
+        down_forward = PAD_DOWN + PAD_LEFT;
+        forward = PAD_LEFT;
+        backward = PAD_RIGHT;
+        down_backward = PAD_DOWN + PAD_RIGHT;
+    }
+    down = PAD_DOWN;
+    switch (g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect) {
+    case 0:
+        if (PLAYER.facingLeft == 0) {
+            if (g_Player.padTapped == PAD_LEFT) {
+                g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+                g_WasFacingLeft7 = 0;
+                g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            }
+            break;
+        }
+        if (g_Player.padTapped == PAD_RIGHT) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 20;
+            g_WasFacingLeft7 = 1;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+        }
+        break;
+    case 1:
+        if (directionsPressed != forward) {
+            if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+                g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+            }
+            break;
+        }
+        g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+        g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+        break;
+    case 2:
+        if ((directionsPressed & down_forward) == down_forward) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+        }
+        break;
+    case 3:
+        if (directionsPressed == down) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+        }
+        break;
+    case 4:
+        if ((directionsPressed & down_backward) == down_backward) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+        }
+        break;
+    case 5:
+        if (directionsPressed == backward) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+        }
+        break;
+    case 6:
+        if (directionsPressed == forward) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer == 0) {
+            g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+        }
+        break;
+    case 7:
+        if (--g_ButtonCombo[COMBO_SOUL_STEAL].timer != 0) {
+            if ((g_Player.padTapped & (PAD_SQUARE | PAD_CIRCLE)) &&
+                !(g_Player.unk46 & 0x8000) &&
+                ((PLAYER.step == Player_Walk) ||
+                 (PLAYER.step == Player_Stand)) &&
+                (CastSpell(SPELL_SOUL_STEAL) != 0)) {
+                func_8010FBF4();
+                g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+                LearnSpell(SPELL_SOUL_STEAL);
+                return 1;
+            }
+            break;
+        }
+        g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect = 0;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("dra/nonmatchings/704D8", func_8011151C);

--- a/src/dra/704D8.c
+++ b/src/dra/704D8.c
@@ -551,7 +551,7 @@ bool CheckSoulStealInput(void) {
     down = PAD_DOWN;
     switch (g_ButtonCombo[COMBO_SOUL_STEAL].buttonsCorrect) {
     case 0:
-        if (PLAYER.facingLeft == 0) {
+        if (!PLAYER.facingLeft) {
             if (g_Player.padTapped == PAD_LEFT) {
                 g_ButtonCombo[COMBO_SOUL_STEAL].timer = 24;
                 g_WasFacingLeft7 = 0;

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -23,7 +23,7 @@ void func_80111830(void) {
             var_v0 = CheckTetraSpiritInput();
             break;
         case 6:
-            var_v0 = func_801112AC();
+            var_v0 = CheckSoulStealInput();
             break;
         case 9:
             var_v0 = func_8011151C();

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -275,7 +275,7 @@ typedef enum {
     COMBO_HELLFIRE,
     COMBO_TETRA_SPIRIT,
     COMBO_UNK5,
-    COMBO_UNK6,
+    COMBO_SOUL_STEAL,
     COMBO_UNK7,
     COMBO_UNK8,
     COMBO_UNK9,
@@ -607,6 +607,7 @@ extern s32 g_WasFacingLeft3; // for dark metamorphosis "" ""
 extern s32 g_WasFacingLeft4; // for summon spirit "" ""
 extern s16 g_WasFacingLeft5; // for hellfire "" ""
 extern s32 g_WasFacingLeft6; // for tetra spirit "" ""
+extern s32 g_WasFacingLeft7; // for soul steal "" ""
 extern s32 D_80137FDC;
 extern s32 D_80137FE0;
 extern s32 D_80137FE4;
@@ -881,7 +882,7 @@ bool CheckSummonSpiritInput();
 void func_8010DBFC(s32*, s32*);
 bool CheckHellfireInput();
 bool CheckTetraSpiritInput();
-s32 func_801112AC();
+bool CheckSoulStealInput();
 s32 func_8011151C();
 void func_80111928(void);
 void func_80111CC0(void);


### PR DESCRIPTION
Mostly more of the same.

A bit interesting, most of the timers get set to 24, where the other spells all used 20. Seems the developers wanted to make Soul Steal slightly easier, likely due to the complicated input.

Interestingly, for the first button, in case 0, there is a discrepancy based on whether you start the spell facing left or right. If you start facing left (so your first press is back, to the right), you get 20 frames, while facing right gives 24. Not sure if this is worthy of a `@bug` annotation?