### PR TITLE
Extract RIC factory blueprints

### DIFF
--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -33,6 +33,8 @@ segments:
       - [0x20, spritesheet, richter, disks/us/BIN/F_GAME2.BIN, 0x40400]
       - [0x170AC, .data, spriteparts]
       - [0x18568, data]
+      - [0x18A6C, assets, factory_blueprint, g_RicFactoryBlueprints]
+      - [0x18C40, data]
       - [0x194B0, data]
       - [0x19B50, data]
       - [0x19BE0, data]

--- a/tools/splat_ext/assets.py
+++ b/tools/splat_ext/assets.py
@@ -231,8 +231,10 @@ class PSXSegAssets(N64Segment):
 if __name__ == "__main__":
     input_file_name = sys.argv[1]
     output_file_name = sys.argv[2]
-    config_file_name = input_file_name.replace(".json", "_config.json")
-    config_file_name = config_file_name.replace("assets/dra", "tools/splat_ext")
+
+    pathless_input_filename = input_file_name.split("/")[-1]
+    config_file_name = pathless_input_filename.replace(".json", "_config.json")
+    config_file_name = "tools/splat_ext/" + config_file_name
     with open(config_file_name, "r") as config_in:
         config_json = config_in.read()
 


### PR DESCRIPTION
Adjusts the splat to extract these blueprints the same as the DRA ones, and also adjusts `assets.py` to work with assets besides those in DRA.