### PR TITLE
Decompile DRA func_8010E570

### DIFF
--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -460,7 +460,7 @@ void func_8010E570(s32 arg0) {
     case 3:
     case 4:
         var_a0 = 6;
-        if (ABS(PLAYER.velocityX) > 0x28000) {
+        if (ABS(PLAYER.velocityX) > FIX(2.5)) {
             var_a0 = 4;
         }
         break;

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -294,7 +294,7 @@ void func_8010E0D0(s32 arg0) {
 }
 void func_8010E168(s32 arg0, s16 arg1) {
     if (arg0 == 0) {
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x15002C, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, 0x150000 | 44, 0);
         if (arg1 >= g_Player.D_80072F1A) {
             g_Player.D_80072F1A = arg1;
         }
@@ -429,8 +429,48 @@ void func_8010E4D0(void) {
     func_8010E470(0, 0);
 }
 
-INCLUDE_ASM("dra/nonmatchings/6D59C", func_8010E570);
-void func_8010E570(/*?*/ s32);
+void func_8010E570(s32 arg0) {
+    s32 var_a0;
+    bool condition = false;
+
+    condition = ((g_Player.pl_vram_flag & 0x20) != condition);
+
+    PLAYER.velocityX = arg0;
+    PLAYER.velocityY = 0;
+    SetPlayerStep(Player_Stand);
+    if (g_Player.unk48 != 0) {
+        PLAYER.step_s = 2;
+        condition = 0;
+    }
+    switch (g_Player.unk50) {
+
+    case 9:
+        var_a0 = 4;
+        break;
+    case 1:
+        var_a0 = 4;
+        if (PLAYER.ext.player.unkAC == 9) {
+            PLAYER.ext.player.unkAC = D_800ACF54[2 + condition];
+            return;
+        }
+        if (PLAYER.ext.player.unkAC == 7) {
+            var_a0 = 0;
+        }
+        break;
+    case 3:
+    case 4:
+        var_a0 = 6;
+        if (ABS(PLAYER.velocityX) > 0x28000) {
+            var_a0 = 4;
+        }
+        break;
+    default:
+        var_a0 = 8;
+        break;
+    }
+    var_a0 += condition;
+    func_8010DA48(D_800ACF54[var_a0]);
+}
 
 void func_8010E6AC(s32 arg0) {
     bool condition = false;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -415,6 +415,7 @@ extern u16 D_800AC958[];
 extern s32 D_800ACC64[]; // probably a struct
 extern Vram g_Vram;
 extern CdFile* D_800ACC74[];
+extern u8 D_800ACF54[];
 extern u8 D_800ACFB4[][4];
 #if defined(VERSION_HD)
 extern s32 D_800ACEDC_hd;


### PR DESCRIPTION
This is one I first looked at many months ago, finally I got a match.

That being said, no idea what it does.

This also includes what I think is an innocent unrelated change to func_8010E168; if I'm being honest, I just forgot to remove that change from my local repo. I can push a new commit to remove it if desired but for now I'll leave it since it's an improvement and not worth its own whole PR.