### PR TITLE
Refactor of RIC functions

### DIFF
--- a/config/symbols.us.ric.txt
+++ b/config/symbols.us.ric.txt
@@ -3,4 +3,5 @@ DestroyEntity = 0x80156C60;
 GetTeleportToOtherCastle = 0x80156CCC;
 UpdateEntityRichter = 0x80157BFC;
 SetPlayerStep = 0x8015C908;
+SetSpeedX = 0x8015CA84;
 g_DebugWaitInfoTimer = 0x80174F7C;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -279,7 +279,7 @@ void func_80158F38(void) {
         }
 
         if (PLAYER.step_s == 0) {
-            func_8015CA84(0x14000);
+            SetSpeedX(0x14000);
         }
     }
 }
@@ -305,7 +305,7 @@ void func_80158FA4(void) {
                 PLAYER.velocityX = 0;
             }
         } else if (PLAYER.step_s == 0) {
-            func_8015CA84(0x24000);
+            SetSpeedX(0x24000);
         }
     }
 }
@@ -323,7 +323,7 @@ void func_801595D8(void) {
     if (g_Player.D_80072F0A != 0 && g_Player.padTapped & PAD_CROSS) {
         func_8015D020();
     } else if (func_8015C9CC() != 0) {
-        func_8015CA84(0xC000);
+        SetSpeedX(0xC000);
     }
 }
 

