### PR TITLE
Decompile highly duplicated GTE-using function

### DIFF
--- a/config/splat.us.stno3.yaml
+++ b/config/splat.us.stno3.yaml
@@ -71,6 +71,7 @@ segments:
       - [0x376E8, rodata]
       - [0x377A4, .rodata, 56264] # EntityBat
       - [0x377B8, .rodata, 564B0] # EntityZombie
+      - [0x377CC, rodata] #D_801B77CC
       - [0x377D4, c]
       - [0x3C4EC, c]
       - [0x3E134, c]

--- a/src/st/cen/1B274.c
+++ b/src/st/cen/1B274.c
@@ -252,16 +252,16 @@ void func_8019BED4(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_8018D5F8;
+    rot = D_8018D5F8;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -276,27 +276,27 @@ void func_8019BED4(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/cen/1B274.c
+++ b/src/st/cen/1B274.c
@@ -259,7 +259,6 @@ void func_8019BED4(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_8018D5F8;

--- a/src/st/cen/1B274.c
+++ b/src/st/cen/1B274.c
@@ -248,7 +248,82 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/1B274", func_8019BED4);
+void func_8019BED4(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_8018D5F8;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/cen/nonmatchings/1B274", func_8019C2BC);
 

--- a/src/st/cen/1B274.c
+++ b/src/st/cen/1B274.c
@@ -249,7 +249,7 @@ void BottomCornerText(u8* str, u8 lower_left) {
 }
 
 void func_8019BED4(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -274,7 +274,8 @@ void func_8019BED4(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -290,8 +291,8 @@ void func_8019BED4(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -313,7 +314,7 @@ void func_8019BED4(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -79,6 +79,7 @@ extern u16 D_801811C8[];
 extern u16 D_801811D8[];
 extern u8 D_80181238;
 extern ObjInit2 D_8018125C[];
+extern SVECTOR D_8018D5F8;
 extern LayoutEntity* D_8019C764;
 extern u16* D_8019C768;
 extern u8 D_8019C76C;

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -749,7 +749,7 @@ void BottomCornerText(u8* str, u8 lower_left) {
 }
 
 void func_801A2018(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -774,7 +774,8 @@ void func_801A2018(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -790,8 +791,8 @@ void func_801A2018(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -813,7 +814,7 @@ void func_801A2018(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -752,16 +752,16 @@ void func_801A2018(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_80191A5C;
+    rot = D_80191A5C;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -776,27 +776,27 @@ void func_801A2018(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -748,7 +748,82 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A2018);
+void func_801A2018(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_80191A5C;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A2400);
 

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -759,7 +759,6 @@ void func_801A2018(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_80191A5C;

--- a/src/st/dre/dre.h
+++ b/src/st/dre/dre.h
@@ -121,6 +121,8 @@ extern u16 D_801810E0[];
 extern u8* D_801810F4[];
 extern s32 c_GoldPrizes[];
 
+extern SVECTOR D_80191A5C;
+
 // *** EntitySoulStealOrb properties START ***
 
 extern u16 D_8018138C[]; // NOTE(sestren): Random angle offsets?

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -563,6 +563,9 @@ void EntityRoomForeground(Entity* entity) {
 
 INCLUDE_ASM("asm/us/st/mad/nonmatchings/15520", func_80198BC8);
 
+// This is a heavily duplicated function. It does not work here
+// because GTE functions are not found in MAD, I think there is
+// an issue in the #include structure where parts of the sdk are missing.
 INCLUDE_ASM("asm/us/st/mad/nonmatchings/15520", func_80198FA0);
 
 INCLUDE_ASM("asm/us/st/mad/nonmatchings/15520", func_80199388);

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -127,16 +127,16 @@ void func_801D6880(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_801B77CC;
+    rot = D_801B77CC;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -151,27 +151,27 @@ void func_801D6880(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -134,7 +134,6 @@ void func_801D6880(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_801B77CC;

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -124,7 +124,7 @@ void EntityZombieSpawner(Entity* self) {
 }
 
 void func_801D6880(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -149,7 +149,8 @@ void func_801D6880(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -165,8 +166,8 @@ void func_801D6880(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -188,7 +189,7 @@ void func_801D6880(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -75,8 +75,6 @@ void EntityZombie(Entity* self) {
     }
 }
 
-const u32 rodataPadding_377CC[] = {0, 0};
-
 /*
  * An invisible entity that is responsible for spawning the "floor
  * zombies" that come up from the ground and swarm the player.
@@ -125,7 +123,82 @@ void EntityZombieSpawner(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/564B0", func_801D6880);
+void func_801D6880(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_801B77CC;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/no3/nonmatchings/564B0", func_801D6C68);
 

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -256,5 +256,6 @@ extern u16 D_80182740[];
 // *** EntitySoulStealOrb properties END ***
 
 extern SVECTOR D_801B73E0;
+extern SVECTOR D_801B77CC;
 
 extern Dialogue g_Dialogue;

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -466,7 +466,6 @@ void func_801D1F38(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_801B2464;

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -459,16 +459,16 @@ void func_801D1F38(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_801B2464;
+    rot = D_801B2464;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -483,27 +483,27 @@ void func_801D1F38(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -456,7 +456,7 @@ void EntityBladeSword(Entity* self) {
 }
 
 void func_801D1F38(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -481,7 +481,8 @@ void func_801D1F38(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -497,8 +498,8 @@ void func_801D1F38(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -520,7 +521,7 @@ void func_801D1F38(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -455,7 +455,82 @@ void EntityBladeSword(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", func_801D1F38);
+void func_801D1F38(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_801B2464;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", func_801D2320);
 

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -322,3 +322,4 @@ extern u16 D_801820CC[];
 // *** EntitySoulStealOrb properties END ***
 
 extern SVECTOR D_801B1EA0;
+extern SVECTOR D_801B2464;

--- a/src/st/nz0/49930.c
+++ b/src/st/nz0/49930.c
@@ -1,7 +1,7 @@
 #include "nz0.h"
 
 void func_801C9930(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -26,7 +26,8 @@ void func_801C9930(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -42,8 +43,8 @@ void func_801C9930(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -65,7 +66,7 @@ void func_801C9930(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/nz0/49930.c
+++ b/src/st/nz0/49930.c
@@ -4,16 +4,16 @@ void func_801C9930(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_801B0934;
+    rot = D_801B0934;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -28,27 +28,27 @@ void func_801C9930(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/nz0/49930.c
+++ b/src/st/nz0/49930.c
@@ -1,6 +1,81 @@
 #include "nz0.h"
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/49930", func_801C9930);
+void func_801C9930(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_801B0934;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/nz0/nonmatchings/49930", func_801C9D18);
 

--- a/src/st/nz0/49930.c
+++ b/src/st/nz0/49930.c
@@ -11,7 +11,6 @@ void func_801C9930(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_801B0934;

--- a/src/st/nz0/nz0.h
+++ b/src/st/nz0/nz0.h
@@ -353,6 +353,7 @@ extern s32 D_801823A4;
 extern const char D_801B058C[]; // "charal %x\n"
 extern const char D_801B0598[]; // "charal %x\n"
 extern const char D_801B08C8[]; // "charal %x\n"
+extern SVECTOR D_801B0934;
 extern s16 D_801CB68E;
 extern u16 D_801CB690;
 extern s16 D_801CB692;

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -123,7 +123,6 @@ void func_801951F0(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_80188DE8;

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -116,16 +116,16 @@ void func_801951F0(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_80188DE8;
+    rot = D_80188DE8;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -140,27 +140,27 @@ void func_801951F0(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -112,7 +112,82 @@ void func_80194DD4(Entity* entity) {
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", BottomCornerText);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", func_801951F0);
+void func_801951F0(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_80188DE8;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", func_801955D8);
 

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -113,7 +113,7 @@ void func_80194DD4(Entity* entity) {
 INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", BottomCornerText);
 
 void func_801951F0(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -138,7 +138,8 @@ void func_801951F0(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -154,8 +155,8 @@ void func_801951F0(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -177,7 +178,7 @@ void func_801951F0(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/rwrp/rwrp.h
+++ b/src/st/rwrp/rwrp.h
@@ -12,6 +12,7 @@ extern PfnEntityUpdate D_801803E0[];
 extern u16 D_80180494[];
 extern s16 D_80180A94[];
 extern ObjInit2 D_80181134[];
+extern SVECTOR D_80188DE8;
 extern LayoutEntity* D_80195A30;
 extern LayoutEntity* D_80195A34;
 void CreateEntityFromLayout(Entity*, LayoutEntity*);

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -1065,7 +1065,6 @@ void func_801BD0C0(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_801A7D3C;

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -1055,7 +1055,7 @@ void EntityCutscenePhotographFire(Entity* entity) {
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BC5C0);
 
 void func_801BD0C0(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -1080,7 +1080,8 @@ void func_801BD0C0(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -1096,8 +1097,8 @@ void func_801BD0C0(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -1119,7 +1120,7 @@ void func_801BD0C0(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -1054,7 +1054,82 @@ void EntityCutscenePhotographFire(Entity* entity) {
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BC5C0);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BD0C0);
+void func_801BD0C0(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_801A7D3C;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BD4A8);
 

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -1058,16 +1058,16 @@ void func_801BD0C0(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_801A7D3C;
+    rot = D_801A7D3C;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -1082,27 +1082,27 @@ void func_801BD0C0(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/st0/st0.h
+++ b/src/st/st0/st0.h
@@ -145,6 +145,7 @@ extern u8 D_80181EF0[];
 extern u16 D_80181EF4[];
 extern u16 D_80181F04[];
 extern u8 D_801824CC[];
+extern SVECTOR D_801A7D3C;
 extern u16* D_801C00A4;
 extern s32 D_801C24C8;
 extern s32 D_801C2580;

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -1035,7 +1035,82 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/F420", func_80193270);
+void func_80193270(Primitive* arg0) {
+    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR stackpad;
+    SVECTOR sp20;
+    VECTOR sp28;
+    SVECTOR sp38;
+    SVECTOR sp40;
+    SVECTOR sp48;
+    SVECTOR sp50;
+    MATRIX sp58;
+    SVECTOR sp78;
+    u16 temp_a0;
+    u8 temp_v1_2;
+
+    sp78 = D_80186FC8;
+    if (arg0->p3 & 8) {
+        // Fake logic here, sp10 is not an SVECTOR but it matches.
+        // tried using an f32 but couldn't get it to work.
+        sp10.vy = arg0->next->x1;
+        sp10.vx = arg0->next->y1;
+        LOW(sp10.vx) += LOW(arg0->next->u0);
+        arg0->next->x1 = sp10.vy;
+        arg0->next->y1 = sp10.vx;
+        LOW(arg0->next->x0) += LOW(arg0->next->r1);
+    }
+    temp_v1_2 = arg0->next->b3;
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
+    sp28.vx = 0;
+    sp28.vy = 0;
+    sp28.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&sp78, &sp58);
+    if (arg0->p3 & 0x20) {
+        sp20.vx = arg0->next->x3;
+        sp20.vy = arg0->next->y3;
+        RotMatrixX(sp20.vx, &sp58);
+        RotMatrixY(sp20.vy, &sp58);
+    }
+    sp20.vz = arg0->next->tpage;
+    RotMatrixZ(sp20.vz, &sp58);
+    TransMatrix(&sp58, &sp28);
+    if (arg0->p3 & 0x10) {
+        sp28.vx = (s32) arg0->next->x2;
+        sp28.vy = (s32) arg0->next->y2;
+        sp28.vz = 0x1000;
+        ScaleMatrix(&sp58, &sp28.vx);
+    }
+    SetRotMatrix(&sp58);
+    SetTransMatrix(&sp58);
+    SetGeomScreen(0x400);
+    SetGeomOffset(arg0->next->x1, arg0->next->y0);
+    sp38.vx = -LOH(arg0->next->r2) / 2;
+    sp38.vy = -LOH(arg0->next->b2) / 2;
+    sp38.vz = 0;
+    sp40.vx = LOH(arg0->next->r2) / 2;
+    sp40.vy = -LOH(arg0->next->b2) / 2;
+    sp40.vz = 0;
+    sp48.vx = -LOH(arg0->next->r2) / 2;
+    sp48.vy = LOH(arg0->next->b2) / 2;
+    sp48.vz = 0;
+    sp50.vx = LOH(arg0->next->r2) / 2;
+    sp50.vy = LOH(arg0->next->b2) / 2;
+    sp50.vz = 0;
+    gte_ldv0(&sp38);
+    gte_rtps();
+    gte_stsxy(&arg0->x0); 
+    gte_ldv0(&sp40);
+    gte_rtps();
+    gte_stsxy(&arg0->x1);
+    gte_ldv0(&sp48);
+    gte_rtps();
+    gte_stsxy(&arg0->x2);
+    gte_ldv0(&sp50);
+    gte_rtps();
+    gte_stsxy(&arg0->x3);
+}
 
 INCLUDE_ASM("asm/us/st/wrp/nonmatchings/F420", func_80193658);
 

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -1039,16 +1039,16 @@ void func_80193270(Primitive* arg0) {
     SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
-    VECTOR sp28;
+    VECTOR trans1;
     SVECTOR sp38;
     SVECTOR sp40;
     SVECTOR sp48;
     SVECTOR sp50;
-    MATRIX sp58;
-    SVECTOR sp78;
+    MATRIX m;
+    SVECTOR rot;
     u8 temp_v1_2;
 
-    sp78 = D_80186FC8;
+    rot = D_80186FC8;
     if (arg0->p3 & 8) {
         // Fake logic here, sp10 is not an SVECTOR but it matches.
         // tried using an f32 but couldn't get it to work.
@@ -1063,27 +1063,27 @@ void func_80193270(Primitive* arg0) {
     LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
         temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
-    sp28.vx = 0;
-    sp28.vy = 0;
-    sp28.vz = 0x400 - LOH(arg0->next->u1);
-    RotMatrix(&sp78, &sp58);
+    trans1.vx = 0;
+    trans1.vy = 0;
+    trans1.vz = 0x400 - LOH(arg0->next->u1);
+    RotMatrix(&rot, &m);
     if (arg0->p3 & 0x20) {
         sp20.vx = arg0->next->x3;
         sp20.vy = arg0->next->y3;
-        RotMatrixX(sp20.vx, &sp58);
-        RotMatrixY(sp20.vy, &sp58);
+        RotMatrixX(sp20.vx, &m);
+        RotMatrixY(sp20.vy, &m);
     }
     sp20.vz = arg0->next->tpage;
-    RotMatrixZ(sp20.vz, &sp58);
-    TransMatrix(&sp58, &sp28);
+    RotMatrixZ(sp20.vz, &m);
+    TransMatrix(&m, &trans1);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32)arg0->next->x2;
-        sp28.vy = (s32)arg0->next->y2;
-        sp28.vz = 0x1000;
-        ScaleMatrix(&sp58, &sp28.vx);
+        trans1.vx = (s32)arg0->next->x2;
+        trans1.vy = (s32)arg0->next->y2;
+        trans1.vz = 0x1000;
+        ScaleMatrix(&m, &trans1);
     }
-    SetRotMatrix(&sp58);
-    SetTransMatrix(&sp58);
+    SetRotMatrix(&m);
+    SetTransMatrix(&m);
     SetGeomScreen(0x400);
     SetGeomOffset(arg0->next->x1, arg0->next->y0);
     sp38.vx = -LOH(arg0->next->r2) / 2;

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -1036,7 +1036,7 @@ void BottomCornerText(u8* str, u8 lower_left) {
 }
 
 void func_80193270(Primitive* arg0) {
-    SVECTOR sp10; //FAKE, not really an svector
+    SVECTOR sp10; // FAKE, not really an svector
     SVECTOR stackpad;
     SVECTOR sp20;
     VECTOR sp28;
@@ -1061,7 +1061,8 @@ void func_80193270(Primitive* arg0) {
         LOW(arg0->next->x0) += LOW(arg0->next->r1);
     }
     temp_v1_2 = arg0->next->b3;
-    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) = temp_v1_2 | (temp_v1_2 << 8);
+    LOH(arg0->r0) = LOH(arg0->r1) = LOH(arg0->r2) = LOH(arg0->r3) =
+        temp_v1_2 | (temp_v1_2 << 8);
     arg0->b0 = arg0->b1 = arg0->b2 = arg0->b3 = temp_v1_2;
     sp28.vx = 0;
     sp28.vy = 0;
@@ -1077,8 +1078,8 @@ void func_80193270(Primitive* arg0) {
     RotMatrixZ(sp20.vz, &sp58);
     TransMatrix(&sp58, &sp28);
     if (arg0->p3 & 0x10) {
-        sp28.vx = (s32) arg0->next->x2;
-        sp28.vy = (s32) arg0->next->y2;
+        sp28.vx = (s32)arg0->next->x2;
+        sp28.vy = (s32)arg0->next->y2;
         sp28.vz = 0x1000;
         ScaleMatrix(&sp58, &sp28.vx);
     }
@@ -1100,7 +1101,7 @@ void func_80193270(Primitive* arg0) {
     sp50.vz = 0;
     gte_ldv0(&sp38);
     gte_rtps();
-    gte_stsxy(&arg0->x0); 
+    gte_stsxy(&arg0->x0);
     gte_ldv0(&sp40);
     gte_rtps();
     gte_stsxy(&arg0->x1);

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -1046,7 +1046,6 @@ void func_80193270(Primitive* arg0) {
     SVECTOR sp50;
     MATRIX sp58;
     SVECTOR sp78;
-    u16 temp_a0;
     u8 temp_v1_2;
 
     sp78 = D_80186FC8;

--- a/src/st/wrp/wrp.h
+++ b/src/st/wrp/wrp.h
@@ -42,4 +42,6 @@ extern u32 D_80181110[];
 
 // *** EntitySoulStealOrb properties END ***
 
+extern SVECTOR D_80186FC8;
+
 void func_8018F838(Entity*);


### PR DESCRIPTION
Not sure what this one does, but it's in all the overlays.

I couldn't get `mad` to work, since it gives errors when I reference functions like `RotMatrixZ` (which isn't even one of the new `gte_` defines). I figured we can leave that for later since `mad` is its own weird thing.

I also found an issue with the splat for `no3` where some boundaries were being drawn in the wrong places; this is now corrected which allows the function to work in that location.

The function takes a primitive as its argument and does some stuff with it. I don't know what it actually does. It appears that the different overlays use it in different places (and some overlays don't call it at all). The function loads an external SVECTOR from a variable, which I added to the `.h` file for each overlay. The vector is in a weird location in some overlays, especially in no3 where it appears to be the last few bytes of the rodata.

Anyway, happy to take naming ideas for either the function or the SVECTOR that it loads. And I imagine we'll end up renaming those sp variables.

We have a lot of casts and especially LOH calls in this one. Maybe we're interpreting the primitive wrong. It doesn't match up with the FakePrim we've been using lately, so I don't know what to make of this.

I think those are the main highlights! There aren't many functions that use the GTE and it's nice that there is so much duplication so we can deal with a lot of them all at once. I expect a lot of changes on this one so please don't hold back :)

Here's the scratch for one instance of the function, in case you'd like to play around with anything: https://decomp.me/scratch/N5RR5