### PR TITLE
Decompile RIC func_80156DE4

### DIFF
--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -58,7 +58,39 @@ TeleportCheck GetTeleportToOtherCastle(void) {
     return TELEPORT_CHECK_NONE;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_80156DE4);
+s16 func_80156DE4(void) {
+    // Variables that change during execution
+    Collider collider;
+    s32 yvar;
+    s32 collisions;
+    s32 i;
+    // Values that are set once and never again (but not const for some reason)
+    s32 xpos = PLAYER.posX.i.hi;
+    s32 xp4 = xpos + 4;
+    s32 xm4 = xpos - 4;
+    s32 coll_flags = EFFECT_SOLID_FROM_ABOVE | EFFECT_SOLID;
+
+    for (i = 0; i < 3; i++) {
+        yvar = PLAYER.posY.i.hi + D_80154568[i];
+        g_api.CheckCollision(xpos, yvar, &collider, 0);
+        collisions = 0;
+        if ((collider.effects & coll_flags) == EFFECT_SOLID) {
+            collisions += 1;
+        }
+        g_api.CheckCollision(xp4, yvar, &collider, 0);
+        if ((collider.effects & coll_flags) == EFFECT_SOLID) {
+            collisions += 1;
+        }
+        g_api.CheckCollision(xm4, yvar, &collider, 0);
+        if ((collider.effects & coll_flags) == EFFECT_SOLID) {
+            collisions += 1;
+        }
+        if (collisions != 0) {
+            return i + 1;
+        }
+    }
+    return 0;
+}
 
 INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_80156F40);
 

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -39,6 +39,7 @@ extern s32 func_8016840C(s16 x, s16 y);
 extern void func_80169C10(Entity* entity);
 extern void func_80169D74(Entity* entity);
 
+extern s16 D_80154568[];
 extern s32 D_80154570;
 extern s32 D_8015459C;
 extern s16 D_801545A8;


### PR DESCRIPTION
This one is a bit frustrating. The reason for that is that this is a duplicate of DRA `func_80110394`. Luckily, when I started decompiling this one, I recognized the assembly as being similar, since I decompiled that function in DRA a long time ago. I think the reason the function duplicate finder misses it is that it uses g_api.CheckCollision, while the DRA version was able to directly call CheckCollision without going through g_api.

Also, this one uses `i<3` in its for-loop, while the DRA one used i<4.

Overall, seems that being aware of `g_api` mismatches will be important to keep in mind as we go forward. I think I'm going to try to decompile a lot of RIC in the near future, so that it can catch up to DRA. And maybe if we're lucky, that will help to solve some of the functions that are currently tricky in DRA. We'll see.