--- a/src/ric/1FCD0.c
+++ b/src/ric/1FCD0.c
@@ -54,7 +54,7 @@ void func_8015BE84(void) {
     if (g_Player.padPressed & PAD_SQUARE && g_Player.unk44 & 0x80) {
         PLAYER.step = 4;
         func_8015C920(&D_8015555C);
-        func_8015CA84(-0x18000);
+        SetSpeedX(-0x18000);
         PLAYER.velocityY = 0;
         if (g_Player.unk72 == 0) {
             PLAYER.velocityY = -0x48000;

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -59,7 +59,7 @@ s32 func_8015C9CC(void) {
     return 0;
 }
 
-void func_8015CA84(s32 speed) {
+void SetSpeedX(s32 speed) {
     if (g_CurrentEntity->facingLeft == 1)
         speed = -speed;
     g_CurrentEntity->velocityX = speed;
@@ -167,7 +167,7 @@ void func_8015CDE0(s32 arg0) {
     g_Player.unk44 = 0;
     SetPlayerStep(1);
     func_8015C920(&D_80155488);
-    func_8015CA84(0x14000);
+    SetSpeedX(0x14000);
     PLAYER.velocityY = 0;
 }
 
@@ -178,7 +178,7 @@ void func_8015CE7C(void) {
         g_Player.unk44 = 0;
         SetPlayerStep(0x19);
         func_8015C920(&D_80155670);
-        func_8015CA84(0x24000);
+        SetSpeedX(0x24000);
         g_Player.D_80072F16 = 0x28;
         PLAYER.velocityY = 0;
         func_801606BC(g_CurrentEntity, 0x50001, 0);
@@ -220,43 +220,36 @@ block_6:
 }
 
 void func_8015D020(void) {
-    u16 temp; // TODO: !FAKE
-
     if (g_Player.unk72 != 0) {
         func_8015CF08();
         return;
     }
-
-    if (func_8015C9CC() != 0 || PLAYER.step == 0x17) {
+    if (func_8015C9CC() != 0 || PLAYER.step == Player_Slide) {
         func_8015C920(&D_8015550C);
-        if (PLAYER.step == 0x19) {
-            func_8015CA84(0x24000);
-            temp = 0x10;
-            goto block_8;
+        if (PLAYER.step == Player_Unk25) {
+            SetSpeedX(FIX(2.25));
+            g_Player.unk44 = 0x10;
+        } else {
+            SetSpeedX(FIX(1.25));
+            g_Player.unk44 = 0;
         }
-        func_8015CA84(0x14000);
-        g_Player.unk44 = 0;
     } else {
         func_8015C920(&D_801554F0);
-        temp = 4;
         PLAYER.velocityX = 0;
-    block_8:
-        g_Player.unk44 = temp;
+        g_Player.unk44 = 4;
     }
-
-    SetPlayerStep(4);
-
+    SetPlayerStep(Player_Jump);
     if (D_80154570 != 0) {
-        PLAYER.velocityY = -0x4B000;
+        PLAYER.velocityY = -FIX(4.6875);
     } else {
-        PLAYER.velocityY = -0x57000;
+        PLAYER.velocityY = -FIX(5.4375);
     }
 }
 
 void func_8015D120(void) {
     SetPlayerStep(8);
     PLAYER.velocityX = 0;
-    func_8015CA84(0x14000);
+    SetSpeedX(0x14000);
     PLAYER.velocityY = -0x78000;
     g_Player.pl_high_jump_timer = 0;
     func_8015C920(&D_8015579C);

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -65,7 +65,7 @@ void func_8015D9D4(void) {
     SetPlayerStep(0x17);
     func_8015C920(&D_80155750);
     g_CurrentEntity->velocityY = 0;
-    func_8015CA84(0x58000);
+    SetSpeedX(0x58000);
     func_8015CC28();
     func_801606BC(g_CurrentEntity, 0x19, 0);
     g_api.PlaySfx(0x707);
@@ -77,7 +77,7 @@ void func_8015DA60(void) {
     SetPlayerStep(0x1A);
     func_8015C920(&D_8015577C);
     g_CurrentEntity->velocityY = FIX(-2);
-    func_8015CA84(0x58000);
+    SetSpeedX(0x58000);
     func_8015CC28();
     func_801606BC(g_CurrentEntity, 0x19, 0);
     g_api.PlaySfx(0x6FA);
@@ -89,7 +89,7 @@ void func_8015DB04(void) {
     SetPlayerStep(0x18);
     func_8015C920(&D_801557D8);
     g_CurrentEntity->velocityY = 0;
-    func_8015CA84(0x58000);
+    SetSpeedX(0x58000);
     g_Player.unk46 = 5;
     g_Player.D_80072F18 = 4;
     func_801606BC(g_CurrentEntity, 0x1A, 0);

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -9,7 +9,46 @@ typedef enum {
 } EntityIDs;
 
 typedef enum {
-    Dummy,
+    Player_Stand,
+    Player_Walk,
+    Player_Crouch,
+    Player_Fall,
+    Player_Jump,
+    Player_MorphBat,
+    Player_AlucardStuck,
+    Player_MorphMist,
+    Player_HighJump,
+    Player_UnmorphBat,
+    Player_Hit,
+    Player_StatusStone,
+    Player_BossGrab, // Darkwing Bat and Akmodan II
+    Player_KillWater,
+    Player_UnmorphMist,
+    Player_SwordWarp, // Alucard Sword and Osafune Katana
+    Player_Kill,
+    Player_Unk17,
+    Player_Teleport, // also Grand Cross and Spiral Axe
+    Player_FlameWhip,
+    Player_Hydrostorm,
+    Player_ThousandBlades,
+    Player_RichterFourHolyBeasts,
+    Player_Slide,
+    Player_Unk24, // MorphWolf and Richter's Tackle
+    Player_Unk25, // UnMorphWolf and Sprint
+    Player_SlideKick,
+    Player_Unk27, // other item crashes
+    Player_SpellDarkMetamorphosis = 32,
+    Player_SpellSummonSpirit,
+    Player_SpellHellfire,
+    Player_SpellTetraSpirit,
+    Player_Spell36,
+    Player_SpellSoulSteal,
+    Player_Unk38,
+    Player_SpellSwordBrothers,
+    Player_AxearmorStand,
+    Player_AxearmorWalk,
+    Player_AxearmorJump,
+    Player_AxearmorHit,
 } PlayerSteps;
 
 extern void func_80159C04(void);

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -20,7 +20,7 @@ extern void SetPlayerStep(PlayerSteps step);
 void func_8015C920(AnimationFrame* unk0);
 extern void func_8015C93C(s32 speed);
 extern s32 func_8015C9CC(void);
-extern void func_8015CA84(s32 speed);
+extern void SetSpeedX(s32 speed);
 extern void func_8015CCC8(s32 arg0, s32 velocityX);
 extern void func_8015CD98(s32 velocityX);
 extern void func_8015CDE0(s32);


### PR DESCRIPTION
- Main focus is an update of func_8015D020. That had a TODO to remove a variable, which I have now removed. I also used enums for player steps, and changed the speeds to use FIX(). I also cleaned up the control flow to remove the goto.

- While working on that function, I noticed that it calls an unnamed function. The duplicates list at https://raw.githubusercontent.com/Xeeynamo/sotn-decomp/gh-duplicates/duplicates.txt indicates that SetSpeedX was missing from RIC. I added that in now and adjusted all uses in RIC, including the ones in func_8015D020.

That's about it; these are two different changes but given that we're just changing the format of them, I'm assuming this will not be an issue to have them in one PR.

Had to add PlayerSteps into RIC since we're using enums for Player.step and SetPlayerStep. I think maybe these should be moved out of dra.h and into somewhere more generic, but for now copying it over works well enough. If there are steps that are reused between Alucard and Richter for mutually exclusive moves (ie, step N is an Alucard-specific move for Alucard and a Richter-specific move for Richter) then we will need to maintain separate lists. This works for now.