### PR TITLE
Decompile RIC func_8017091C

### DIFF
--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -54,7 +54,7 @@ segments:
       - [0x1AB68, .rodata, 32324]
       - [0x1AB88, rodata]
       - [0x1ABC8, .rodata, 345EC] # func_801705EC jtbl
-      - [0x1ABF0, rodata]
+      - [0x1AC10, rodata]
       - [0x1AC60, c, 1AC60]
       - [0x1F348, c, 1F348]
       - [0x1FCD0, c, 1FCD0]

--- a/include/entity.h
+++ b/include/entity.h
@@ -557,6 +557,11 @@ typedef struct {
     /* 0x7E */ s16 unk7E;
 } ET_GiantSpinningCross;
 
+typedef struct {
+    s16 unk7C;
+    s16 unk7E;
+} ET_8017091C;
+
 typedef union {
     /* 0x7C */ struct Primitive* prim;
     /* 0x7C */ ET_EntFactory factory;
@@ -581,6 +586,7 @@ typedef union {
     /* 0x7C */ ET_Merman merman;
     /* 0x7C */ ET_Merman_2 merman2;
     /* 0x7C */ ET_MermanWaterSplash mermanWaterSplash;
+    /* 0x7C */ ET_8017091C et_8017091C;
     /* 0x7C */ ET_801CF254 et_801CF254;
     /* 0x7C */ ET_GurkhaSword gurkhaSword;
     /* 0x7C */ ET_Dracula dracula;

--- a/src/ric/345EC.c
+++ b/src/ric/345EC.c
@@ -35,8 +35,6 @@ void func_801705EC(Entity* entity) {
     }
 }
 
-const u32 rodataPadding_80156BEC = 0;
-
 INCLUDE_ASM("asm/us/ric/nonmatchings/345EC", func_801706C0);
 
 void func_80170874(s32 bufSize, s32* buf) {
@@ -53,7 +51,144 @@ void func_80170874(s32 bufSize, s32* buf) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/345EC", func_8017091C);
+void func_8017091C(Entity* self) {
+    u16 sp10[4];
+    s16 sp18;
+    u16 sp20;
+    s32 temp_s0;
+    s16 angle;
+    s32 angleCos;
+    s32 angleSin;
+    s16 xCoord;
+    s16 yCoord;
+    Primitive* prim;
+    s32 i;
+    s32 randomSeed;
+    s16 var_s4;
+    s16 var_s6;
+
+    switch (self->step) {
+    case 0:
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 0xF);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
+        }
+        self->flags = 0x04840000;
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 15; i++) {
+            prim->tpage = 0x1A;
+            prim->clut = 0x194;
+            prim->u0 = prim->u2 = (rand() % 5) * 0x10 - 0x70;
+            prim->u1 = prim->u3 = prim->u0 + 0x20;
+            if (rand() & 1) {
+                prim->v0 = prim->v1 = 0xD0;
+                prim->v2 = prim->v3 = 0xE0;
+            } else {
+                prim->v0 = prim->v1 = 0xE0;
+                prim->v2 = prim->v3 = 0xD0;
+            }
+            prim->priority = 0xC1;
+            prim->blendMode = 0x20C;
+            prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 = prim->b1 =
+                prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 =
+                    prim->b3 = 0x80;
+            prim = prim->next;
+        }
+        prim = &g_PrimBuf[self->primIndex];
+        temp_s0 = self->params / 0x100 * 0x200;
+        sp20 = (temp_s0)-0x100 + rand() % 0x200;
+        randomSeed = rand();
+        for (i = 0; i < 15; i++) {
+            srand(randomSeed);
+            sp10[1] = self->posX.i.hi;
+            sp10[3] = self->posY.i.hi;
+            angle = func_801706C0(&sp10, sp20, i, &sp18);
+            xCoord = sp10[0];
+            yCoord = sp10[2];
+            var_s6 = (i == 0) ? 2 : 8;
+            var_s4 = (i < 7) ? 8 : 2;
+
+            angleCos = rcos(angle);
+            angleSin = rsin(angle);
+            prim->x0 = xCoord + (-(angleSin * -var_s6) >> 0xC);
+            prim->y0 = yCoord + ((angleCos * -var_s6) >> 0xC);
+            prim->x1 =
+                xCoord + ((angleCos * sp18 - (angleSin * -var_s4)) >> 0xC);
+            prim->y1 =
+                yCoord + ((angleSin * sp18 + (angleCos * -var_s4)) >> 0xC);
+            prim->x2 = xCoord + (-(angleSin * var_s6) >> 0xC);
+            prim->y2 = yCoord + ((angleCos * var_s6) >> 0xC);
+            prim->x3 =
+                xCoord + ((angleCos * sp18 - (angleSin * var_s4)) >> 0xC);
+            prim->y3 =
+                yCoord + ((angleSin * sp18 + (angleCos * var_s4)) >> 0xC);
+            prim = prim->next;
+        }
+        self->ext.et_8017091C.unk7E = 1;
+        self->step++;
+        return;
+    case 1:
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 15; i++) {
+            prim->blendMode &= ~BLEND_VISIBLE;
+            prim = prim->next;
+        }
+        self->step++;
+    case 2:
+        if (++self->ext.et_8017091C.unk7C >= 5) {
+            prim = &g_PrimBuf[self->primIndex];
+            for (i = 0; i < 15; i++) {
+                prim->clut = 0x15F;
+                prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 =
+                    prim->b1 = prim->r2 = prim->g2 = prim->b2 = prim->r3 =
+                        prim->g3 = prim->b3 = 0xFF;
+                prim->v0 = prim->v1 = prim->v0 - 0x10;
+                // Seems fake but without this the registers get shuffled
+                xCoord = prim->v2;
+                prim->v2 = prim->v3 = xCoord - 0x10;
+                prim = prim->next;
+            }
+            self->ext.et_8017091C.unk7C = 0;
+            self->step++;
+            return;
+        }
+        break;
+    case 3:
+    case 5:
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 15; i++) {
+            prim->clut = 0x194;
+            prim = prim->next;
+        }
+        self->step++;
+        return;
+    case 4:
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 15; i++) {
+            prim->clut = 0x15F;
+            prim = prim->next;
+        }
+        self->step++;
+        return;
+    case 6:
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 15; i++) {
+            prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 = prim->b1 =
+                prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 =
+                    prim->b3 = 0x60 - (self->ext.et_8017091C.unk7C * 4);
+            prim = prim->next;
+        }
+        if (++self->ext.et_8017091C.unk7C >= 0x10) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+}
+// Needs to be in between functions in this file with rodata
+// Can remove once all rodata is pulled in.
+const u32 rodataPadding_345EC = 0;
 
 INCLUDE_ASM("asm/us/ric/nonmatchings/345EC", func_80170F64);
 

--- a/src/ric/345EC.c
+++ b/src/ric/345EC.c
@@ -74,7 +74,7 @@ void func_8017091C(Entity* self) {
             DestroyEntity(self);
             return;
         }
-        self->flags = 0x04840000;
+        self->flags = FLAG_UNK_04000000 | FLAG_HAS_PRIMS | FLAG_UNK_40000;
         prim = &g_PrimBuf[self->primIndex];
         for (i = 0; i < 15; i++) {
             prim->tpage = 0x1A;

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -77,6 +77,7 @@ extern void func_80167964(Entity* entity);
 extern s32 func_8016840C(s16 x, s16 y);
 extern void func_80169C10(Entity* entity);
 extern void func_80169D74(Entity* entity);
+extern s32 func_801706C0(u16*, s16, s16, s16*);
 
 extern s16 D_80154568[];
 extern s32 D_80154570;


### PR DESCRIPTION
This appears to be an entity updating function unique to RIC. I do not know what it is for yet.

Main reason for doing it is that it has rodata and the file it is in currently requires a rodata padding to be present. Having this one working and parsing the rodata into it means we can move the padding, and once we finish everything in this file, we will be able to remove the padding entirely.