### PR TITLE
Fix directory .md file output in analyze_calls CI

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -204,6 +204,7 @@ jobs:
             python3 tools/function_finder/function_finder_psx.py --use-call-trees > gh-duplicates/functions.md
             rm -rf gh-duplicates/function_calls/ || true
             mv function_calls gh-duplicates/
+            mv function_graphs.md gh-duplicates
       - name: Generate duplicates report
         run: |
           make force_symbols

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -438,6 +438,6 @@ if __name__ == "__main__":
             markdown = generate_md(functions)
             with open(f"{output_dir}/../function_graphs.md", "w") as f:
                 f.write(markdown)
-                print("Markdown written to" + os.path.realpath(f.name))
+                print("Markdown written to " + os.path.realpath(f.name))
             print(f"Generated HTML in {time.perf_counter() - timer} seconds")
     print("Exiting.")


### PR DESCRIPTION
I've been meaning to do this for a long time now.

The analyze_calls script running in the CI creates a .md file which acts as a directory pointing to all the function graphs that were generated. It also generates an HTML file. Because Github does not natively render HTML files, but does render Markdown files, it is preferrable to have this for the sake of easy viewing and linking within the gh-duplicates branch.

We need to just move the generated file into the proper directory, which will hopefully make it show up at https://github.com/Xeeynamo/sotn-decomp/tree/gh-duplicates. I'm very hopeful that this will work, and not be yet another "Fix CI" commit...

I also added a space to an output string. Doesn't really matter but might as well make things look a tiny bit nicer.