### PR TITLE
Split CI debug module build

### DIFF
--- a/.github/workflows/tool-debugmodule.yaml
+++ b/.github/workflows/tool-debugmodule.yaml
@@ -1,0 +1,31 @@
+name: Build Debug Module tool
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'config/**.txt'
+      - 'include/**'
+      - 'tools/sotn-debugmodule/**'
+  pull_request:
+    paths:
+      - 'config/**.txt'
+      - 'include/**'
+      - 'tools/sotn-debugmodule/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install requirements
+        run: sudo apt-get install gcc-mipsel-linux-gnu
+      - name: Clone repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          submodules: false
+      - name: build
+        working-directory: tools/sotn-debugmodule
+        run: make

--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -1,4 +1,4 @@
-name: Update progress
+name: Build PSX version
 
 on:
   push:
@@ -83,9 +83,6 @@ jobs:
         run: make -j build
       - name: Check if they match
         run: make check
-      - name: Check debug module
-        if: matrix.version == 'us'
-        run: make disk_debug
       - name: Analyze calls dry run
         if: matrix.version == 'us'
         run: |


### PR DESCRIPTION
I noticed since #642 the artifacts published by the CI have become very big and that takes a big chunk of execution time. That is solved by running `make` within `tools/sotn-debugmodule`. Also since the debug module has no dependencies to be installed, it can run in its own separate CI to further reduce the execution time, even if the improvement would be marginal.

This CI is a bit experimental. Compare to the other CI it is triggered by `pull_request` instead of `pull_request_target`. That allows to simplify `actions/checkout@v3` with the draw-back CI configurations from foreign contributors can be injected into the repo. It shouldn't be a problem as collaborators would need to manually approve the CI execution for new contributors. Also using `paths:` instead of `paths-ignore:` should give us more control on what we execute in the first place.