### PR TITLE
Extract subweapon definitions

### DIFF
--- a/config/splat.us.dra.yaml
+++ b/config/splat.us.dra.yaml
@@ -43,7 +43,7 @@ segments:
       - [0x2EC0, .data, 5D6C4]
       - [0x2EE8, data]
       - [0x3C40, data]
-      - [0x4A00, data]
+      - [0x4A00, assets, subweapondefs, g_SubwpnDefs]
       - [0x4B04, assets, equipment, g_EquipDefs]
       - [0x7718, assets, accessory, g_AccessoryDefs]
       - [0x8258, data]

--- a/tools/splat_ext/subweapondefs_config.json
+++ b/tools/splat_ext/subweapondefs_config.json
@@ -1,0 +1,36 @@
+{
+    "struct": {
+        "attack": "s16",
+        "heartCost": "s16",
+        "attackElement": "u16",
+        "unk6": "u8",
+        "nFramesInvincibility": "u8",
+        "stunFrames": "u16",
+        "unkA": "u8",
+        "blueprintNum":"u8",
+        "hitboxState": "u16",
+        "hitEffect": "u16",
+        "crashId": "u8",
+        "unk11": "u8",
+        "entityRoomIndex": "u16"
+    },
+    "fields": {
+        "attackElement": [
+        "field_att0",
+        "field_att1",
+        "field_att2",
+        "field_att3",
+        "field_att4",
+        "HIT",
+        "CUT",
+        "POISON",
+        "CURSE",
+        "STONE",
+        "WATER",
+        "DARK",
+        "HOLY",
+        "ICE",
+        "THUNDER",
+        "FIRE"
+    ]}
+}


### PR DESCRIPTION
Fairly straightforward one here I think.

Unfortunately the subweapon name does not appear in the definition (actually... are subweapon names in the game at all? I don't recall them being in there, I think it's all just in the manual?) so it's hard to map these definitions to the subweapons. Might be good to think about whether we could insert comments somehow. Anyway, this works for now and might help with collecting the subweapons in one place to understand the remaining members of the definition.