### PR TITLE
Decompile DRA func_800EA720

### DIFF
--- a/src/dra/4A538.c
+++ b/src/dra/4A538.c
@@ -91,7 +91,32 @@ s32 func_800EA5E4(u32 arg0) {
     return -1;
 }
 
-INCLUDE_ASM("dra/nonmatchings/4A538", func_800EA720);
+u16 func_800EA720(u32 colorDst, u32 colorSrc) {
+    u16 colorRes = colorSrc;
+
+    if (GET_RED(colorRes) < GET_RED(colorDst)) {
+        colorRes = (colorRes & ~RED_MASK) | (GET_RED(colorRes) + 1);
+    }
+    if (GET_RED(colorDst) < GET_RED(colorRes)) {
+        colorRes = (colorRes & ~RED_MASK) | (GET_RED(colorRes) - 1);
+    }
+
+    if (GET_GREEN(colorRes) < GET_GREEN(colorDst)) {
+        colorRes = (colorRes & ~GREEN_MASK) | (GET_GREEN(colorRes) + 0x20);
+    }
+    if (GET_GREEN(colorDst) < GET_GREEN(colorRes)) {
+        colorRes = (colorRes & ~GREEN_MASK) | (GET_GREEN(colorRes) - 0x20);
+    }
+
+    if (GET_BLUE(colorRes) < GET_BLUE(colorDst)) {
+        colorRes = (colorRes & ~BLUE_MASK) | (GET_BLUE(colorRes) + 0x400);
+    }
+    if (GET_BLUE(colorDst) < GET_BLUE(colorRes)) {
+        colorRes = (colorRes & ~BLUE_MASK) | (GET_BLUE(colorRes) - 0x400);
+    }
+
+    return colorRes;
+}
 
 INCLUDE_ASM("dra/nonmatchings/4A538", func_800EA7CC);
 

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -18,6 +18,14 @@
 #define SEQ_TABLE_S_MAX 0x10
 #define SEQ_TABLE_T_MAX 1
 
+#define RED_MASK 0x1F
+#define GREEN_MASK 0x3E0
+#define BLUE_MASK 0x7C00
+
+#define GET_RED(x) ((x)&RED_MASK)
+#define GET_GREEN(x) ((x)&GREEN_MASK)
+#define GET_BLUE(x) ((x)&BLUE_MASK)
+
 typedef enum {
     DEBUG_NORMAL,
     DEBUG_TEXTURE_VIEWER,


### PR DESCRIPTION
If there's a better place to put the macros let me know,

The linter doesn't like it when the following macros are formatted like this : 

`#define GET_RED(x) ((x) & RED_MASK)`

as it changes them to this : 

`#define GET_RED(x) ((x)&RED_MASK)`

(removes the spaces around the `&` operator)

It's probably not configured for it as it's not happening to the `|` operator. 

