### PR TITLE
pcsound: add 627C4, 63ED4

### DIFF
--- a/Makefile.pc.mk
+++ b/Makefile.pc.mk
@@ -11,6 +11,7 @@ C_FILES_PC          := main.c log.c stubs.c sotn.c
 C_FILES_PC          += pc.c sdl2.c
 C_FILES_PSX_SDK     := libapi.c libetc.c libgpu.c libgte.c libgs.c libcd.c libcard.c libspu.c libsnd.c cdc.c
 C_FILES_DRA         := 42398.c play.c loading.c
+C_FILES_DRA         += 627C4.c 63ED4.c
 C_FILES_DRA         += 91EBC.c 92F60.c 93290.c 93BDC.c 94F50.c 953A0.c
 
 OBJS                := $(C_FILES_PC:%.c=$(PC_BUILD_DIR)/src/pc/%.o)

--- a/src/pc/psxsdk/libgpu.c
+++ b/src/pc/psxsdk/libgpu.c
@@ -64,3 +64,7 @@ int SetGraphDebug(int level) { NOT_IMPLEMENTED; }
 u_long* ClearOTag(u_long* ot, int n) { NOT_IMPLEMENTED; }
 
 u_short LoadClut2(u_long* clut, int x, int y) { NOT_IMPLEMENTED; }
+
+u_short LoadTPage(u_long* pix, int tp, int abr, int x, int y, int w, int h) {
+    NOT_IMPLEMENTED;
+}

--- a/src/pc/psxsdk/libgte.c
+++ b/src/pc/psxsdk/libgte.c
@@ -4,6 +4,22 @@
 
 void InitGeom() { NOT_IMPLEMENTED; }
 
-int rsin(int x) { NOT_IMPLEMENTED; }
+int rsin(int x) {
+    NOT_IMPLEMENTED;
+    return 0;
+}
 
