### PR TITLE
Decompile some duplicate functions

### DIFF
--- a/config/symbols.us.strwrp.txt
+++ b/config/symbols.us.strwrp.txt
@@ -18,6 +18,7 @@ PreventEntityFromRespawning = 0x8018D668;
 GetDistanceToPlayerX = 0x8018D880;
 MoveEntity = 0x8018D934;
 FallEntity = 0x8018D964;
+AllocEntity = 0x8018DDF0;
 UnkEntityFunc0 = 0x8018E024;
 SetStep = 0x8018E1C0;
 InitializeEntity = 0x8018E290;

--- a/include/game.h
+++ b/include/game.h
@@ -1516,7 +1516,6 @@ extern Entity D_80074C08[];
 extern Unkstruct8 g_CurrentRoomTileLayout;
 extern Entity D_8007A958[]; // &g_Entities[160]
 extern Entity D_8007C0D8[]; // &g_Entities[192]
-extern Entity D_8007D858[]; // &g_Entities[224]
 extern Entity D_8007DE38[];
 extern unkGraphicsStruct g_unkGraphicsStruct;
 extern s32 g_entityDestroyed[];

--- a/src/st/cen/18084.c
+++ b/src/st/cen/18084.c
@@ -223,7 +223,22 @@ INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_8019902C);
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_801990F8);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_801991C0);
+void func_801991C0(void) {
+    Entity* entity;
+    s8 temp_s4 = Random() & 3;
+    s16 temp_s3 = ((Random() & 0xF) << 8) - 0x800;
+    s32 i;
+
+    for (i = 0; i < 6; i++) {
+        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        if (entity != NULL) {
+            CreateEntityFromEntity(2, g_CurrentEntity, entity);
+            entity->ext.generic.unk84.U8.unk1 = 6 - i;
+            entity->ext.generic.unk80.modeS16.unk0 = temp_s3;
+            entity->ext.generic.unk84.U8.unk0 = temp_s4;
+        }
+    }
+}
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80199278);
 

