### PR TITLE
Decompile DRA func_800FBAC4

### DIFF
--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -3696,7 +3696,45 @@ void func_800FB9BC(void) {
         YScrollPerElement;
 }
 
-INCLUDE_ASM("dra/nonmatchings/5298C", func_800FBAC4);
+void func_800FBAC4(void) {
+    s32 i;
+    s32 j;
+    s32* var_a1;
+    s32 importantcategory;
+
+    for (i = D_80137618; i > 0; i--) {
+        // j is used as a temp to swap these two variables.
+        j = g_Settings.equipOrderTypes[i];
+        g_Settings.equipOrderTypes[i] = g_Settings.equipOrderTypes[i - 1];
+        g_Settings.equipOrderTypes[i - 1] = j;
+    }
+
+    D_80137618 = 0;
+    var_a1 = D_801375D8;
+    *var_a1++ = 0;
+    for (i = 0; i < 11; i++) {
+        importantcategory = g_Settings.equipOrderTypes[i];
+        for (j = 0; j < 0xA9; j++) {
+            if (g_Status.equipHandCount[g_Status.equipHandOrder[j]] != 0 &&
+                g_Status.equipHandOrder[j] != 0 &&
+                g_EquipDefs[g_Status.equipHandOrder[j]].itemCategory ==
+                    importantcategory) {
+                *var_a1++ = g_Status.equipHandOrder[j];
+            }
+        }
+    }
+
+    for (j = 0; j < 0xA9; j++) {
+        if (g_Status.equipHandCount[g_Status.equipHandOrder[j]] == 0) {
+            *var_a1++ = g_Status.equipHandOrder[j];
+        }
+    }
+
+    var_a1 = D_801375D8;
+    for (i = 0; i < 0xA9; i++) {
+        g_Status.equipHandOrder[i] = *var_a1++;
+    }
+}
 
 INCLUDE_ASM("dra/nonmatchings/5298C", func_800FBC24);
 


### PR DESCRIPTION
One more from 5298C.c.

I think this has something to do with the item sorting menu where you select an item category and it shows all items from that category, but I'm not certain.

In the first for-loop, we're swapping values in equipOrderTypes. Unfortunately we have to use j as the swapping variable; that was the only way I could get it to match.

More than happy to give better names to var_a1 and importantcategory, if anyone knows what these variables are actually for.