### PR TITLE
Allow function_finder to filter on keywords

### DIFF
--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -27,6 +27,14 @@ parser.add_argument(
     help="Disable fetching scratch links from decomp.me",
 )
 
+parser.add_argument(
+    "--keywords",
+    metavar="keyword",
+    type=str,
+    nargs="+",
+    help="Only match paths with these keywords",
+)
+
 
 # look in asm files, read in the text and check for branches and jump tables
 def get_asm_files(asm_path):
@@ -119,6 +127,14 @@ if __name__ == "__main__":
     asm_files = sorted(asm_files, key=lambda x: (x["branches"]))
     asm_files = sorted(asm_files, key=lambda x: len(x["text"].split("\n")))
 
+    if args.keywords and len(args.keywords):
+        # filter based on keywords
+        asm_files = [
+            file
+            for file in asm_files
+            if any(keyword in str(file["name"]) for keyword in args.keywords)
+        ]
+
     output = []
 
     for f in asm_files:
@@ -138,8 +154,8 @@ if __name__ == "__main__":
                 # found a decomp.me WIP, get the URL
                 wip = c_file[2]
 
-        if '/psxsdk/' in name:
-            ovl_name = name.split('/')[5] # grab library name
+        if "/psxsdk/" in name:
+            ovl_name = name.split("/")[5]  # grab library name
             func_name = os.path.splitext(os.path.basename(name))[0]
         else:
             matches = re.search(r"\/(\w+)\/nonmatchings\/\w+\/(\w+)\.s", name)


