### PR TITLE
Decompile DRA CheckSwordBrothersInput

### DIFF
--- a/config/splat.hd.dra.yaml
+++ b/config/splat.hd.dra.yaml
@@ -84,7 +84,6 @@ segments:
       - [0x40EDC, rodata] # jtbl_800E0EDC
       - [0x40FA8, .rodata, 6D59C] # func_8010EDB8
       - [0x41224, .rodata, 704D8] # jtbl_800E1224
-      - [0x412BC, rodata]
       - [0x412DC, .rodata, 71830]
       - [0x4132C, .rodata, 71830] # jtbl_800E132C
       - [0x414A4, .rodata, 72BB0] # jtbl_800E14A4

--- a/config/splat.us.dra.yaml
+++ b/config/splat.us.dra.yaml
@@ -97,7 +97,6 @@ segments:
       - [0x40E48, rodata] # EntityAlucard jump table
       - [0x4108C, .rodata, 6D59C] # func_8010EDB8
       - [0x41308, .rodata, 704D8] # func_80110968
-      - [0x413A0, rodata]
       - [0x413C0, .rodata, 71830]
       - [0x41410, .rodata, 71830] # func_801120B4
       - [0x41588, .rodata, 72BB0] # func_80112BB0

--- a/src/dra/704D8.c
+++ b/src/dra/704D8.c
@@ -647,4 +647,131 @@ bool CheckSoulStealInput(void) {
     return 0;
 }
 
-INCLUDE_ASM("dra/nonmatchings/704D8", func_8011151C);
+bool CheckSwordBrothersInput(void) {
+    s32 directionsPressed;
+    s32 down_forward;
+    s32 forward;
+    s32 up_forward;
+
+    directionsPressed =
+        g_Player.padPressed & (PAD_UP | PAD_RIGHT | PAD_DOWN | PAD_LEFT);
+    if (!PLAYER.facingLeft) {
+        down_forward = PAD_DOWN + PAD_RIGHT;
+        forward = PAD_RIGHT;
+        up_forward = PAD_UP + PAD_RIGHT;
+    } else {
+        down_forward = PAD_DOWN + PAD_LEFT;
+        forward = PAD_LEFT;
+        up_forward = PAD_UP + PAD_LEFT;
+    }
+
+    // Check if sword familiar is currently active. If not, prevent having
+    // buttons correct
+    if (D_8006CBC4 != 5) {
+        g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+    }
+
+    switch (g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect) {
+    case 0:
+        if (directionsPressed == PAD_DOWN) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+        }
+        break;
+    case 1:
+        if (directionsPressed == down_forward) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 2:
+        if (directionsPressed == forward) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 3:
+        if (directionsPressed == up_forward) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 4:
+        if (directionsPressed == PAD_UP) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 64;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 5:
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (!(directionsPressed & PAD_UP)) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 6:
+        if (!(directionsPressed & PAD_UP)) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+        }
+        break;
+    case 7:
+        if (directionsPressed == PAD_DOWN) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect++;
+            break;
+        }
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        break;
+    case 8:
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+        }
+        if ((g_Player.padTapped & (PAD_SQUARE | PAD_CIRCLE)) &&
+            !(g_Player.unk46 & 0x8000)) {
+            if (PLAYER.step == Player_Crouch) {
+                if (CastSpell(SPELL_SWORD_BROTHERS) != 0) {
+                    func_8010FD24();
+                    g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect =
+                        COMBO_COMPLETE;
+                    g_ButtonCombo[COMBO_SWORD_BROTHERS].timer = 20;
+                    LearnSpell(SPELL_SWORD_BROTHERS);
+                    g_Player.unk70 = 1;
+                    return 1;
+                }
+                break;
+            }
+            FntPrint("command ok\n");
+            break;
+        }
+        break;
+    case COMBO_COMPLETE:
+        FntPrint("100sword set ok\n");
+        if (--g_ButtonCombo[COMBO_SWORD_BROTHERS].timer == 0) {
+            g_ButtonCombo[COMBO_SWORD_BROTHERS].buttonsCorrect = 0;
+            g_Player.unk70 = 1;
+        }
+        break;
+    }
+    return 0;
+}

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -26,7 +26,7 @@ void func_80111830(void) {
             var_v0 = CheckSoulStealInput();
             break;
         case 9:
-            var_v0 = func_8011151C();
+            var_v0 = CheckSwordBrothersInput();
             break;
         case 14:
             var_v0 = CheckSummonSpiritInput();

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -278,7 +278,7 @@ typedef enum {
     COMBO_SOUL_STEAL,
     COMBO_UNK7,
     COMBO_UNK8,
-    COMBO_UNK9,
+    COMBO_SWORD_BROTHERS,
     COMBO_UNK10,
     COMBO_UNK11,
     COMBO_UNK12,
@@ -883,7 +883,7 @@ void func_8010DBFC(s32*, s32*);
 bool CheckHellfireInput();
 bool CheckTetraSpiritInput();
 bool CheckSoulStealInput();
-s32 func_8011151C();
+bool CheckSwordBrothersInput();
 void func_80111928(void);
 void func_80111CC0(void);
 bool func_80111D24(void);


### PR DESCRIPTION
The last one of this set!

Before merging, we should work out how to deal with D_8006CBC4 since right now we don't have a good way to enum it.

Oddly this didn't use rodata for the switch even though the others did. It does use rodata for the FntPrint strings though.

Otherwise I think those are all the highlights.