-int rcos(int x) { NOT_IMPLEMENTED; }
+int rcos(int x) {
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+long ratan2(long y, long x) {
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+long SquareRoot0(long a) {
+    NOT_IMPLEMENTED;
+    return 0;
+}

--- a/src/pc/sdl2.c
+++ b/src/pc/sdl2.c
@@ -95,6 +95,24 @@ u_long MyPadRead(int id) {
         if (keyb[SDL_SCANCODE_RIGHT]) {
             pressed |= PAD_RIGHT;
         }
+        if (keyb[SDL_SCANCODE_X]) {
+            pressed |= PAD_CROSS;
+        }
+        if (keyb[SDL_SCANCODE_S]) {
+            pressed |= PAD_TRIANGLE;
+        }
+        if (keyb[SDL_SCANCODE_Z]) {
+            pressed |= PAD_SQUARE;
+        }
+        if (keyb[SDL_SCANCODE_D]) {
+            pressed |= PAD_CIRCLE;
+        }
+        if (keyb[SDL_SCANCODE_BACKSPACE]) {
+            pressed |= PAD_SELECT;
+        }
+        if (keyb[SDL_SCANCODE_RETURN]) {
+            pressed |= PAD_START;
+        }
         if (keyb[SDL_SCANCODE_Q]) {
             pressed |= PAD_L1;
         }
@@ -129,4 +147,85 @@ int MyDrawSync(int mode) {
     MyDrawSyncCallback(mode);
 
     return 0;
+}
+
+void SetSdlVertexG4(SDL_Vertex* v, POLY_G4* poly) {
+    v[0].position.x = poly->x0;
+    v[0].position.y = poly->y0;
+    v[0].color.r = poly->r0;
+    v[0].color.g = poly->g0;
+    v[0].color.b = poly->b0;
+    v[0].color.a = 0xFF;
+    v[1].position.x = poly->x1;
+    v[1].position.y = poly->y1;
+    v[1].color.r = poly->r1;
+    v[1].color.g = poly->g1;
+    v[1].color.b = poly->b1;
+    v[1].color.a = 0xFF;
+    v[2].position.x = poly->x2;
+    v[2].position.y = poly->y2;
+    v[2].color.r = poly->r2;
+    v[2].color.g = poly->g2;
+    v[2].color.b = poly->b2;
+    v[2].color.a = 0xFF;
+    v[4].position.x = poly->x3;
+    v[4].position.y = poly->y3;
+    v[4].color.r = poly->r3;
+    v[4].color.g = poly->g3;
+    v[4].color.b = poly->b3;
+    v[4].color.a = 0xFF;
+    v[3] = v[1];
+    v[5] = v[2];
+}
+
+void SetSdlVertexPrim(SDL_Vertex* v, Primitive* prim) {
+    v[0].position.x = prim->x0;
+    v[0].position.y = prim->y0;
+    v[0].color.r = prim->r0;
+    v[0].color.g = prim->g0;
+    v[0].color.b = prim->b0;
+    v[0].color.a = 0xFF;
+    v[1].position.x = prim->x1;
+    v[1].position.y = prim->y1;
+    v[1].color.r = prim->r1;
+    v[1].color.g = prim->g1;
+    v[1].color.b = prim->b1;
+    v[1].color.a = 0xFF;
+    v[2].position.x = prim->x2;
+    v[2].position.y = prim->y2;
+    v[2].color.r = prim->r2;
+    v[2].color.g = prim->g2;
+    v[2].color.b = prim->b2;
+    v[2].color.a = 0xFF;
+    v[4].position.x = prim->x3;
+    v[4].position.y = prim->y3;
+    v[4].color.r = prim->r3;
+    v[4].color.g = prim->g3;
+    v[4].color.b = prim->b3;
+    v[4].color.a = 0xFF;
+    v[3] = v[1];
+    v[5] = v[2];
+}
+
+void MyRenderPrimitives(void) {
+    SDL_Vertex v[6];
+
+    for (int i = 0; i < LEN(g_PrimBuf); i++) {
+        Primitive* prim = &g_PrimBuf[i];
+        switch (prim->type) {
+        case PRIM_GT4:
+            SetSdlVertexPrim(v, prim);
+            SDL_RenderGeometry(g_Renderer, NULL, v, 6, NULL, 0);
+            break;
+        }
+    }
+    for (int i = 0; i < g_GpuUsage.g4; i++) {
+        SetSdlVertexG4(v, &g_CurrentBuffer->polyG4[i]);
+        SDL_RenderGeometry(g_Renderer, NULL, v, 6, NULL, 0);
+    }
+    for (int i = 0; i < g_GpuUsage.line; i++) {
+        LINE_G2* poly = &g_CurrentBuffer->lineG2[i];
+        SDL_SetRenderDrawColor(g_Renderer, poly->r0, poly->g0, poly->b0, 255);
+        SDL_RenderDrawLine(g_Renderer, poly->x0, poly->y0, poly->x1, poly->y1);
+    }
 }

--- a/src/pc/stubs.c
+++ b/src/pc/stubs.c
@@ -14,6 +14,7 @@ s32 g_LoadFile;
 u32 g_CdStep;
 GameState g_GameState;
 Entity g_Entities[TOTAL_ENTITY_COUNT];
+unkGraphicsStruct g_unkGraphicsStruct;
 Primitive g_PrimBuf[MAX_PRIM_COUNT];
 Lba g_StagesLba[0x50];
 FgLayer D_8003C708;
@@ -69,6 +70,7 @@ u16 D_8003C104[];
 s32 D_8003C738;
 u8 g_CastleFlags[0x300];
 s32 D_8006C374;
+s32 D_8006C378;
 u16 D_8003C3C2[];
 u32 D_80070BCC;
 s32 g_Servant;
@@ -77,6 +79,9 @@ s32 g_IsTimeAttackUnlocked;
 Unkstruct_8003C908 D_8003C908;
 s32 D_8003C100;
 s32 D_800978B4;
+u32 g_RoomCount;
+char D_80097902[] = "dummy";
+s32 D_8003C90C[2] = {0};
 
 // dra.h
 GpuUsage g_GpuMaxUsage;
@@ -119,6 +124,172 @@ s32 D_800987B4;
 u8 g_PadsRepeatTimer[BUTTON_COUNT * PAD_COUNT];
 s32 D_80136410;
 s32 D_80136414[];
+s32 D_801375C0;
+s32 D_801375C4;
+s32 D_801375C8;
+s32 D_801375CC;
+s32 D_801375D0;
+s32 D_801375D4;
+s32* D_801375D8;
+s32 D_801375DC[0];
+s32 D_801375E0[8];
+s32 D_801375FC;
+s32 D_80137608;
+s32 g_IsCloakLiningUnlocked;
+s32 g_IsCloakColorUnlocked;
+s32 g_IsSelectingEquipment;
+s32 g_EquipmentCursor;
+s32 D_80137614;
+s32 D_80137618;
+MenuData g_MenuData = {0};
+u8 D_801376B0;
+s16 D_801376C4;
+s16 D_801376C8;
+MenuContext g_JosephsCloakContext;
+s32 D_8013783C;
+s32 D_801377FC[0x10];
+s32 D_80137840;
+s32 D_80137844[];
+s32 D_80137848[];
+s32 D_8013784C;
+s16 g_RelicMenuFadeTimer;
+s32 g_TimeAttackEntryTimes[];
+s32 c_strTimeAttackEntry[];
+s32 c_strTimeAttackGoals[];
+s32 g_NewAttackRightHand;
+s32 g_NewAttackLeftHand;
+s32 g_NewDefenseEquip;
+s32 g_NewPlayerStatsTotal[];
+s32 D_80137948;
+s8* D_8013794C; // Pointer to texture pattern
+s32 D_80137950;
+s32 D_80137954;
+s32 D_80137958;
+s32 g_ServantPrevious;
+s32 D_80137960;
+s32 D_80137964;
+s32 D_80137968;
+s32 D_80139824;
+s32 D_80139828[];
+s32 D_8013982C;
+s32 D_80139830[];
+s32 D_8013983C;
+s32 D_80139840;
+s32 D_80139844;
+s32 D_80139848;
+s32 D_8013984C;
+s32 D_80139850;
+s32 D_80139854;
+MenuContextInit MenuContextData[] = {
+    {0x009E, 0x0064, 0x004C, 0x0050, 0x0040, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x00C8, 0x0010, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x0061, 0x0020, 0x0000},
+    {0x0000, 0x0078, 0x0168, 0x004A, 0x0020, 0x0000},
+    {0x0000, 0x00C1, 0x0168, 0x001F, 0x0040, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x00AA, 0x0020, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x00AA, 0x0020, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x00AA, 0x0020, 0x0000},
+    {0x00A8, 0x0078, 0x0090, 0x0040, 0x0030, 0x0000},
+    {0x0094, 0x002C, 0x00C8, 0x0070, 0x0030, 0x0000},
+    {0x00AC, 0x002C, 0x0041, 0x0020, 0x0030, 0x0000},
+    {0x00AC, 0x0070, 0x0039, 0x0020, 0x0030, 0x0000},
+    {0x00AC, 0x004C, 0x007C, 0x0028, 0x0030, 0x0000},
+    {0x000C, 0x0020, 0x0154, 0x0099, 0x0030, 0x0000},
+    {0x0114, 0x0020, 0x004D, 0x00B7, 0x0050, 0x0000},
+    {0x0000, 0x0018, 0x0168, 0x00C8, 0x0018, 0x0000},
+};
+
+u8 c_chPlaystationButtons[];
+u8 c_chShoulderButtons[];
+RECT D_800A2D90;
+JosephsCloak g_JosephsCloak;
+u8 g_Pix[4][128 * 128 / 2];
+const char* c_strALUCARD[] = {"dummy"};
+const char* c_strGOLD[] = {"dummy"};
+const char* c_strButtonRightHand[] = {"dummy"};
+const char* D_800A83AC[] = {"dummy"};
+const char** c_strSTR = {"dummy"};
+const char* c_strCON = "dummy";
+const char* c_strINT = "dummy";
+const char* c_strLCK = "dummy";
+const char* c_strEXP = "dummy";
+const char* c_strNEXT = "dummy";
+const char* c_strLEVEL = "dummy";
+const char* c_strTIME = "dummy";
+const char* c_strROOMS = "dummy";
+const char* c_strKILLS = "dummy";
+const char* c_strHP = "dummy";
+const char* c_strMP = "dummy";
+const char* c_strHEART = "dummy";
+const char* c_strSTATUS = "dummy";
+const char* c_strButton = "dummy";
+const char* c_strCloak = "dummy";
+const char* c_strCloak2 = "dummy";
+const char* c_strExterior = "dummy";
+const char* c_strLining = "dummy";
+const char* c_strButtonLeftHand = "dummy";
+const char* c_strButtonJump = "dummy";
+const char* c_strButtonSpecial = "dummy";
+const char* c_strButtonWolf = "dummy";
+const char* c_strButtonMist = "dummy";
+const char* c_strButtonBat = "dummy";
+const char* c_strNormal = "dummy";
+const char* c_strReversal = "dummy";
+const char* c_strSound = "dummy";
+const char* c_strStereo = "dummy";
+const char* c_strMono = "dummy";
+const char* c_strWindow = "dummy";
+const char* c_strTime = "dummy";
+const char* c_strALUCART = "dummy";
+const char* c_strSSword = "dummy";
+const char* g_WingSmashComboStr = "dummy";
+const char* c_strEquip = "dummy";
+const char* c_strSpells = "dummy";
+const char* c_strRelics = "dummy";
+const char* c_strSystem = "dummy";
+const char* c_strFamiliars = "dummy";
+const char* c_strFamiliar = "dummy";
+const char* c_strSpecial2 = "dummy";
+u8* c_strTimeAttackHiddenEntry = "dummy";
+s32 c_strTimeAttackEntries[0x40] = {0};
+ImgSrc* g_imgUnk8013C200_impl = {
+    0,
+    0,
+    0,
+    NULL,
+};
+ImgSrc* g_imgUnk8013C200 = &g_imgUnk8013C200_impl;
+ImgSrc* g_imgUnk8013C270 = &g_imgUnk8013C200_impl;
+s32 g_ExpNext[100] = {0};
+s32 g_PrevEquippedWeapons[2];
+u8 D_800A2D7C[3] = {0};
+u8 D_800A2D80[0x10] = {
+    0x00, 0x20, 0x30, 0x40, 0x50, 0x60, 0x69, 0x70,
+    0x75, 0x78, 0x7A, 0x7C, 0x7D, 0x7E, 0x7F, 0x80,
+};
+s32 D_8013AEE4;
+Unkstruct_800A2D98 D_800A2D98[10] = {0};
+s32 D_800A3194[];
+s32 D_80139060;
+u32 D_8013799C;
+s32 D_801379A0;
+s32 D_801379A4;
+s32 D_801379A8;
+Unkstruct_80102CD8 D_801379AC;
+s32 D_801379B0;
+s32 D_80137E40;
+s32 D_80137E44;
+s32 D_80137E48;
+s32 D_80137E4C;
+s32 D_80137E50;
+s32 D_80137E54;
+s32 D_80137E58;
+s32 D_80137E5C;
+s32 D_80137E60;
+s32 D_80137E64;
+s32 D_80137E68;
+s32 D_80137E6C;
+s32 D_80137F6C;
 
 // sound bss
 s16 g_SoundCommandRingBufferReadPos;
@@ -246,8 +417,6 @@ void HideAllBackgroundLayers(void) { NOT_IMPLEMENTED; }
 
 void DestroyAllPrimitives(void) { NOT_IMPLEMENTED; }
 
-void DestroyEntities(s16 startIndex) { NOT_IMPLEMENTED; }
-
 void SetupEvents(void) { NOT_IMPLEMENTED; }
 
 s32 LoadFileSim(s32 fileId, SimFileType type) {
@@ -271,10 +440,6 @@ void RenderEntities(void) { NOT_IMPLEMENTED; }
 
 void RenderTilemap(void) { NOT_IMPLEMENTED; }
 
-void RenderPrimitives(void) { NOT_IMPLEMENTED; }
-
-void DrawEntitiesHitbox(s32 blendMode) { NOT_IMPLEMENTED; }
-
 void UpdateCd(void) { NOT_IMPLEMENTED; }
 
 void LoadPendingGfx(void) { NOT_IMPLEMENTED; }
@@ -291,8 +456,6 @@ void ResetEntityArray(void) { NOT_IMPLEMENTED; }
 void func_800F2120(void) { NOT_IMPLEMENTED; }
 
 void func_800FF0B8(void) { NOT_IMPLEMENTED; }
-
-void ApplyJosephsCloakPalette(void) { NOT_IMPLEMENTED; }
 
 void LoadGfxAsync(s32 gfxId) {
     NOT_IMPLEMENTED;
@@ -321,28 +484,133 @@ void FreePrimitives(s32 index) { NOT_IMPLEMENTED; }
 
 void func_800EA5AC(u16 arg0, u8 arg1, u8 arg2, u8 arg3) { NOT_IMPLEMENTED; }
 
-void func_80107250(POLY_GT4* poly, s32 colorIntensity) { NOT_IMPLEMENTED; }
-
-void func_801072BC(POLY_GT4* poly) { NOT_IMPLEMENTED; }
-
-void func_801072DC(POLY_GT4* poly) { NOT_IMPLEMENTED; }
-
-void SetTexturedPrimRect(
-    Primitive* poly, s32 x, s32 y, s32 width, s32 height, s32 u, s32 v) {
-    NOT_IMPLEMENTED;
-}
-
-void SetPrimRect(Primitive* poly, s32 x, s32 y, s32 width, s32 height) {
-    NOT_IMPLEMENTED;
-}
-
 void func_800E5D30(void* arg0, u16 arg1, u16 arg2, s32 arg3) {
     NOT_IMPLEMENTED;
 }
 
 void InitStatsAndGear(bool isDeathTakingItems) { NOT_IMPLEMENTED; }
 
+void func_801083BC(void) { NOT_IMPLEMENTED; }
+
+void func_80102628(s32 arg0) { NOT_IMPLEMENTED; }
+
+void func_800EB6B4(void) { NOT_IMPLEMENTED; }
+
+void func_8010A234(s32 arg0) { NOT_IMPLEMENTED; }
+
+s32 func_801025F4(void) {
+    NOT_IMPLEMENTED;
+    return 1;
+}
+
+s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+void LoadEquipIcon(s32 equipIcon, s32 palette, s32 index) { NOT_IMPLEMENTED; }
+
+void AddToInventory(u16 itemId, s32 itemCategory) { NOT_IMPLEMENTED; }
+
+void func_800EAEA4(void) { NOT_IMPLEMENTED; }
+
+void func_800FF60C(void) { NOT_IMPLEMENTED; }
+
+u32 CheckEquipmentItemCount(u32 itemId, u32 equipType) { NOT_IMPLEMENTED; }
+
+u8* GetEquipOrder(s32 equipTypeFilter) {
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+u8* GetEquipCount(s32 equipTypeFilter) {
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+const char* GetEquipmentName(s32 equipTypeFilter, s32 equipId) {
+    NOT_IMPLEMENTED;
+    return "NOT_IMPLEMENTED";
+}
+
+u16 g_FontCharData[0x60] = {1, 1, 1, 0, 0, 0};
+u16* func_80106A28(u32 arg0, u16 kind) {
+    NOT_IMPLEMENTED;
+    return g_FontCharData;
+}
+
+s32 func_800FD6C4(s32 equipTypeFilter) {
+    NOT_IMPLEMENTED;
+    return 0;
+}
+
+void func_801026BC(s32 arg0) { NOT_IMPLEMENTED; }
+
+void func_800F9D88(const char* str, s32 arg1, s32 arg2) { NOT_IMPLEMENTED; }
+
+void MemcardInit(void) { NOT_IMPLEMENTED; }
+
+void MemcardInfoInit(void) { NOT_IMPLEMENTED; }
+
+s32 MemcardFormat(s32 nPort, s32 nCard) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 MemcardParse(s32 nPort, s32 nCard) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+void MakeMemcardPath(char* dstSaveName, s32 block) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 MemcardClose(s32 nPort) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 func_800E9880(s32 nPort, s32 nCard) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 MemcardDetectSave(s32 nPort, u8* expectedSaveName, s32 block) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 GetMemcardFreeBlockCount(s32 nPort) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+s32 MemcardWriteFile(
+    s32 nPort, s32 nCard, const char* name, void* data, s32 flags, s32 create) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+void StoreSaveData(SaveData* save, s32 block, s32 cardIcon) { NOT_IMPLEMENTED; }
+
+// can be removed with 5298C.c
+void ApplyJosephsCloakPalette(void) { NOT_IMPLEMENTED; }
+
+// can be removed with 5298C.c
 void CheckWeaponCombo(void) { NOT_IMPLEMENTED; }
+
+int g_AllocatedPrims = 0;
+s32 func_800EDD9C(u8 primitives, s32 count) {
+    for (int i = 0; i < count; i++) {
+        g_PrimBuf[i].type = primitives;
+    }
+
+    int lastFreePrim = g_AllocatedPrims;
+    g_AllocatedPrims += count;
+    return g_AllocatedPrims;
+}
 
 // copied from 47BB8.c
 void ResetPadsRepeat(void) {
@@ -355,6 +623,34 @@ void ResetPadsRepeat(void) {
     for (i = 0; i < LEN(g_PadsRepeatTimer); i++) {
         *ptr++ = 0x10;
     }
+}
+
+// copied from 47BB8.c
+void UpdatePadsRepeat(void) {
+    u16 button = 1;
+    u16 repeat = 0;
+    u16 unk = g_pads[0].tapped;
+    u16 pressed = g_pads[0].pressed;
+    u8* timers = g_PadsRepeatTimer;
+    s32 i = 0;
+
+    while (i < 0x10) {
+        if (pressed & button) {
+            if (unk & button) {
+                repeat |= button;
+                timers[0] = 0x10;
+            } else {
+                if (--timers[0] == 0xFF) {
+                    repeat |= button;
+                    timers[0] = 5;
+                }
+            }
+        }
+        i++;
+        timers++;
+        button <<= 1;
+    }
+    g_pads[0].repeat = repeat;
 }
 
 // copied from 47BB8.c
@@ -386,5 +682,5 @@ void ReadPads(void) {
             pad->pressed = padd >> 0x10;
         pad->tapped = (pad->pressed ^ pad->previous) & pad->pressed;
     }
-    ResetPadsRepeat();
+    UpdatePadsRepeat();
 }


### PR DESCRIPTION
Prepares importing the `HandleMenu` as shown on Discord a couple of weeks ago. The function `MyRenderPrimitives` is very barebone and can render untextured primitives without accounting the render order `ot`.