### PR DESCRIPTION
The point of this is to be able to get results only for what you want to work on. e.g:
```
python3 ./tools/function_finder/function_finder_psx.py --keywords libsnd libspu --no-fetch
| Ovl    | Function               |   Length |   Branches | Jtbl   | WIP   | %   |
|--------|------------------------|----------|------------|--------|-------|-----|
| libspu | _spu_FgetRXXa          |       23 |          3 |        |       |     |
| libsnd | SpuVmGetProgPan        |       28 |          3 |        |       |     |
| libsnd | SsUtGetDetVVol         |       30 |          3 |        |       |     |
| libsnd | _SsSndReplay           |       32 |          1 |        |       |     |
| libsnd | SpuVmGetSeqVol         |       33 |          1 |        |       |     |
| libsnd | SpuVmSetProgPan        |       36 |          3 |        |       |     |
| libsnd | SpuVmSetProgVol        |       36 |          3 |        |       |     |
| libspu | _SpuIsInAllocateArea   |       38 |          6 |        |       |     |
| libspu | SpuQuit                |       38 |          7 |        |       |     |
| libspu | SpuSetKey              |       39 |          4 |        |       |     |
| libspu | _SpuIsInAllocateArea_  |       40 |          6 |        |       |     |
| libspu | SpuFree                |       40 |          7 |        |       |     |
| libsnd | _SsUtBuildADSR         |       42 |          2 |        |       |     |
| libsnd | SsUtPitchBend          |       42 |          3 |        |       |     |
| libsnd | SsUtGetVVol            |       43 |          3 |        |       |     |
| libsnd | SsUtSetVVol            |       43 |          3 |        |       |     |
| libspu | _spu_reset             |       43 |          3 |        |       |     |
| libspu | SpuGetAllKeysStatus    |       45 |          8 |        |       |     |
| libsnd | _SsSndPause            |       46 |          2 |        |       |     |
| libspu | _spu_FsetRXXa          |       52 |          8 |        |       |     |
| libspu | SpuSetAnyVoice         |       54 |          4 |        |       |     |
| libspu | SpuIsTransferCompleted |       54 |         11 |        |       |     |
| libsnd | note2pitch             |       55 |          5 |        |       |     |
| libsnd | SpuVmVSetUp            |       58 |          5 |        |       |     |
| libspu | _SpuInit               |       58 |          7 |        |       |     |
| libsnd | SsSeqOpen              |       61 |          8 |        |       |     |
| libsnd | SsUtChangeADSR         |       62 |          6 |        |       |     |
| libsnd | SpuVmPitchBend         |       68 |          5 |        |       |     |
| libspu | SpuRGetAllKeysStatus   |       68 |         15 |        |       |     |
| libsnd | _SsInit                |       69 |          7 |        |       |     |
| libspu | _spu_note2pitch        |       72 |          8 |        |       |     |
| libsnd | SpuVmSeKeyOn           |       72 |         12 |        |       |     |
| libsnd | note2pitch2            |       73 |          6 |        |       |     |
| libsnd | _SsSeqPlay             |       80 |         11 |        |       |     |
| libsnd | SsUtKeyOffV            |       81 |          6 |        |       |     |
| libsnd | _SsContModulation      |       86 |          7 |        |       |     |
| libsnd | _SsContPortaTime       |       86 |          7 |        |       |     |
| libsnd | SsUtChangePitch        |       88 |          8 |        |       |     |
| libsnd | _SsContNrpn1           |       88 |         10 |        |       |     |
| libsnd | SpuVmSeqKeyOff         |       92 |          6 |        |       |     |
| libspu | SpuSetIRQ              |       93 |         14 |        |       |     |
| libsnd | _SsContNrpn2           |       95 |         16 |        |       |     |
| libsnd | _SsSndStop             |       98 |          3 |        |       |     |
| libsnd | SsVabTransBodyPartly   |       99 |         13 |        |       |     |
| libsnd | _SsContPortamento      |      100 |         10 |        |       |     |
| libspu | _spu_pitch2note        |      102 |         13 |        |       |     |
| libsnd | _SsClose               |      103 |          5 |        |       |     |
| libsnd | SpuVmSetSeqVol         |      104 |          7 |        |       |     |
| libsnd | SsSetTickMode          |      111 |         20 | Yes    |       |     |
| libsnd | vmNoiseOn2             |      113 |          5 |        |       |     |
| libsnd | SePitchBend            |      114 |          5 |        |       |     |
| libspu | SpuClearReverbWorkArea |      120 |         18 |        |       |     |
| libspu | _spu_FiDMA             |      121 |         15 |        |       |     |
| libsnd | SsUtSetVagAtr          |      122 |          4 |        |       |     |
| libsnd | SeAutoPan              |      123 |         13 |        |       |     |
| libsnd | SeAutoVol              |      123 |         13 |        |       |     |
| libsnd | SsUtAllKeyOff          |      129 |          5 |        |       |     |
| libsnd | _SsSndTempo            |      135 |         15 |        |       |     |
| libsnd | SpuVmKeyOff            |      137 |         11 |        |       |     |
| libsnd | SsUtKeyOff             |      138 |         12 |        |       |     |
| libsnd | SpuVmPBVoice           |      140 |         10 |        |       |     |
| libsnd | SpuVmDoAllocate        |      142 |          4 |        |       |     |
| libsnd | SpuVmAlloc             |      172 |         20 |        |       |     |
| libsnd | SsSeqCalledTbyT        |      175 |         24 |        |       |     |
| libsnd | _SsStart               |      180 |         37 |        |       |     |
| libsnd | _SsSndDecrescendo      |      185 |         21 |        |       |     |
| libspu | _spu_t                 |      192 |         24 |        |       |     |
| libsnd | _SsGetSeqData          |      193 |         37 |        |       |     |
| libspu | SpuMalloc              |      195 |         22 |        |       |     |
| libspu | SpuMallocWithStartAddr |      197 |         28 |        |       |     |
| libsnd | _SsSndCrescendo        |      198 |         21 |        |       |     |
| libsnd | _SsSndSetVabAttr       |      209 |         45 | Yes    |       |     |
| libspu | func_800286E0          |      217 |         27 |        |       |     |
| libsnd | _SsInitSoundSeq        |      222 |         21 |        |       |     |
| libsnd | _SsSetControlChange    |      222 |         33 | Yes    |       |     |
| libspu | _spu_writeByIO         |      230 |         24 |        |       |     |
| libsnd | SetAutoPan             |      231 |         21 |        |       |     |
| libsnd | _SsGetMetaEvent        |      231 |         22 |        |       |     |
| libsnd | SetAutoVol             |      232 |         21 |        |       |     |
| libspu | _SpuMallocSeparateTo3  |      235 |         22 |        |       |     |
| libsnd | SsUtKeyOnV             |      250 |         24 |        |       |     |
| libsnd | SsUtKeyOn              |      252 |         25 |        |       |     |
| libsnd | SpuVmFlush             |      258 |         21 |        |       |     |
| libsnd | SpuVmInit              |      259 |         13 |        |       |     |
| libspu | SpuSetCommonAttr       |      287 |         57 | Yes    |       |     |
| libspu | SpuGetVoiceAttr        |      289 |         61 |        |       |     |
| libsnd | SsVabOpenHeadWithMode  |      290 |         37 |        |       |     |
| libsnd | vmNoiseOn              |      328 |         16 |        |       |     |
| libsnd | SpuVmKeyOnNow          |      333 |         15 |        |       |     |
| libsnd | SpuVmSetVol            |      354 |         18 |        |       |     |
| libspu | _spu_init              |      356 |         27 |        |       |     |
| libspu | SpuSetReverbModeParam  |      362 |         47 |        |       |     |
| libsnd | _SsContDataEntry       |      386 |         41 |        |       |     |
| libsnd | SpuVmKeyOn             |      400 |         25 |        |       |     |
| libspu | _SpuSetVoiceAttr       |      487 |         94 | Yes    |       |     |
```