### PR TITLE
Reduce _MSC_VER footprint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ set(SOURCE_FILES_PC
 )
 
 if(WIN32)
-set(SOURCE_FILES_PC $(SOURCE_FILES_PC) src/pc/plat_win.c)
+list(APPEND SOURCE_FILES_PC src/pc/plat_win.c)
 else()
-set(SOURCE_FILES_PC $(SOURCE_FILES_PC) src/pc/plat_unix.c)
+list(APPEND SOURCE_FILES_PC src/pc/plat_unix.c)
 endif()
 
 set(SOURCE_FILES_PSX_SDK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ set(SOURCE_FILES_PC
     src/pc/sotn.c
     src/pc/pc.c
     src/pc/sdl2.c
-    src/pc/plat_win.c
 )
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,14 @@ set(SOURCE_FILES_PC
     src/pc/sotn.c
     src/pc/pc.c
     src/pc/sdl2.c
+    src/pc/plat_win.c
 )
+
+if(WIN32)
+set(SOURCE_FILES_PC $(SOURCE_FILES_PC) src/pc/plat_win.c)
+else()
+set(SOURCE_FILES_PC $(SOURCE_FILES_PC) src/pc/plat_unix.c)
+endif()
 
 set(SOURCE_FILES_PSX_SDK
     src/main/psxsdk/libgpu/ext.c

--- a/Makefile.pc.mk
+++ b/Makefile.pc.mk
@@ -9,7 +9,7 @@ CC_FLAGS_PC         += -I$(INCLUDE_DIR) -I$(SRC_DIR)/dra/ -I$(SRC_DIR)/pc/3rd
 LD_FLAGS_PC         := -fsanitize=address -lc -lm -lSDL2 -lSDL2_image
 
 C_FILES_PC          := main.c log.c stubs.c sotn.c
-C_FILES_PC          += pc.c sdl2.c
+C_FILES_PC          += pc.c sdl2.c plat_unix.c
 C_FILES_PSX_SDK     := libgpu/ext.c
 C_FILES_MOCK_SDK    := libapi.c libetc.c libgpu.c libgte.c libgs.c libcd.c libcard.c libspu.c libsnd.c cdc.c
 C_FILES_3RD         := cJSON/cJSON.c

--- a/src/pc/plat_unix.c
+++ b/src/pc/plat_unix.c
@@ -1,0 +1,98 @@
+#include <common.h>
+#include <log.h>
+#include <string.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <psxsdk/kernel.h>
+
+void _adjust_path(char* dst, const char* src, int maxlen) {
+    INFOF("TODO: adjust path '%s'", src);
+    strncpy(dst, src, maxlen);
+    dst[maxlen - 1] = '\0';
+}
+
+void _populate_entry(struct DIRENTRY* dst, struct dirent* src) {
+    struct stat fileStat;
+    if (stat(src->d_name, &fileStat) == -1) {
+        ERRORF("failed to stat '%s'", src->d_name);
+    }
+
+    // TODO: names longer than 20 characters are not supported
+    if (strlen(src->d_name) >= sizeof(dst->name) - 1) {
+        WARNF("dir name '%s' will be truncated", src->d_name);
+    }
+    strncpy(dst->name, src->d_name, sizeof(dst->name) - 1);
+    dst->name[sizeof(dst->name) - 1] = '\0';
+    dst->attr = 0; // not sure what this is
+    dst->size = fileStat.st_size;
+    dst->head = 0; // not sure what this is
+    dst->system[0] = 'O';
+    dst->system[1] = 'S';
+    dst->system[2] = '\0';
+    dst->system[3] = '\0';
+}
+
+struct DIRENTRY* my_firstfile(char* dirPath, struct DIRENTRY* firstEntry) {
+    char adjPath[0x100];
+    _adjust_path(adjPath, dirPath, sizeof(adjPath));
+
+    DEBUGF("opendir('%s')", adjPath);
+    DIR* dir = opendir(adjPath);
+
+    if (!dir) {
+        ERRORF("Failed to open directory '%s'", adjPath);
+        return NULL;
+    }
+
+    struct dirent* entry = readdir(dir);
+    if (!entry) {
+        ERRORF("Failed to read directory '%s'", adjPath);
+        closedir(dir);
+        return NULL;
+    }
+
+    _populate_entry(firstEntry, entry);
+    firstEntry->next = (struct DIRENTRY*)dir;
+
+    // since libapi does not offer a 'closefile', the expectation is that the
+    // caller will consume 'nextfile' until a NULL is received, effectively
+    // calling 'closedir' and freeing the resource created here.
+    // If that does not happen, a memory leak will occur.
+    return firstEntry;
+}
+
+struct DIRENTRY* my_nextfile(struct DIRENTRY* outEntry) {
+    if (!outEntry) {
+        return NULL;
+    }
+
+    if (!outEntry->next) {
+        return NULL;
+    }
+
+    DIR* dir = (DIR*)outEntry->next;
+    struct dirent* entry = readdir(dir);
+
+    while (entry) {
+        // filter by regular files
+        if (entry->d_type == DT_REG) {
+            _populate_entry(outEntry, entry);
+            return outEntry;
+        }
+
+        entry = readdir(dir);
+    }
+
+    // Close the directory if there are no more entries
+    closedir(dir);
+    outEntry->next = NULL;
+    return NULL;
+}
+
+long my_erase(char* path) {
+    char adjPath[0x100];
+    _adjust_path(adjPath, path, sizeof(adjPath));
+
+    DEBUGF("remove('%s')", adjPath);
+    return remove(adjPath) == 0;
+}

--- a/src/pc/plat_win.c
+++ b/src/pc/plat_win.c
@@ -1,0 +1,28 @@
+#include <common.h>
+#include <log.h>
+#include <string.h>
+#include <psxsdk/kernel.h>
+
+void _adjust_path(char* dst, const char* src, int maxlen) {
+    INFOF("TODO: adjust path '%s'", src);
+    strncpy(dst, src, maxlen);
+    dst[maxlen - 1] = '\0';
+}
+
+struct DIRENTRY* my_firstfile(char* dirPath, struct DIRENTRY* firstEntry) {
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+struct DIRENTRY* my_nextfile(struct DIRENTRY* outEntry) {
+    NOT_IMPLEMENTED;
+    return NULL;
+}
+
+long my_erase(char* path) {
+    char adjPath[0x100];
+    _adjust_path(adjPath, path, sizeof(adjPath));
+
+    DEBUGF("remove('%s')", adjPath);
+    return remove(adjPath) == 0;
+}

--- a/src/pc/psxsdk/libapi.c
+++ b/src/pc/psxsdk/libapi.c
@@ -1,16 +1,5 @@
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <common.h>
 #include <log.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#ifndef _MSC_VER
-#include <dirent.h>
-#endif
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <psxsdk/kernel.h>
 
 int VSync(int mode) {
@@ -36,109 +25,17 @@ void EnterCriticalSection(void) { NOT_IMPLEMENTED; }
 
 void ExitCriticalSection(void) { NOT_IMPLEMENTED; }
 
-void _adjust_path(char* dst, const char* src, int maxlen) {
-#ifndef _MSC_VER
-    INFOF("TODO: adjust path '%s'", src);
-    strncpy(dst, src, maxlen);
-    dst[maxlen - 1] = '\0';
-#endif
-}
-
-void _populate_entry(struct DIRENTRY* dst, struct dirent* src) {
-#ifndef _MSC_VER
-    struct stat fileStat;
-    if (stat(src->d_name, &fileStat) == -1) {
-        ERRORF("failed to stat '%s'", src->d_name);
-    }
-
-    // TODO: names longer than 20 characters are not supported
-    if (strlen(src->d_name) >= sizeof(dst->name) - 1) {
-        WARNF("dir name '%s' will be truncated", src->d_name);
-    }
-    strncpy(dst->name, src->d_name, sizeof(dst->name) - 1);
-    dst->name[sizeof(dst->name) - 1] = '\0';
-    dst->attr = 0; // not sure what this is
-    dst->size = fileStat.st_size;
-    dst->head = 0; // not sure what this is
-    dst->system[0] = 'O';
-    dst->system[1] = 'S';
-    dst->system[2] = '\0';
-    dst->system[3] = '\0';
-#endif
-}
-
+struct DIRENTRY* my_firstfile(char* dirPath, struct DIRENTRY* firstEntry);
 struct DIRENTRY* firstfile(char* dirPath, struct DIRENTRY* firstEntry) {
-#ifndef _MSC_VER
-    char adjPath[0x100];
-    _adjust_path(adjPath, dirPath, sizeof(adjPath));
-
-    DEBUGF("opendir('%s')", adjPath);
-    DIR* dir = opendir(adjPath);
-
-    if (!dir) {
-        ERRORF("Failed to open directory '%s'", adjPath);
-        return NULL;
-    }
-
-    struct dirent* entry = readdir(dir);
-    if (!entry) {
-        ERRORF("Failed to read directory '%s'", adjPath);
-        closedir(dir);
-        return NULL;
-    }
-
-    _populate_entry(firstEntry, entry);
-    firstEntry->next = (struct DIRENTRY*)dir;
-
-// since libapi does not offer a 'closefile', the expectation is that the
-// caller will consume 'nextfile' until a NULL is received, effectively
-// calling 'closedir' and freeing the resource created here.
-// If that does not happen, a memory leak will occur.
-#endif
-    return firstEntry;
+    return my_firstfile(dirPath, firstEntry);
 }
 
-// dirent not available on MSVC
+struct DIRENTRY* my_nextfile(struct DIRENTRY* outEntry);
 struct DIRENTRY* nextfile(struct DIRENTRY* outEntry) {
-#ifndef _MSC_VER
-    if (!outEntry) {
-        return NULL;
-    }
-
-    if (!outEntry->next) {
-        return NULL;
-    }
-
-    DIR* dir = (DIR*)outEntry->next;
-    struct dirent* entry = readdir(dir);
-
-    while (entry) {
-        // filter by regular files
-        if (entry->d_type == DT_REG) {
-            _populate_entry(outEntry, entry);
-            return outEntry;
-        }
-
-        entry = readdir(dir);
-    }
-
-    // Close the directory if there are no more entries
-    closedir(dir);
-    outEntry->next = NULL;
-#endif
-    return NULL;
+    return my_nextfile(outEntry);
 }
 
-long erase(char* path) {
-#ifndef _MSC_VER
-    char adjPath[0x100];
-    _adjust_path(adjPath, path, sizeof(adjPath));
-
-    DEBUGF("remove('%s')", adjPath);
-    return remove(adjPath) == 0;
-#else
-    return 0;
-#endif
-}
+long my_erase(char* path);
+long erase(char* path) { return my_erase(path); }
 
 long format(char* fs) { NOT_IMPLEMENTED; }

--- a/src/pc/psxsdk/libcard.c
+++ b/src/pc/psxsdk/libcard.c
@@ -1,8 +1,3 @@
-#ifdef _MSC_VER
-#include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif
 #include <common.h>
 #include <psxsdk/libcard.h>
 #include <log.h>

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -2,11 +2,6 @@
 #include "dra.h"
 #include "servant.h"
 #include "sfx.h"
-#ifdef _MSC_VER
-#include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif
 #include <cJSON/cJSON.h>
 
 #include <stdio.h>


### PR DESCRIPTION
Reduce the amount of `#ifdef` by abstracting platform specific code into ad-hoc C files that can be linked and swapped.

I trimmed down `libapi.c` and used the `My`/`my_` pattern for those specific PSX API calls. The new `plat_unix.c` contains the usual code, while `plat_win.c` contains placeholder functions waiting for an implementation. I have no rush to do so because I have yet to test if the unix version works.

I removed from `sotn.c` and `libcard.c` any reference to SDL, which is now self-contained in `sdl2.c`.
