### PR TITLE
Decompile RIC CheckHighJumpInput

### DIFF
--- a/config/symbols.us.ric.txt
+++ b/config/symbols.us.ric.txt
@@ -1,6 +1,7 @@
 g_richter_spritesheet = 0x8013C020;
 DestroyEntity = 0x80156C60;
 GetTeleportToOtherCastle = 0x80156CCC;
+CheckHighJumpInput = 0x80157A50;
 UpdateEntityRichter = 0x80157BFC;
 SetPlayerStep = 0x8015C908;
 SetSpeedX = 0x8015CA84;

--- a/include/game.h
+++ b/include/game.h
@@ -1437,6 +1437,13 @@ typedef struct {
     /* 0x27 */ u8 unk27;
 } PlayerDraw; /* size = 0x28 */
 
+// Used to track the state of moves the player does with a sequence of buttons.
+// This includes spells, some of Richter's moves, etc.
+typedef struct {
+    s16 buttonsCorrect;
+    s16 timer;
+} ButtonComboState;
+
 extern s32 D_8003925C;
 extern s32 g_IsTimeAttackUnlocked;
 

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -342,11 +342,6 @@ typedef enum {
     COMBO_DARK_METAMORPH,
 } ButtonComboIdx;
 
-typedef struct {
-    s16 buttonsCorrect;
-    s16 timer;
-} ButtonComboState;
-
 struct SeqData {
     u8 volume;
     u8 reverb_depth;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -177,9 +177,44 @@ INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_801572A8);
 
 INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_80157894);
 
-// DECOMP_ME_WIP func_80157A50 https://decomp.me/scratch/hk5zb
-// Almost matched, just a jump issue
-INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_80157A50);
+void CheckHighJumpInput(void) {
+    switch (D_801758E4.buttonsCorrect) { /* irregular */
+    case 0:
+        if (g_Player.padTapped & PAD_DOWN) {
+            if (g_Player.padHeld == 0) {
+                D_801758E4.timer = 16;
+                D_801758E4.buttonsCorrect++;
+                return;
+            }
+        }
+        return;
+    case 1:
+        if (g_Player.padTapped & PAD_UP) {
+            D_801758E4.timer = 16;
+            D_801758E4.buttonsCorrect++;
+            return;
+        }
+        if (--D_801758E4.timer == 0) {
+            D_801758E4.buttonsCorrect = 0;
+        }
+        break;
+    case 2:
+        if ((D_801758E4.timer != 0) && (--D_801758E4.timer == 0)) {
+            D_801758E4.buttonsCorrect = 0;
+            return;
+        }
+        if ((g_Player.padTapped & PAD_CROSS) && (g_Player.unk46 == 0) &&
+            ((PLAYER.step == Player_Crouch) || (PLAYER.step == Player_Stand) ||
+             ((PLAYER.step == Player_Jump) && (PLAYER.velocityY > FIX(1))) ||
+             (PLAYER.step == Player_Fall))) {
+            if (g_Player.unk72 == 0) {
+                DoHighJump();
+            }
+            D_801758E4.buttonsCorrect = 0;
+        }
+        break;
+    }
+}
 
 INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", UpdateEntityRichter);
 

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -246,15 +246,15 @@ void func_8015D020(void) {
     }
 }
 
-void func_8015D120(void) {
-    SetPlayerStep(8);
+void DoHighJump(void) {
+    SetPlayerStep(Player_HighJump);
     PLAYER.velocityX = 0;
-    SetSpeedX(0x14000);
-    PLAYER.velocityY = -0x78000;
+    SetSpeedX(FIX(1.25));
+    PLAYER.velocityY = FIX(-7.5);
     g_Player.pl_high_jump_timer = 0;
     func_8015C920(&D_8015579C);
     func_8015CC28();
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x2DU, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 45), 0);
     g_api.PlaySfx(0x6FB);
     g_Player.D_80072F18 = 4;
     if (g_Player.unk72 != 0) {

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -159,6 +159,7 @@ extern s32 D_80175080;
 extern s32 D_801758B0[];
 extern Entity* D_801758CC[];
 extern u32 D_801758D0;
+extern ButtonComboState D_801758E4;
 extern u16 D_80175950;
 extern u16 D_80175952;
 extern u16 D_80175954;


### PR DESCRIPTION
The function that keeps track of if Richter has pressed down-up-cross to do a High Jump move.

This is the first time we have a button combo being tracked outside of DRA, so I moved the ButtonComboState struct from dra.h to game.h.

When the input succeeds, a function is called, so I've named that function DoHighJump and also made general changes to that function to bring it up to date with our current code standards (like FIX()).

I think those are the main highlights!