### PR TITLE
Fix pointer argument for func_800F9D88

### DIFF
--- a/src/dra/5298C.c
+++ b/src/dra/5298C.c
@@ -3085,13 +3085,13 @@ void func_800F9D40(s32 arg0, s32 arg1, s32 arg2) {
 }
 
 #if defined(VERSION_US)
-void func_800F9D88(s32 arg0, s32 arg1, s32 arg2) {
+void func_800F9D88(const char* str, s32 arg1, s32 arg2) {
     if (arg2 != 0) {
         D_8013794C = g_Pix[2];
     }
     D_80137950 = 0;
     D_80137954 = 0x100;
-    func_800F99B8(arg0, arg1, 0);
+    func_800F99B8(str, arg1, 0);
 }
 #endif
 


### PR DESCRIPTION
Came across this function.

Its main job is that it passes its arguments onward to `func_800F99B8` (these two functions are easy to confuse the names of, these numbers are too similar...)

Since the first argument of func_800F99B8 is a `const char*`, this function should be changed to match.