### PR TITLE
Update README.md - fix one grammar error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Decompiling a game is a mastodontic task. If you have some basic programming ski
 This project is possible thanks to the hard work of tools provided by the Decompilation community:
 
 * [mips2c](https://github.com/matt-kempster/m2c) from @matt-kempster to decompile MIPS assembly into C. This has proven to be more accurate than Hexrays IDA and Ghidra.
-* [splat](https://github.com/ethteck/splat) from @ethteck to disassemble code and extract data with a symbol map. This tool provides the fundamental of the SOTN decomp.
+* [splat](https://github.com/ethteck/splat) from @ethteck to disassemble code and extract data with a symbol map. This tool provides the fundamentals of the SOTN decomp.
 * [asm-differ](https://github.com/simonlindholm/asm-differ) from @simonlindholm to know how the decompiled code compares to the original binary.
 * [decomp-permuter](https://github.com/simonlindholm/decomp-permuter) from @simonlindholm to pick different versions of the same code that better matches the original binary.
 * [maspsx](https://github.com/mkst/maspsx) by @mkst to replicate the customized assembler used in the official PSX SDK.


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**Special thanks**"

"**the fundamental of the SOTN**"  should be "**the fundamentals of the SOTN**"

Screenshot-

![Screenshot (70)](https://github.com/Xeeynamo/sotn-decomp/assets/115995339/23f5ea8f-50f5-4970-bf2f-e423ea1561c5)
