### PR TITLE
Improve DRA SetNextRoomToLoad

### DIFF
--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -71,13 +71,13 @@ void func_800F0940(void) {
     }
 }
 
-bool SetNextRoomToLoad(u32 x, u32 y) {
+s32 SetNextRoomToLoad(u32 x, u32 y) {
     s32 res;
     RoomHeader* room;
     u32 stack[4];
 
     if (g_Player.unk0C & 0x40000) {
-        return false;
+        return 0;
     }
     res = func_800F087C(x, y);
     if (res) {
@@ -87,18 +87,17 @@ bool SetNextRoomToLoad(u32 x, u32 y) {
     room = g_api.o.rooms;
     while (true) {
         if (room->left == 0x40) {
-            return false;
+            return 0;
         }
-        if (room->left <= x && room->top <= y) {
-            if (room->right >= x && room->bottom >= y) {
-                stack[0] = &room->load;
-                if (room->load.tilesetId == 0xFF &&
-                    D_800A245C[room->load.tileLayoutId].stageId == STAGE_ST0) {
-                    return false;
-                }
-                D_801375BC = &room->load;
-                return true;
+        if (room->left <= x && room->top <= y && room->right >= x &&
+            room->bottom >= y) {
+            stack[0] = &room->load;
+            if (room->load.tilesetId == 0xFF &&
+                D_800A245C[room->load.tileLayoutId].stageId == STAGE_ST0) {
+                return 0;
             }
+            D_801375BC = &room->load;
+            return 1;
         }
         room++;
     }

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -821,7 +821,7 @@ void FreePrimitives(s32 index);
 void DemoOpenFile(s32);
 void DemoInit(s32 arg0);
 s32 func_800F087C(u32, u32);
-bool SetNextRoomToLoad(u32 chunkX, u32 chunkY);
+s32 SetNextRoomToLoad(u32 chunkX, u32 chunkY);
 s32 func_800F0CD8(s32 arg0);
 s32 func_800F16D0(void);
 void func_800F1868(s32, s32, u8*);


### PR DESCRIPTION
This one is already decompiled, but I noticed that there are some minor issues.

One is that it has a return type of bool, but it is able to return the result of func_800F087C, which is itself an s32. Therefore, this should return s32.

While we're at it, there was a nested if-statement that doesn't need to be nested, so I un-nested it.

Nothing huge, but I think this makes the function slightly better. Main thing is getting the return type right.