### PR TITLE
Refactor some functions with gravity jump

### DIFF
--- a/src/dra/5D6C4.c
+++ b/src/dra/5D6C4.c
@@ -747,14 +747,10 @@ s32 HandleTransformationMP(TransformationForm form, CallMode mode) {
     }
 }
 
-s32 func_800FF064(s32 arg0) {
-    s32 playerMP;
-
-    playerMP = g_Status.mp - 4;
-
-    if (playerMP > 0) {
-        if (arg0 != 0) {
-            g_Status.mp = playerMP;
+bool HandleGravityBootsMP(CallMode mode) {
+    if ((g_Status.mp - 4) > 0) {
+        if (mode != CHECK_ONLY) {
+            g_Status.mp -= 4;
         }
         return 0;
     }

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -562,22 +562,23 @@ void func_8010E940(void) {
     }
 }
 
-void func_8010E9A4(void) {
+void DoGravityJump(void) {
     if (func_8010E27C() != 0) {
-        SetSpeedX(0x30000);
+        SetSpeedX(FIX(3));
     } else {
         PLAYER.velocityX = 0;
     }
 
-    if (PLAYER.step == 4) {
+    if (PLAYER.step == Player_Jump) {
         g_Player.unk44 |= 1;
     } else {
         g_Player.unk44 = 0;
     }
-
+    // Factory with blueprint 2, creates child entity 3 which is
+    // EntityGravityBootBeam
     CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 2), 0);
     SetPlayerStep(Player_HighJump);
-    PLAYER.velocityY = -0xC0000;
+    PLAYER.velocityY = FIX(-12);
     func_8010DA48(0x21);
     g_Player.unk4A = 0;
 }

--- a/src/dra/704D0.c
+++ b/src/dra/704D0.c
@@ -28,11 +28,11 @@ bool CheckGravityBootsInput(void) {
         }
         if (IsRelicActive(RELIC_GRAVITY_BOOTS) &&
             (g_Player.padTapped & PAD_CROSS) && !(g_Player.unk46 & 0x8000) &&
-            ((PLAYER.step == 2) ||
-             ((PLAYER.step == 4) && (g_Player.unk44 & 1)))) {
+            ((PLAYER.step == Player_Crouch) ||
+             ((PLAYER.step == Player_Jump) && (g_Player.unk44 & 1)))) {
             if (g_Player.unk72 == 0) {
-                if (func_800FF064(1) >= 0) {
-                    func_8010E9A4();
+                if (HandleGravityBootsMP(REDUCE) >= 0) {
+                    DoGravityJump();
                     g_ButtonCombo[COMBO_GRAVITY_BOOTS].buttonsCorrect = 0;
                     return 1;
                 }


### PR DESCRIPTION
- Rename func_800FF064 to HandleGravityBootsMP (call graph proves that this is the only use: https://raw.githubusercontent.com/Xeeynamo/sotn-decomp/gh-duplicates/function_calls/dra.func_800FF064.svg)
- Rewrite that function to use the CallMode system we developed earlier, and also rewrite it to not need the extra variable. Function is now much shorter.
- Rename func_8010E9A4 to DoGravityJump. This function sets Alucard's velocity to move up rapidly, spawns the gravity boot laser beam entity, and sets the player state machine's step.
- Fill in enums for SetPlayerStep in a few related places.

Overall I think this makes the logic more readable. Next going to look into g_Player.unk44 because that seems to be the last missing piece here.