--- a/src/st/cen/18084.c
+++ b/src/st/cen/18084.c
@@ -11,8 +11,7 @@ void EntityUnkId13(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/cen/18084.c
+++ b/src/st/cen/18084.c
@@ -12,7 +12,7 @@ void EntityUnkId13(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -230,7 +230,7 @@ void func_801991C0(void) {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(2, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -62,14 +62,14 @@ void EntityUnkId01(Entity* self) {
 
     if (self->unk44 != 0) {
         g_api.PlaySfx(NA_SE_BREAK_CANDLE);
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != 0) {
             CreateEntityFromCurrentEntity(E_EXPLOSION, newEntity);
             newEntity->params = D_8018059C[params] | 0x10;
         }
 
         for (ptr = &D_801805BC, i = 0; i < 4; i++) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != 0) {
                 CreateEntityFromEntity(0x80, self, newEntity);
                 newEntity->posX.i.hi += *ptr;
@@ -85,7 +85,7 @@ void EntityUnkId01(Entity* self) {
 
         if (params != 0) {
             for (j = 0; j < 3; j++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != 0) {
                     CreateEntityFromEntity(0x80, self, newEntity);
                     newEntity->posX.i.hi += *ptr;

--- a/src/st/dre/11A64.c
+++ b/src/st/dre/11A64.c
@@ -102,7 +102,7 @@ void EntityBreakable(Entity* entity) {
         AnimateEntity(g_eBreakableAnimations[temp_s0], entity);
         if (entity->unk44 != 0) {
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
-            temp_v0 = AllocEntity(D_8007D858, &D_8007D858[32]);
+            temp_v0 = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (temp_v0 != NULL) {
                 CreateEntityFromCurrentEntity(2, temp_v0);
                 temp_v0->params = g_eBreakableExplosionTypes[temp_s0];

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -11,7 +11,7 @@ void EntityUnkId13(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -356,7 +356,7 @@ void func_8019F304(void) {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(2, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -10,8 +10,7 @@ void EntityUnkId13(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -60,8 +60,7 @@ void func_8019572C(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -61,7 +61,7 @@ void func_8019572C(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -400,7 +400,7 @@ void func_80196934(void) {
     temp_s3 = ((Random() & 0xF) << 8) - 0x800;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(2, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -133,8 +133,7 @@ void EntityBreakable(Entity* entity) {
         if (entity->unk44) { // If the candle is destroyed
             Entity* entityDropItem;
             g_api.PlaySfx(0x635);
-            entityDropItem =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            entityDropItem = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -134,7 +134,7 @@ void EntityBreakable(Entity* entity) {
             Entity* entityDropItem;
             g_api.PlaySfx(0x635);
             entityDropItem =
-                AllocEntity(D_8007D858, D_8007D858 + MaxEntityCount);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/mad/mad.h
+++ b/src/st/mad/mad.h
@@ -44,7 +44,6 @@ void func_8019344C(void);
 extern u8 D_8003BEE8[];
 extern Entity* g_CurrentEntity;
 extern Entity g_Entities[];
-extern Entity D_8007D858[];
 extern Entity D_8007EF1C;
 extern s32 g_BottomCornerTextTimer;
 extern s32 g_BottomCornerTextPrims;

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -98,7 +98,7 @@ void EntityBreakable(Entity* entity) {
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
             entityDropItem =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =
@@ -733,7 +733,7 @@ void EntityCavernDoor(Entity* self) {
             }
 
             if (!(g_Timer & 15)) {
-                entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (entity != NULL) {
                     CreateEntityFromEntity(6, self, entity);
                     entity->posY.i.hi = 156;
@@ -1070,7 +1070,7 @@ void EntityMermanRockLeftSide(Entity* self) {
 
             g_api.PlaySfx(SE_WALL_BREAK);
 
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 0x13;
@@ -1082,7 +1082,7 @@ void EntityMermanRockLeftSide(Entity* self) {
             params = &D_80181344[self->ext.generic.unk84.S16.unk0 * 3];
 
             for (i = 0; i < 3; i++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_FALLING_ROCK_2, self, newEntity);
                     newEntity->params = *params++;
@@ -1169,7 +1169,7 @@ void EntityMermanRockRightSide(Entity* self) {
 
             g_api.PlaySfx(SE_WALL_BREAK);
 
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(2, self, newEntity);
                 newEntity->params = 0x13;
@@ -1181,7 +1181,7 @@ void EntityMermanRockRightSide(Entity* self) {
             params = &D_80181344[self->ext.generic.unk84.S16.unk0 * 3];
 
             for (i = 0; i < 3; i++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_FALLING_ROCK_2, self, newEntity);
                     newEntity->params = *params++;
@@ -1282,7 +1282,7 @@ void EntityFallingRock2(Entity* self) {
 
         if (collider.effects & EFFECT_SOLID) {
             if (self->velocityY > FIX(4.0)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != 0) {
                     CreateEntityFromEntity(2, self, newEntity);
                     newEntity->params = 0x11;
@@ -1478,7 +1478,7 @@ void EntityFallingRock(Entity* self) {
         g_api.CheckCollision(
             self->posX.i.hi, self->posY.i.hi + 8, &collider, 0);
         if (collider.effects & EFFECT_SOLID) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(6, self, newEntity);
                 newEntity->params = 0x10;
@@ -1706,7 +1706,7 @@ void EntityHeartRoomGoldDoor(Entity* self) {
             }
 
             if (!(g_Timer & 0xF)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(6, self, newEntity);
                     newEntity->posY.i.hi = 188;

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -97,8 +97,7 @@ void EntityBreakable(Entity* entity) {
         if (entity->unk44) { // If the candle is destroyed
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
-            entityDropItem =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            entityDropItem = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -49,7 +49,7 @@ void EntityFlyingOwlAndLeaves(Entity* entity) {
             entity->velocityX = FIX(10);
             entity->velocityY = FIX(1.625);
             for (i = 0; i < 8; i++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromCurrentEntity(0x60, newEntity);
                     newEntity->params = i;

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -30,8 +30,7 @@ void EntityUnkId13(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -31,7 +31,7 @@ void EntityUnkId13(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -351,7 +351,7 @@ void func_801C9BC0(void) {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(2, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;
@@ -1038,7 +1038,7 @@ void EntitySplashWater(Entity* self) {
             g_api.func_80134714(D_801813A8, 0x7F, temp_a2);
             self->velocityY = D_80183878[params].x;
             self->ext.waterEffects.unk7C = D_80183878[params].y;
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(E_WATER_DROP, newEntity);
                 newEntity->velocityY = self->velocityY;
@@ -1594,7 +1594,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     AnimateEntity(D_80183994, entity);
     MoveEntity();
     if (entity->flags & 0x100) {
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(2, entity, newEntity);
             newEntity->params = 0;
@@ -1840,7 +1840,7 @@ void EntityMermanFireball(Entity* self) {
         self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
         self->rotY = self->rotX = 0x80;
 
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_ID_15, self, entity);
             entity->ext.generic.unk94 = 4;
@@ -1857,7 +1857,7 @@ void EntityMermanFireball(Entity* self) {
         }
 
         if (self->flags & 0x100) {
-            entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entity != NULL) {
                 CreateEntityFromEntity(2, self, entity);
                 entity->params = 0;

--- a/src/st/no3/56264.c
+++ b/src/st/no3/56264.c
@@ -6,7 +6,7 @@ void EntityBat(Entity* entity) {
     s16 yDistance;
 
     if (entity->flags & 0x100) {
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(2, entity, newEntity);
             newEntity->params = 1;

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -8,7 +8,7 @@ void EntityZombie(Entity* self) {
         func_801CAD28(SE_ZOMBIE_EXPLODE);
         self->hitboxState = 0;
         // Spawn Zombie explosion
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(0x62, self, newEntity);
             newEntity->zPriority = self->zPriority + 1;

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -91,8 +91,7 @@ void EntityBreakable(Entity* entity) {
         if (entity->unk44) { // If the candle is destroyed
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
-            entityDropItem =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            entityDropItem = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -92,7 +92,7 @@ void EntityBreakable(Entity* entity) {
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
             entityDropItem =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =
@@ -674,7 +674,7 @@ void func_801B40F8(Entity* self) {
             }
 
             if (!(g_Timer & 15)) {
-                entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (entity != NULL) {
                     CreateEntityFromEntity(E_INTENSE_EXPLOSION, self, entity);
                     entity->posY.i.hi = 156;
@@ -1014,7 +1014,7 @@ void EntityMermanRockLeftSide(Entity* self) {
 
             g_api.PlaySfx(NA_SE_EN_ROCK_BREAK);
 
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 0x13;
@@ -1026,7 +1026,7 @@ void EntityMermanRockLeftSide(Entity* self) {
             params = &D_8018120C[self->ext.generic.unk84.S16.unk0 * 3];
 
             for (i = 0; i < 3; i++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_FALLING_ROCK_2, self, newEntity);
                     newEntity->params = *params++;
@@ -1113,7 +1113,7 @@ void EntityMermanRockRightSide(Entity* self) {
 
             g_api.PlaySfx(NA_SE_EN_ROCK_BREAK);
 
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 0x13;
@@ -1125,7 +1125,7 @@ void EntityMermanRockRightSide(Entity* self) {
             params = &D_8018120C[self->ext.generic.unk84.S16.unk0 * 3];
 
             for (i = 0; i < 3; i++) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_FALLING_ROCK_2, self, newEntity);
                     newEntity->params = *params++;
@@ -1225,7 +1225,7 @@ void EntityFallingRock2(Entity* self) {
 
         if (collider.effects & EFFECT_SOLID) {
             if (self->velocityY > FIX(4.0)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != 0) {
                     CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                     newEntity->params = 0x11;
@@ -1419,7 +1419,7 @@ void EntityFallingRock(Entity* self) {
         g_api.CheckCollision(
             self->posX.i.hi, self->posY.i.hi + 8, &collider, 0);
         if (collider.effects & EFFECT_SOLID) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_INTENSE_EXPLOSION, self, newEntity);
                 newEntity->params = 0x10;
@@ -1641,7 +1641,7 @@ void func_801B653C(void) {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_ID_4D, g_CurrentEntity, entity);
             entity->params = 2;

--- a/src/st/np3/36990.c
+++ b/src/st/np3/36990.c
@@ -435,7 +435,7 @@ void EntitySlogra(Entity* self) {
             func_801BC8E4(&D_801812D0);
             AnimateEntity(D_801813C4, self);
             if (!(g_Timer % 4)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                     newEntity->posX.i.hi -= 16 - (Random() & 31);
@@ -451,7 +451,7 @@ void EntitySlogra(Entity* self) {
             break;
 
         case SLOGRA_DYING_END:
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 3;
@@ -546,7 +546,7 @@ void EntitySlograSpearProjectile(Entity* self) {
     Entity* entity;
 
     if (self->flags & 0x100) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, entity);
             entity->params = 1;
@@ -1122,7 +1122,7 @@ void EntityGaibon(Entity* self) {
 
         case GAIBON_DYING_TURN_INTO_BONES:
             if (!(self->ext.GS_Props.timer & 7)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                     newEntity->posY.i.hi += 28;
@@ -1271,7 +1271,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
         MoveEntity();
         AnimateEntity(D_801815EC, self);
         if (!(g_Timer & 3)) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_GAIBON_BIG_FIREBALL, self, newEntity);
                 newEntity->params = 1;

--- a/src/st/np3/402F4.c
+++ b/src/st/np3/402F4.c
@@ -30,8 +30,7 @@ void func_801C03E4(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/np3/402F4.c
+++ b/src/st/np3/402F4.c
@@ -31,7 +31,7 @@ void func_801C03E4(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -440,7 +440,7 @@ void func_801C1848(void) {
     temp_s3 = ((Random() & 0xF) << 8) - 0x800;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/np3/44DCC.c
+++ b/src/st/np3/44DCC.c
@@ -176,7 +176,7 @@ void EntitySplashWater(Entity* self) {
             g_api.func_80134714(D_8018122C, 0x7F, temp_a2);
             self->velocityY = D_80182188[params].x;
             self->ext.waterEffects.unk7C = D_80182188[params].y;
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(E_WATER_DROP, newEntity);
                 newEntity->velocityY = self->velocityY;
@@ -1144,7 +1144,7 @@ void EntityMerman2(Entity* self) {
                     prim->blendMode = BLEND_VISIBLE;
                     self->step_s++;
                 } else {
-                    newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                    newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x37, self, newEntity);
                         newEntity->facingLeft = self->facingLeft;
@@ -1241,7 +1241,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     AnimateEntity(D_801822A4, entity);
     MoveEntity();
     if (entity->flags & 0x100) {
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
             newEntity->params = 0;

--- a/src/st/np3/48238.c
+++ b/src/st/np3/48238.c
@@ -67,7 +67,7 @@ void EntityMerman(Entity* self) {
         func_801C2598(0x71D);
         self->hitboxState = 0;
         if (self->step == MERMAN_LUNGE) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;
@@ -396,7 +396,7 @@ void EntityMerman(Entity* self) {
                 self->ext.merman.palette++;
                 if (self->ext.merman.palette == 0x2C0) {
                     func_801C2598(0x65B);
-                    newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                    newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x3C, self, newEntity);
                         newEntity->params = 2;
@@ -430,7 +430,7 @@ void func_801C8DF0(Entity* self) {
         self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
         self->rotY = self->rotX = 0x80;
 
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_ID_15, self, entity);
             entity->ext.generic.unk94 = 4;
@@ -447,7 +447,7 @@ void func_801C8DF0(Entity* self) {
         }
 
         if (self->flags & 0x100) {
-            entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, entity);
                 entity->params = 0;

--- a/src/st/np3/490E8.c
+++ b/src/st/np3/490E8.c
@@ -227,7 +227,7 @@ void EntityBoneScimitar(Entity* self) {
     case BONE_SCIMITAR_DESTROY:
         g_api.PlaySfx(NA_SE_EN_SKELETON_DESTROY);
         for (i = 0; i < 7; i++) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity == NULL) {
                 break;
             }

--- a/src/st/np3/4997C.c
+++ b/src/st/np3/4997C.c
@@ -6,7 +6,7 @@ void EntityBat(Entity* entity) {
     s16 yDistance;
 
     if (entity->flags & 0x100) {
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
             newEntity->params = 1;

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -8,7 +8,7 @@ void EntityZombie(Entity* self) {
         func_801C2598(NA_SE_EN_ZOMBIE_EXPLODE);
         self->hitboxState = 0;
         // Spawn Zombie explosion
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(0x4D, self, newEntity);
             newEntity->zPriority = self->zPriority + 1;

--- a/src/st/np3/49F98.c
+++ b/src/st/np3/49F98.c
@@ -262,7 +262,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x49, self, newEntity);
                 if (self->facingLeft != 0) {
@@ -293,7 +293,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x49, self, newEntity);
                 if (self->facingLeft != 0) {
@@ -323,7 +323,7 @@ void EntityBloodyZombie(Entity* self) {
     case BLOODY_ZOMBIE_TAKE_HIT:
         if (self->step_s == 0) {
             // Splat blood
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x4A, self, newEntity);
                 newEntity->facingLeft = GetSideToPlayer() & 1;
@@ -354,7 +354,7 @@ void EntityBloodyZombie(Entity* self) {
         if (self->animFrameIdx < 13) {
             if (!(g_Timer % 8)) {
                 func_801C2598(NA_SE_EN_BLOODY_ZOMBIE_HEMORRHAGE);
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x4A, self, newEntity);
                     newEntity->facingLeft = self->ext.generic.unk84.U8.unk0;
@@ -395,7 +395,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (AnimateEntity(D_80182634, self) == 0) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -329,7 +329,7 @@ void EntityBottomSecretRoomFloor(
             tilePos += 0x10;
         }
 
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
             newEntity->params = 0x11;
@@ -400,7 +400,7 @@ void func_801B19A0(Entity* self) {
                 func_801C29B0(0x644);
                 for (i = 0; i < 2; i++) {
                     newEntity =
-                        AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                        AllocEntity(&g_Entities[224], &g_Entities[256]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x22, self, newEntity);
                         newEntity->params = 0x1;
@@ -411,7 +411,7 @@ void func_801B19A0(Entity* self) {
             }
             if (self->velocityY < FIX(0.5)) {
                 newEntity =
-                    AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                    AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(
                         E_INTENSE_EXPLOSION, self, newEntity);
@@ -782,7 +782,7 @@ void EntityCannon(Entity* self) {
             g_api.func_80102CD8(1);
             g_api.PlaySfx(0x6AC);
             self->velocityX = FIX(8);
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != 0) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 0x13;
@@ -837,7 +837,7 @@ void EntityCannonShot(Entity* self) {
         MoveEntity();
         if ((self->posX.i.hi + g_Camera.posX.i.hi) < 112) {
             g_api.func_80102CD8(1);
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 3;
@@ -1252,7 +1252,7 @@ void func_801B3648(Entity* self) {
         if (AnimateEntity(D_80180F30, self) == 0) {
             CreateEntityFromEntity(E_HEART_DROP, self, &self[1]);
             self[1].params = D_80180F4C[self->params];
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;
@@ -1310,7 +1310,7 @@ void func_801B37C0(Entity* self) {
         self[1].params = D_80180F9C[self->params];
         do { // !FAKE
         } while (0);
-        newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
             newEntity->params = 2;
@@ -1385,7 +1385,7 @@ void func_801B3B78() {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(0x38, g_CurrentEntity, entity);
             entity->params = 2;

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -399,8 +399,7 @@ void func_801B19A0(Entity* self) {
             if (self->params == 0) {
                 func_801C29B0(0x644);
                 for (i = 0; i < 2; i++) {
-                    newEntity =
-                        AllocEntity(&g_Entities[224], &g_Entities[256]);
+                    newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                     if (newEntity != NULL) {
                         CreateEntityFromEntity(0x22, self, newEntity);
                         newEntity->params = 0x1;
@@ -410,8 +409,7 @@ void func_801B19A0(Entity* self) {
                 break;
             }
             if (self->velocityY < FIX(0.5)) {
-                newEntity =
-                    AllocEntity(&g_Entities[224], &g_Entities[256]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(
                         E_INTENSE_EXPLOSION, self, newEntity);

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -537,7 +537,7 @@ void EntitySlogra(Entity* self) {
             EntitySlograSpecialCollision(D_8018105C);
             AnimateEntity(D_80181150, self);
             if (!(g_Timer % 4)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                     newEntity->posX.i.hi -= 16 - (Random() & 31);
@@ -553,7 +553,7 @@ void EntitySlogra(Entity* self) {
             break;
 
         case SLOGRA_DYING_END:
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 3;
@@ -649,7 +649,7 @@ void EntitySlograSpearProjectile(Entity* self) {
     Entity* entity;
 
     if (self->flags & 0x100) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, entity);
             entity->params = 1;
@@ -1162,7 +1162,7 @@ void EntityGaibon(Entity* self) {
         case GAIBON_DYING_TURN_INTO_BONES:
             if ((self->ext.GS_Props.timer % 8) == 0) {
                 func_801C29B0(NA_SE_EN_GAIBON_FLAME);
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_FIRE, self, newEntity);
                     newEntity->posY.i.hi += 28;
@@ -1329,7 +1329,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
         MoveEntity();
         AnimateEntity(D_80181378, self);
         if (!(g_Timer & 3)) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_GAIBON_BIG_FIREBALL, self, newEntity);
                 newEntity->params = 1;

--- a/src/st/nz0/4070C.c
+++ b/src/st/nz0/4070C.c
@@ -30,8 +30,7 @@ void func_801C07FC(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/nz0/4070C.c
+++ b/src/st/nz0/4070C.c
@@ -31,7 +31,7 @@ void func_801C07FC(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -475,7 +475,7 @@ void func_801C1848(void) {
     temp_s3 = ((Random() & 0xF) << 8) - 0x800;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/nz0/43708.c
+++ b/src/st/nz0/43708.c
@@ -228,7 +228,7 @@ void EntityBoneScimitar(Entity* self) {
     case BONE_SCIMITAR_DESTROY:
         g_api.PlaySfx(NA_SE_EN_SKELETON_DESTROY);
         for (i = 0; i < 7; i++) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity == NULL) {
                 break;
             }

--- a/src/st/nz0/43F9C.c
+++ b/src/st/nz0/43F9C.c
@@ -34,7 +34,7 @@ void func_801C3F9C(Unkstruct_801C3F9C** self) {
         (*self)->unk10 += 0x1800;
         (*self)->unk2C--;
         if ((*self)->unk2C == 0) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, newEntity);
                 newEntity->posX.i.hi = (*self)->unk14;
@@ -281,7 +281,7 @@ void EntityAxeKnight(Entity* self) {
         if (self->ext.generic.unk80.modeS16.unk0 != 0) {
             temp = --self->ext.generic.unk80.modeS16.unk0;
             if (!(self->ext.generic.unk80.modeS16.unk0 & 7)) {
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                     temp >>= 3;

--- a/src/st/nz0/44EAC.c
+++ b/src/st/nz0/44EAC.c
@@ -262,7 +262,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2C, self, newEntity);
                 if (self->facingLeft != 0) {
@@ -293,7 +293,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (!(Random() % 64)) { // Drop BloodDrips from the enemy knife
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2C, self, newEntity);
                 if (self->facingLeft != 0) {
@@ -323,7 +323,7 @@ void EntityBloodyZombie(Entity* self) {
     case BLOODY_ZOMBIE_TAKE_HIT:
         if (self->step_s == 0) {
             // Splat blood
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x2D, self, newEntity);
                 newEntity->facingLeft = GetSideToPlayer() & 1;
@@ -354,7 +354,7 @@ void EntityBloodyZombie(Entity* self) {
         if (self->animFrameIdx < 13) {
             if (!(g_Timer % 8)) {
                 func_801C29B0(NA_SE_EN_BLOODY_ZOMBIE_HEMORRHAGE);
-                newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+                newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (newEntity != NULL) {
                     CreateEntityFromEntity(0x2D, self, newEntity);
                     newEntity->facingLeft = self->ext.generic.unk84.U8.unk0;
@@ -395,7 +395,7 @@ void EntityBloodyZombie(Entity* self) {
         }
 
         if (AnimateEntity(D_80182334, self) == 0) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
                 newEntity->params = 2;

--- a/src/st/nz0/45F2C.c
+++ b/src/st/nz0/45F2C.c
@@ -150,7 +150,7 @@ void EntitySkeleton(Entity* self) {
     case SKELETON_DESTROY:
         func_801C29B0(NA_SE_EN_SKELETON_DESTROY);
         for (i = 0; i < 6; i++) { // Spawn Skeleton pieces
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromCurrentEntity(0x30, newEntity);
                 newEntity->facingLeft = self->facingLeft;

--- a/src/st/nz0/47048.c
+++ b/src/st/nz0/47048.c
@@ -53,7 +53,7 @@ void EntitySubWeaponContainer(Entity* self) {
 
     case SUBWPNCONT_IDLE: // Spawn Liquid bubbles
         if (!(g_Timer & 0xF)) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x3C, self, newEntity);
                 rnd = (Random() & 0x18) - 12;
@@ -83,7 +83,7 @@ void EntitySubWeaponContainer(Entity* self) {
         self->flags &= ~FLAG_HAS_PRIMS;
         g_api.PlaySfx(NA_SE_EV_GLASS_BREAK);
         while (i < ENTITY_SUBWPNCONT_DEBRIS_COUNT) {
-            newEntity = AllocEntity(D_8007D858, &D_8007D858[32]);
+            newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(0x3A, self, newEntity);
                 newEntity->posX.i.hi += glassPieceTBL->posX;

--- a/src/st/rwrp/113A0.c
+++ b/src/st/rwrp/113A0.c
@@ -201,7 +201,7 @@ void func_801924DC(void) {
     s32 i;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(2, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/rwrp/113A0.c
+++ b/src/st/rwrp/113A0.c
@@ -194,8 +194,22 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192348);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192414);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_801924DC);
+void func_801924DC(void) {
+    Entity* entity;
+    s8 temp_s4 = Random() & 3;
+    s16 temp_s3 = ((Random() & 0xF) << 8) - 0x800;
+    s32 i;
 
+    for (i = 0; i < 6; i++) {
+        entity = AllocEntity(D_8007D858, &D_8007D858[32]);
+        if (entity != NULL) {
+            CreateEntityFromEntity(2, g_CurrentEntity, entity);
+            entity->ext.generic.unk84.U8.unk1 = 6 - i;
+            entity->ext.generic.unk80.modeS16.unk0 = temp_s3;
+            entity->ext.generic.unk84.U8.unk0 = temp_s4;
+        }
+    }
+}
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192594);
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_8019276C);

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -282,7 +282,18 @@ s32 func_8018DC08(s16* posX) {
     return 1;
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018DDF0);
+Entity* AllocEntity(Entity* start, Entity* end) {
+    Entity* current = start;
+    while (current < end) {
+        if (current->entityId == E_NONE) {
+            DestroyEntity(current);
+            return current;
+        }
+
+        current++;
+    }
+    return NULL;
+}
 
 s32 func_8018DE50(u8 arg0, s16 arg1) { return D_80180A94[arg0] * arg1; }
 

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -297,8 +297,7 @@ void func_801B7BFC(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -298,7 +298,7 @@ void func_801B7BFC(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -629,7 +629,7 @@ void func_801B8C48(void) {
     temp_s3 = ((Random() & 0xF) << 8) - 0x800;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, D_8007D858 + MaxEntityCount);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/wrp/6FD0.c
+++ b/src/st/wrp/6FD0.c
@@ -1164,7 +1164,7 @@ void EntityBreakable(Entity* entity) {
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
             entityDropItem =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/wrp/6FD0.c
+++ b/src/st/wrp/6FD0.c
@@ -1163,8 +1163,7 @@ void EntityBreakable(Entity* entity) {
         if (entity->unk44) { // If the candle is destroyed
             Entity* entityDropItem;
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
-            entityDropItem =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            entityDropItem = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);
                 entityDropItem->params =

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -32,7 +32,7 @@ void func_8018F510(Entity* entity) {
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
             Entity* newEntity =
-                AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+                AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;
@@ -551,7 +551,7 @@ void func_8019055C(void) {
     temp_s3 = ((Random() & 0xF) << 8) - 0x800;
 
     for (i = 0; i < 6; i++) {
-        entity = AllocEntity(D_8007D858, &D_8007D858[MaxEntityCount]);
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, g_CurrentEntity, entity);
             entity->ext.generic.unk84.U8.unk1 = 6 - i;

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -31,8 +31,7 @@ void func_8018F510(Entity* entity) {
             entity->ext.generic.unk80.entityPtr->entityId;
     case 1:
         if (entity->ext.generic.unk7C.U8.unk0++ >= 5) {
-            Entity* newEntity =
-                AllocEntity(&g_Entities[224], &g_Entities[256]);
+            Entity* newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);
                 newEntity->entityId = E_EXPLOSION;


### PR DESCRIPTION
My last PR involved decompiling an unknown entity. I was hoping to find a call to CreateEntityFromEntity which would match, but none has been decompiled yet.

I noticed that there is a function which calls CreateEntityFromEntity which is decompiled in all overlays except CEN and RWRP. I figured we might as well finish it out and have it done in all of them.

The RWRP version calls AllocEntity, which also wasn't decompiled in RWRP, so I copied that in as well.

Not at all an important PR, and if we're not doing PR's that are only duplicates then feel free to close this without merging.