### PR TITLE
Load sfx data

### DIFF
--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -477,7 +477,7 @@ extern const char aRgb02x02x02x;
 extern const char aSp03x;
 extern const char aSp1603x;
 extern const char aTile03x;
-extern Unkstruct_800BF554 g_SfxData[];
+extern Unkstruct_800BF554 g_SfxData[737];
 
 extern char* aLightTimer02x;
 extern SVECTOR D_800E2024;

--- a/src/pc/psxsdk/libsnd.c
+++ b/src/pc/psxsdk/libsnd.c
@@ -70,10 +70,12 @@ s32 SsVabTransCompleted(short immediateFlag) {
 
 s32 SsVabOpenHeadSticky(u_char* addr, u_long vabid, u_long sbaddr) {
     NOT_IMPLEMENTED;
+    return 0;
 }
 
 s32 SsVabTransBodyPartly(u_char* addr, u_long bufsize, u_long vabid) {
     NOT_IMPLEMENTED;
+    return 0;
 }
 
 void SsVabClose(short vab_id) { NOT_IMPLEMENTED; }

--- a/src/pc/psxsdk/libspu.c
+++ b/src/pc/psxsdk/libspu.c
@@ -4,7 +4,10 @@
 
 void SpuSetVoiceAttr(SpuVoiceAttr* arg) { DEBUGF("SpuSetVoiceAttr"); }
 
-long SpuMallocWithStartAddr(unsigned long addr, long size) { NOT_IMPLEMENTED; }
+long SpuMallocWithStartAddr(unsigned long addr, long size) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
 
 SpuIRQCallbackProc SpuSetIRQCallback(SpuIRQCallbackProc in) {
     NOT_IMPLEMENTED;

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <cJSON/cJSON.h>
 
 const char g_DummyName[] = "DUMMY\xFF";
 
@@ -69,6 +70,7 @@ void InitRelicDefs(void);
 void InitEnemyDefs(void);
 void InitSubwpnDefs(void);
 void InitVbVh(void);
+bool InitSfxData(const char* content);
 bool InitGame(void) {
     if (!InitPlatform()) {
         return false;
@@ -166,6 +168,10 @@ bool InitGame(void) {
     g_Vram.D_800ACDA8.h = 0x0010;
 
     InitVbVh();
+
+    if (!FileStringify(InitSfxData, "assets/dra/sfx.json")) {
+        WARNF("failed to init sfx");
+    }
 
     return true;
 }
@@ -403,4 +409,41 @@ void InitVbVh() {
     ReadToArray("assets/dra/vb_1.bin", D_8017D350, LEN(D_8017D350));
     ReadToArray("assets/dra/vb_2.bin", D_8018B4E0, LEN(D_8018B4E0));
     ReadToArray("assets/dra/vb_3.bin", D_801A9C80, LEN(D_801A9C80));
+}
+
+#define DO_ITEM(field_str, jitem, item, to_set)                                \
+    {                                                                          \
+        cJSON* field = NULL;                                                   \
+        field = cJSON_GetObjectItemCaseSensitive(jitem, field_str);            \
+                                                                               \
+        if (cJSON_IsNumber(field)) {                                           \
+            to_set = field->valueint;                                          \
+        } else {                                                               \
+            ERRORF("Wrong field %s", field_str);                               \
+            exit(1);                                                           \
+        }                                                                      \
+    }
+
+bool InitSfxData(const char* content) {
+    cJSON* json = cJSON_Parse(content);
+    cJSON* array = cJSON_GetObjectItemCaseSensitive(json, "asset_data");
+    if (cJSON_IsArray(array)) {
+        int len = cJSON_GetArraySize(array);
+        for (int i = 0; i < len; i++) {
+            Unkstruct_800BF554* item = &g_SfxData[i];
+            cJSON* jitem = cJSON_GetArrayItem(array, i);
+            DO_ITEM("vabid", jitem, item, item->vabid);
+            DO_ITEM("prog", jitem, item, item->prog);
+            DO_ITEM("note", jitem, item, item->note);
+            DO_ITEM("volume", jitem, item, item->volume);
+            DO_ITEM("unk4", jitem, item, item->unk4);
+            DO_ITEM("tone", jitem, item, item->tone);
+            DO_ITEM("unk6", jitem, item, item->unk6);
+        }
+    } else {
+        ERRORF("Error loading sfx.");
+        exit(1);
+    }
+    cJSON_Delete(json);
+    return true;
 }

--- a/src/pc/stubs.c
+++ b/src/pc/stubs.c
@@ -413,7 +413,7 @@ s16 g_VolL;
 s16 g_VolR;
 s16 D_8013AE94;
 u16 D_8013AEE0;
-Unkstruct_800BF554 g_SfxData[1];
+Unkstruct_800BF554 g_SfxData[737];
 u16 D_8013AE7C;
 s16 D_801390A4;
 s16 D_80139010;


### PR DESCRIPTION
This loads the sfx data from the json and fixes a couple of places with missing return values that can cause infinite loops.