### PR TITLE
Decompile RIC func_80161FF0

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -632,6 +632,11 @@ typedef struct {
     struct Entity* parent2;
 } ET_80128C2C;
 
+typedef struct {
+    s16 unk7C;
+    s16 unk7E;
+} ET_80161FF0;
+
 typedef union {
     /* 0x7C */ struct Primitive* prim;
     /* 0x7C */ ET_EntFactory factory;
@@ -660,6 +665,7 @@ typedef union {
     /* 0x7C */ ET_8017091C et_8017091C;
     /* 0x7C */ ET_80170F64 et_80170F64;
     /* 0x7C */ ET_8017161C et_8017161C;
+    /* 0x7C */ ET_80161FF0 et_80161FF0;
     /* 0x7C */ ET_801719A4 et_801719A4;
     /* 0x7C */ ET_BibleSubwpn et_BibleSubwpn;
     /* 0x7C */ ET_801CF254 et_801CF254;

--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -256,3 +256,15 @@ typedef struct {
     u8 unk4;
     u8 unk5;
 } FactoryBlueprint;
+
+typedef struct {
+    s16 xOffset;
+    s16 yOffset;
+    s32 velocityX;
+    s32 velocityY;
+    s16 timerInit;
+    s16 tpage;
+    s16 clut;
+    u8 uBase;
+    u8 vBase;
+} unkStr80154E5C; // size = 0x14

--- a/src/ric/24788.c
+++ b/src/ric/24788.c
@@ -708,7 +708,77 @@ void func_80161EF8(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/24788", func_80161FF0);
+void func_80161FF0(Entity* self) {
+    Primitive* prim;
+
+    u16 posX = self->posX.i.hi;
+    u16 posY = self->posY.i.hi;
+    unkStr80154E5C* temp_s2 = &D_80154E5C[(s16)self->params];
+
+    switch (self->step) {
+    case 0:
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
+        }
+        g_api.PlaySfx(0x881);
+        self->ext.et_80161FF0.unk7C = 0x100;
+        prim = &g_PrimBuf[self->primIndex];
+        prim->u0 = temp_s2->uBase;
+        prim->v0 = temp_s2->vBase;
+        prim->u1 = temp_s2->uBase + 0x7F;
+        prim->v1 = temp_s2->vBase;
+        prim->u2 = temp_s2->uBase;
+        prim->v2 = temp_s2->vBase + 0x6F;
+        prim->u3 = temp_s2->uBase + 0x7F;
+        prim->v3 = temp_s2->vBase + 0x6F;
+        prim->tpage = temp_s2->tpage;
+        prim->clut = temp_s2->clut;
+        prim->priority = PLAYER.zPriority + 8;
+        prim->blendMode = 0x31;
+        self->velocityX = temp_s2->velocityX;
+        self->velocityY = temp_s2->velocityY;
+        self->posX.i.hi += temp_s2->xOffset;
+        posX = self->posX.i.hi;
+        posY = self->posY.i.hi + temp_s2->yOffset;
+        self->posY.i.hi = posY;
+        self->flags = FLAG_UNK_04000000 | FLAG_HAS_PRIMS | FLAG_UNK_10000;
+        self->step++;
+        break;
+    case 1:
+        self->ext.et_80161FF0.unk7C -= 8;
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        if (self->ext.et_80161FF0.unk7C < 25) {
+            self->ext.et_80161FF0.unk7E = temp_s2->timerInit;
+            self->step++;
+        }
+        break;
+    case 2:
+        if (--self->ext.et_80161FF0.unk7E == 0) {
+            self->step++;
+        }
+        break;
+    case 3:
+        self->ext.et_80161FF0.unk7C -= 2;
+        if (self->ext.et_80161FF0.unk7C < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    prim = &g_PrimBuf[self->primIndex];
+    prim->x0 = posX + (((rcos(0x600) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->y0 = posY - (((rsin(0x600) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->x1 = posX + (((rcos(0x200) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->y1 = posY - (((rsin(0x200) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->x2 = posX + (((rcos(0xA00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->y2 = posY - (((rsin(0xA00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->x3 = posX + (((rcos(0xE00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    prim->y3 = posY - (((rsin(0xE00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
+    return;
+}
 
 void func_801623E0(Entity* entity) {
     POLY_GT4* poly;

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -119,6 +119,7 @@ extern unkStr_8011E4BC* D_80154DA0[];
 extern AnimationFrame D_80154DC8[];
 extern AnimationFrame D_80154E04[];
 extern AnimationFrame* D_80154E38;
+extern unkStr80154E5C D_80154E5C[];
 extern AnimationFrame* D_80155394;
 extern AnimationFrame* D_8015539C;
 extern AnimationFrame* D_801553BC;


### PR DESCRIPTION
Some entity, don't know what. There seem to be a lot of entities that just use 7C and 7E from the `ext`, might be something we think about unifying in the future.