### PR TITLE
Flip new implementation of INCLUDE_ASM

### DIFF
--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -8,7 +8,7 @@
 
 #ifndef INCLUDE_ASM
 
-#ifdef INCLUDE_ASM_NEW
+#ifndef INCLUDE_ASM_OLD
 #define INCLUDE_ASM(FOLDER, NAME)                                              \
     __asm__(".section .text\n"                                                 \
             "\t.align\t2\n"                                                    \

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -1,6 +1,5 @@
 #ifndef DRA_H
 #define DRA_H
-#define INCLUDE_ASM_NEW
 
 #include "game.h"
 #include "weapon.h"

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/main", main);
+INCLUDE_ASM("main/nonmatchings/main", main);

--- a/src/main/psxsdk/libapi/counter.c
+++ b/src/main/psxsdk/libapi/counter.c
@@ -1,11 +1,11 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/counter", SetRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/counter", SetRCnt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/counter", GetRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/counter", GetRCnt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/counter", StartRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/counter", StartRCnt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/counter", StopRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/counter", StopRCnt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/counter", ResetRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/counter", ResetRCnt);

--- a/src/main/psxsdk/libapi/l10.c
+++ b/src/main/psxsdk/libapi/l10.c
@@ -2,17 +2,17 @@
 #include <game.h>
 #include <psxsdk/libetc.h>
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", ChangeClearRCnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", ChangeClearRCnt);
 
 int ResetCallback(void) { return D_8002D340->ResetCallback(); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", InterruptCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", InterruptCallback);
 
 void* DMACallback(int dma, void (*func)()) {
     return D_8002D340->DMACallback(dma, func);
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", VSyncCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", VSyncCallback);
 
 int VSyncCallbacks(int ch, void (*f)()) {
     return D_8002D340->VSyncCallbacks(ch, f);
@@ -24,18 +24,18 @@ int RestartCallback(void) { return D_8002D340->RestartCallback(); }
 
 u16 CheckCallback(void) { return D_8002C2BA; }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", GetIntrMask);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", GetIntrMask);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", SetIntrMask);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", SetIntrMask);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", startIntr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", startIntr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", trapIntr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", trapIntr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", setIntr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", setIntr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", stopIntr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", stopIntr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", restartIntr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", restartIntr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libapi/l10", memclr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libapi/l10", memclr);

--- a/src/main/psxsdk/libc/c23.c
+++ b/src/main/psxsdk/libc/c23.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libc/c23", strcmp);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libc/c23", strcmp);

--- a/src/main/psxsdk/libc/c24.c
+++ b/src/main/psxsdk/libc/c24.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libc/c24", strncmp);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libc/c24", strncmp);

--- a/src/main/psxsdk/libc/memmove.c
+++ b/src/main/psxsdk/libc/memmove.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("/asm/us/main/nonmatchings/psxsdk/libc/memmove", memmove);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libc/memmove", memmove);

--- a/src/main/psxsdk/libc/sprintf.c
+++ b/src/main/psxsdk/libc/sprintf.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("/asm/us/main/nonmatchings/psxsdk/libc/sprintf", sprintf);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libc/sprintf", sprintf);

--- a/src/main/psxsdk/libcard/card.c
+++ b/src/main/psxsdk/libcard/card.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcard/card", _card_clear);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcard/card", _card_clear);

--- a/src/main/psxsdk/libcd/bios.c
+++ b/src/main/psxsdk/libcd/bios.c
@@ -1,27 +1,27 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", getintr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", getintr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_sync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_sync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_ready);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_ready);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_cw);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_cw);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_vol);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_vol);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_flush);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_flush);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_initvol);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_initvol);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_initintr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_initintr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_init);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_init);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_datasync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_datasync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_getsector);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_getsector);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", CD_set_test_parmnum);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_set_test_parmnum);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/bios", callback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", callback);

--- a/src/main/psxsdk/libcd/c_002.c
+++ b/src/main/psxsdk/libcd/c_002.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_002", StClearRing);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_002", StClearRing);

--- a/src/main/psxsdk/libcd/c_003.c
+++ b/src/main/psxsdk/libcd/c_003.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_003", StUnSetRing);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_003", StUnSetRing);

--- a/src/main/psxsdk/libcd/c_004.c
+++ b/src/main/psxsdk/libcd/c_004.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_004", data_ready_callback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_004", data_ready_callback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_004", StGetBackloc);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_004", StGetBackloc);

--- a/src/main/psxsdk/libcd/c_005.c
+++ b/src/main/psxsdk/libcd/c_005.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_005", StSetStream);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_005", StSetStream);

--- a/src/main/psxsdk/libcd/c_007.c
+++ b/src/main/psxsdk/libcd/c_007.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_007", StFreeRing);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_007", StFreeRing);

--- a/src/main/psxsdk/libcd/c_008.c
+++ b/src/main/psxsdk/libcd/c_008.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_008", init_ring_status);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_008", init_ring_status);

--- a/src/main/psxsdk/libcd/c_009.c
+++ b/src/main/psxsdk/libcd/c_009.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_009", StGetNext);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_009", StGetNext);

--- a/src/main/psxsdk/libcd/c_010.c
+++ b/src/main/psxsdk/libcd/c_010.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_010", StSetMask);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_010", StSetMask);

--- a/src/main/psxsdk/libcd/c_011.c
+++ b/src/main/psxsdk/libcd/c_011.c
@@ -1,7 +1,7 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_011", StCdInterrupt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_011", StCdInterrupt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_011", mem2mem);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_011", mem2mem);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/c_011", dma_execute);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/c_011", dma_execute);

--- a/src/main/psxsdk/libcd/cdread.c
+++ b/src/main/psxsdk/libcd/cdread.c
@@ -1,11 +1,11 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread", cb_read);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread", cb_read);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread", cd_read_retry);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread", cd_read_retry);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread", CdRead);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread", CdRead);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread", CdReadSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread", CdReadSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread", CdReadCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread", CdReadCallback);

--- a/src/main/psxsdk/libcd/cdread2.c
+++ b/src/main/psxsdk/libcd/cdread2.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread2", CdRead2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread2", CdRead2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdread2", StCdInterrupt2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdread2", StCdInterrupt2);

--- a/src/main/psxsdk/libcd/cdrom.c
+++ b/src/main/psxsdk/libcd/cdrom.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/cdrom", StSetRing);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/cdrom", StSetRing);

--- a/src/main/psxsdk/libcd/event.c
+++ b/src/main/psxsdk/libcd/event.c
@@ -1,9 +1,9 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/event", CdInit);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/event", CdInit);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/event", def_cbsync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/event", def_cbsync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/event", def_cbready);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/event", def_cbready);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/event", def_cbread);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/event", def_cbread);

--- a/src/main/psxsdk/libcd/iso9660.c
+++ b/src/main/psxsdk/libcd/iso9660.c
@@ -1,15 +1,15 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", CdSearchFile);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", CdSearchFile);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", _cmp);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", _cmp);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", CD_newmedia);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", CD_newmedia);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", CD_searchdir);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", CD_searchdir);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", CD_cachefile);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", CD_cachefile);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", cd_read);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", cd_read);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/iso9660", cd_memcpy);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/iso9660", cd_memcpy);

--- a/src/main/psxsdk/libcd/sys.c
+++ b/src/main/psxsdk/libcd/sys.c
@@ -10,40 +10,40 @@ int CdMode(void) { return CD_mode; }
 
 int CdLastCom(void) { return CD_com; }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdLastPos);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdLastPos);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdReset);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdReset);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdFlush);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdFlush);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdSetDebug);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdSetDebug);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdComstr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdComstr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdIntstr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdIntstr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdReady);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdReady);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdSyncCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdSyncCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdReadyCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdReadyCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdControl);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdControl);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdControlF);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdControlF);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdControlB);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdControlB);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdMix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdMix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdGetSector);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdGetSector);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdDataCallback);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdDataCallback);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdDataSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdDataSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdIntToPos);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdIntToPos);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libcd/sys", CdPosToInt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdPosToInt);

--- a/src/main/psxsdk/libetc/intr_dma.c
+++ b/src/main/psxsdk/libetc/intr_dma.c
@@ -1,9 +1,9 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_dma", startIntrDMA);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_dma", startIntrDMA);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_dma", trapIntrDMA);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_dma", trapIntrDMA);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_dma", setIntrDMA);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_dma", setIntrDMA);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_dma", DMA_memclr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_dma", DMA_memclr);

--- a/src/main/psxsdk/libetc/intr_vb.c
+++ b/src/main/psxsdk/libetc/intr_vb.c
@@ -1,9 +1,9 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_vb", startIntrVSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_vb", startIntrVSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_vb", trapIntrVSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_vb", trapIntrVSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_vb", setIntrVSync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_vb", setIntrVSync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/intr_vb", VSync_memclr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/intr_vb", VSync_memclr);

--- a/src/main/psxsdk/libetc/pad.c
+++ b/src/main/psxsdk/libetc/pad.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/pad", PadInit);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/pad", PadInit);
 // void PadInit(s32 arg0) {
 //     D_80073080 = arg0;
 //     D_8003925C = -1;
@@ -9,6 +9,6 @@ INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/pad", PadInit);
 //     ChangeClearPAD(0);
 // }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/pad", PadRead);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/pad", PadRead);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/pad", PadStop);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/pad", PadStop);

--- a/src/main/psxsdk/libetc/vmode.c
+++ b/src/main/psxsdk/libetc/vmode.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/vmode", SetVideoMode);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/vmode", SetVideoMode);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libetc/vmode", GetVideoMode);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libetc/vmode", GetVideoMode);

--- a/src/main/psxsdk/libgpu/font.c
+++ b/src/main/psxsdk/libgpu/font.c
@@ -1,11 +1,11 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/font", SetDumpFnt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", SetDumpFnt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/font", FntLoad);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntLoad);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/font", FntOpen);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntOpen);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/font", FntFlush);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntFlush);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/font", FntPrint);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntPrint);

--- a/src/main/psxsdk/libgpu/prim.c
+++ b/src/main/psxsdk/libgpu/prim.c
@@ -1,75 +1,75 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", GetTPage);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", GetTPage);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", GetClut);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", GetClut);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", DumpTPage);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", DumpTPage);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", DumpClut);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", DumpClut);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", NextPrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", NextPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", IsEndPrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", IsEndPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", AddPrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", AddPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", AddPrims);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", AddPrims);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", CatPrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", CatPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", TermPrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", TermPrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetSemiTrans);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetSemiTrans);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetShadeTex);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetShadeTex);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyF3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyF3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyFT3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyFT3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyG3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyG3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyGT3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyGT3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyF4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyF4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyFT4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyFT4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyG4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyG4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetPolyGT4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetPolyGT4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetSprt8);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetSprt8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetSprt16);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetSprt16);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetSprt);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetSprt);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetTile1);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetTile1);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetTile8);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetTile8);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetTile16);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetTile16);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetTile);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetTile);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetBlockFill);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetBlockFill);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineF2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineF2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineG2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineG2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineF3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineF3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineG3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineG3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineF4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineF4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", SetLineG4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", SetLineG4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", MargePrim);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", MargePrim);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", DumpDrawEnv);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", DumpDrawEnv);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/prim", DumpDispEnv);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/prim", DumpDispEnv);

--- a/src/main/psxsdk/libgpu/sys.c
+++ b/src/main/psxsdk/libgpu/sys.c
@@ -43,7 +43,7 @@ u_long get_cs(short, short);
 u_long get_tw(RECT* tw);
 u_long get_ofs(short, short);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", ResetGraph);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", ResetGraph);
 
 int SetGraphReverse(int mode) {
     unsigned int var_a0;
@@ -190,7 +190,7 @@ u_long* ClearOTagR(u_long* ot, int n) {
     return ot;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", func_80012DBC);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", func_80012DBC);
 
 void DrawOTag(u_long* p) {
     if (D_8002C268 >= 2) {
@@ -217,7 +217,7 @@ DRAWENV* GetDrawEnv(DRAWENV* env) {
     return env;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", PutDispEnv);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", PutDispEnv);
 
 DISPENV* GetDispEnv(DISPENV* env) {
     __builtin_memcpy(env, &D_80037EBC, sizeof(DISPENV));
@@ -245,7 +245,7 @@ void SetDrawOffset(DR_OFFSET* p, u_short* ofs) {
     p->code[1] = 0;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", SetPriority);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", SetPriority);
 
 extern void SetDrawMode(DR_MODE* p, int dfe, int dtd, int tpage, RECT* tw) {
     setlen(p, 2);
@@ -254,52 +254,52 @@ extern void SetDrawMode(DR_MODE* p, int dfe, int dtd, int tpage, RECT* tw) {
 }
 
 extern void SetDrawEnv(DR_ENV* dr_env, DRAWENV* env);
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", SetDrawEnv);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", SetDrawEnv);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_mode);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_mode);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_cs);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_cs);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_ce);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_ce);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_ofs);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_ofs);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_tw);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_tw);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_dx);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_dx);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _status);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _status);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _otc);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _otc);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _clr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _clr);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _dws);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _dws);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _drs);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _drs);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _ctl);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _ctl);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _getctl);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _getctl);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _cwb);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _cwb);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _cwc);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _cwc);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _param);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _param);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _addque);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _addque);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _addque2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _addque2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _exeque);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _exeque);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _reset);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _reset);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", _sync);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", _sync);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", set_alarm);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", set_alarm);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", get_alarm);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_alarm);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgpu/sys", GPU_memset);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", GPU_memset);

--- a/src/main/psxsdk/libgs/gs_007.c
+++ b/src/main/psxsdk/libgs/gs_007.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgs/gs_007", GsInitVcount);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_007", GsInitVcount);

--- a/src/main/psxsdk/libgs/gs_008.c
+++ b/src/main/psxsdk/libgs/gs_008.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgs/gs_008", GsGetVcount);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_008", GsGetVcount);

--- a/src/main/psxsdk/libgs/gs_009.c
+++ b/src/main/psxsdk/libgs/gs_009.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgs/gs_009", GsClearVcount);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_009", GsClearVcount);

--- a/src/main/psxsdk/libgte/cmb_00.c
+++ b/src/main/psxsdk/libgte/cmb_00.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/cmb_00", RotTransPers4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_00", RotTransPers4);

--- a/src/main/psxsdk/libgte/cmb_01.c
+++ b/src/main/psxsdk/libgte/cmb_01.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/cmb_01", RotAverage3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_01", RotAverage3);

--- a/src/main/psxsdk/libgte/cmb_02.c
+++ b/src/main/psxsdk/libgte/cmb_02.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/cmb_02", RotAverage4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_02", RotAverage4);

--- a/src/main/psxsdk/libgte/cmb_06.c
+++ b/src/main/psxsdk/libgte/cmb_06.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("/asm/us/main/nonmatchings/psxsdk/libgte/cmb_06", RotAverageNclip3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_06", RotAverageNclip3);

--- a/src/main/psxsdk/libgte/cmb_07.c
+++ b/src/main/psxsdk/libgte/cmb_07.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_07", RotAverageNclip4);

--- a/src/main/psxsdk/libgte/cmb_09.c
+++ b/src/main/psxsdk/libgte/cmb_09.c
@@ -1,4 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM(
-    "/asm/us/main/nonmatchings/psxsdk/libgte/cmb_09", RotAverageNclipColorCol3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/cmb_09", RotAverageNclipColorCol3);

--- a/src/main/psxsdk/libgte/fgo_01.c
+++ b/src/main/psxsdk/libgte/fgo_01.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/fgo_01", RotMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fgo_01", RotMatrix);

--- a/src/main/psxsdk/libgte/fgo_02.c
+++ b/src/main/psxsdk/libgte/fgo_02.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("/asm/us/main/nonmatchings/psxsdk/libgte/fgo_02", RotMatrixYXZ);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fgo_02", RotMatrixYXZ);

--- a/src/main/psxsdk/libgte/fgo_04.c
+++ b/src/main/psxsdk/libgte/fgo_04.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/fgo_04", RotMatrixX);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fgo_04", RotMatrixX);

--- a/src/main/psxsdk/libgte/fgo_05.c
+++ b/src/main/psxsdk/libgte/fgo_05.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/fgo_05", RotMatrixY);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fgo_05", RotMatrixY);

--- a/src/main/psxsdk/libgte/fgo_06.c
+++ b/src/main/psxsdk/libgte/fgo_06.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/fgo_06", RotMatrixZ);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fgo_06", RotMatrixZ);

--- a/src/main/psxsdk/libgte/fog_01.c
+++ b/src/main/psxsdk/libgte/fog_01.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/fog_01", SetFogNear);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/fog_01", SetFogNear);

--- a/src/main/psxsdk/libgte/geo_01.c
+++ b/src/main/psxsdk/libgte/geo_01.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/geo_01", rcos);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/geo_01", rcos);

--- a/src/main/psxsdk/libgte/msc00.c
+++ b/src/main/psxsdk/libgte/msc00.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("/asm/us/main/nonmatchings/psxsdk/libgte/msc00", InitGeom);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc00", InitGeom);

--- a/src/main/psxsdk/libgte/msc01.c
+++ b/src/main/psxsdk/libgte/msc01.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc01", SquareRoot0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc01", SquareRoot0);

--- a/src/main/psxsdk/libgte/msc02.c
+++ b/src/main/psxsdk/libgte/msc02.c
@@ -1,9 +1,9 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc02", InvSquareRoot);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc02", InvSquareRoot);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc02", func_80017008);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc02", func_80017008);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc02", func_80017078);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc02", func_80017078);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc02", MatrixNormal);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc02", MatrixNormal);

--- a/src/main/psxsdk/libgte/msc09.c
+++ b/src/main/psxsdk/libgte/msc09.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/msc09", SquareRoot12);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/msc09", SquareRoot12);

--- a/src/main/psxsdk/libgte/mtx_00.c
+++ b/src/main/psxsdk/libgte/mtx_00.c
@@ -1,27 +1,27 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", CompMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", CompMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", MulMatrix0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", MulMatrix0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", MulRotMatrix0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", MulRotMatrix0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", MulRotMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", MulRotMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", SetMulMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", SetMulMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ApplyMatrixLV);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ApplyMatrixLV);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ApplyRotMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ApplyRotMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ScaleMatrixL);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ScaleMatrixL);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", PushMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", PushMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", PopMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", PopMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ReadRotMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ReadRotMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ReadLightMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ReadLightMatrix);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_00", ReadColorMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_00", ReadColorMatrix);

--- a/src/main/psxsdk/libgte/mtx_07.c
+++ b/src/main/psxsdk/libgte/mtx_07.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_07", TransMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_07", TransMatrix);

--- a/src/main/psxsdk/libgte/mtx_08.c
+++ b/src/main/psxsdk/libgte/mtx_08.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_08", ScaleMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_08", ScaleMatrix);

--- a/src/main/psxsdk/libgte/mtx_09.c
+++ b/src/main/psxsdk/libgte/mtx_09.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_09", SetRotMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_09", SetRotMatrix);

--- a/src/main/psxsdk/libgte/mtx_10.c
+++ b/src/main/psxsdk/libgte/mtx_10.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_10", SetLightMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_10", SetLightMatrix);

--- a/src/main/psxsdk/libgte/mtx_11.c
+++ b/src/main/psxsdk/libgte/mtx_11.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_11", SetColorMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_11", SetColorMatrix);

--- a/src/main/psxsdk/libgte/mtx_12.c
+++ b/src/main/psxsdk/libgte/mtx_12.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/mtx_12", SetTransMatrix);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/mtx_12", SetTransMatrix);

--- a/src/main/psxsdk/libgte/patchgte.c
+++ b/src/main/psxsdk/libgte/patchgte.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/patchgte", patch_gte);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/patchgte", patch_gte);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/patchgte", func_8001929C);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/patchgte", func_8001929C);

--- a/src/main/psxsdk/libgte/reg03.c
+++ b/src/main/psxsdk/libgte/reg03.c
@@ -1,31 +1,31 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetVertex0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetVertex1);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex1);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetVertex2);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex2);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetVertexTri);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertexTri);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetRGBfifo);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetRGBfifo);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetIR123);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetIR123);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetIR0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetIR0);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo4);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetSXSYfifo);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSXSYfifo);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetRii);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetRii);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetMAC123);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetMAC123);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetData32);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetData32);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetDQA);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetDQA);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg03", SetDQB);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetDQB);

--- a/src/main/psxsdk/libgte/reg10.c
+++ b/src/main/psxsdk/libgte/reg10.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg10", SetBackColor);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg10", SetBackColor);

--- a/src/main/psxsdk/libgte/reg11.c
+++ b/src/main/psxsdk/libgte/reg11.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg11", SetFarColor);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg11", SetFarColor);

--- a/src/main/psxsdk/libgte/reg12.c
+++ b/src/main/psxsdk/libgte/reg12.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg12", SetGeomOffset);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg12", SetGeomOffset);

--- a/src/main/psxsdk/libgte/reg13.c
+++ b/src/main/psxsdk/libgte/reg13.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/reg13", SetGeomScreen);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg13", SetGeomScreen);

--- a/src/main/psxsdk/libgte/smp.c
+++ b/src/main/psxsdk/libgte/smp.c
@@ -1,25 +1,25 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", LocalLight);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", LocalLight);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", DpqColor);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", DpqColor);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColor);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColor);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColor3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColor3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColorDpq);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColorDpq);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColorDpq3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColorDpq3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColorCol);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColorCol);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", NormalColorCol3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", NormalColorCol3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", ColorDpq);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", ColorDpq);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", ColorCol);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", ColorCol);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", AverageSZ3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", AverageSZ3);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp", AverageSZ4);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp", AverageSZ4);

--- a/src/main/psxsdk/libgte/smp_02.c
+++ b/src/main/psxsdk/libgte/smp_02.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp_02", RotTransPers);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp_02", RotTransPers);

--- a/src/main/psxsdk/libgte/smp_03.c
+++ b/src/main/psxsdk/libgte/smp_03.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp_03", RotTransPers3);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp_03", RotTransPers3);

--- a/src/main/psxsdk/libgte/smp_04.c
+++ b/src/main/psxsdk/libgte/smp_04.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp_04", RotTrans);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp_04", RotTrans);

--- a/src/main/psxsdk/libgte/smp_05.c
+++ b/src/main/psxsdk/libgte/smp_05.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp_05", NormalClip);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp_05", NormalClip);

--- a/src/main/psxsdk/libgte/smp_06.c
+++ b/src/main/psxsdk/libgte/smp_06.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libgte/smp_06", NormalClipS);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/smp_06", NormalClipS);

--- a/src/main/psxsdk/libsnd/adsr.c
+++ b/src/main/psxsdk/libsnd/adsr.c
@@ -13,4 +13,4 @@ void _SsUtResolveADSR(u16 arg0, u16 arg1, struct Unk* arg2) {
     arg2->unk8 = arg1 & 0x1F;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/adsr", _SsUtBuildADSR);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/adsr", _SsUtBuildADSR);

--- a/src/main/psxsdk/libsnd/cres.c
+++ b/src/main/psxsdk/libsnd/cres.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/cres", _SsSndCrescendo);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/cres", _SsSndCrescendo);

--- a/src/main/psxsdk/libsnd/decre.c
+++ b/src/main/psxsdk/libsnd/decre.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/decre", _SsSndDecrescendo);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/decre", _SsSndDecrescendo);

--- a/src/main/psxsdk/libsnd/pause.c
+++ b/src/main/psxsdk/libsnd/pause.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/pause", _SsSndPause);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/pause", _SsSndPause);

--- a/src/main/psxsdk/libsnd/replay.c
+++ b/src/main/psxsdk/libsnd/replay.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/replay", _SsSndReplay);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/replay", _SsSndReplay);

--- a/src/main/psxsdk/libsnd/seqinit.c
+++ b/src/main/psxsdk/libsnd/seqinit.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/seqinit", _SsInitSoundSeq);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/seqinit", _SsInitSoundSeq);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/seqinit", SsSeqOpen);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/seqinit", SsSeqOpen);

--- a/src/main/psxsdk/libsnd/seqread.c
+++ b/src/main/psxsdk/libsnd/seqread.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libsnd_internal.h"
 

--- a/src/main/psxsdk/libsnd/ssclose.c
+++ b/src/main/psxsdk/libsnd/ssclose.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "libsnd_internal.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/ssclose", _SsClose);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/ssclose", _SsClose);
 
 void SsSeqClose(short seq_access_num) { _SsClose(seq_access_num); }
 

--- a/src/main/psxsdk/libsnd/ssinit.c
+++ b/src/main/psxsdk/libsnd/ssinit.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/ssinit", _SsInit);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/ssinit", _SsInit);

--- a/src/main/psxsdk/libsnd/ssstart.c
+++ b/src/main/psxsdk/libsnd/ssstart.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "libsnd_internal.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/ssstart", _SsStart);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/ssstart", _SsStart);
 
 void SsStart(void) { _SsStart(1); }
 

--- a/src/main/psxsdk/libsnd/stop.c
+++ b/src/main/psxsdk/libsnd/stop.c
@@ -3,7 +3,7 @@
 
 s32 SpuVmSeqKeyOff(s32, s32, struct SeqStruct*, s32);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/stop", _SsSndStop);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/stop", _SsSndStop);
 
 void _SsSndStop(s16, s16);
 

--- a/src/main/psxsdk/libsnd/tempo.c
+++ b/src/main/psxsdk/libsnd/tempo.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/tempo", _SsSndTempo);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/tempo", _SsSndTempo);

--- a/src/main/psxsdk/libsnd/vm_vsu.c
+++ b/src/main/psxsdk/libsnd/vm_vsu.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libsnd/vm_vsu", SpuVmVSetUp);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/vm_vsu", SpuVmVSetUp);

--- a/src/main/psxsdk/libsnd/vmanager.c
+++ b/src/main/psxsdk/libsnd/vmanager.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libsnd_internal.h"
 

--- a/src/main/psxsdk/libsnd/vs_vh.c
+++ b/src/main/psxsdk/libsnd/vs_vh.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libsnd_internal.h"
 

--- a/src/main/psxsdk/libsnd/vs_vtbp.c
+++ b/src/main/psxsdk/libsnd/vs_vtbp.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/vs_vtbp", SsVabTransBodyPartly);

--- a/src/main/psxsdk/libspu/s_crwa.c
+++ b/src/main/psxsdk/libspu/s_crwa.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libspu_internal.h"
 

--- a/src/main/psxsdk/libspu/s_gva.c
+++ b/src/main/psxsdk/libspu/s_gva.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_gva", SpuGetVoiceAttr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_gva", SpuGetVoiceAttr);

--- a/src/main/psxsdk/libspu/s_ini.c
+++ b/src/main/psxsdk/libspu/s_ini.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "libspu_internal.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_ini", _SpuInit);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_ini", _SpuInit);
 
 void SpuStart(void) {
     s32 temp_v0;

--- a/src/main/psxsdk/libspu/s_itc.c
+++ b/src/main/psxsdk/libspu/s_itc.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_itc", SpuIsTransferCompleted);

--- a/src/main/psxsdk/libspu/s_m_f.c
+++ b/src/main/psxsdk/libspu/s_m_f.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_m_f", SpuFree);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_m_f", SpuFree);

--- a/src/main/psxsdk/libspu/s_m_m.c
+++ b/src/main/psxsdk/libspu/s_m_m.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_m_m", SpuMalloc);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_m_m", SpuMalloc);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_m_m", func_800286E0);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_m_m", func_800286E0);

--- a/src/main/psxsdk/libspu/s_m_util.c
+++ b/src/main/psxsdk/libspu/s_m_util.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libspu_internal.h"
 

--- a/src/main/psxsdk/libspu/s_m_wsa.c
+++ b/src/main/psxsdk/libspu/s_m_wsa.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_m_wsa", _SpuMallocSeparateTo3);

--- a/src/main/psxsdk/libspu/s_n2p.c
+++ b/src/main/psxsdk/libspu/s_n2p.c
@@ -1,5 +1,5 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_n2p", _spu_note2pitch);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_n2p", _spu_note2pitch);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_n2p", _spu_pitch2note);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_n2p", _spu_pitch2note);

--- a/src/main/psxsdk/libspu/s_q.c
+++ b/src/main/psxsdk/libspu/s_q.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_q", SpuQuit);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_q", SpuQuit);

--- a/src/main/psxsdk/libspu/s_sav.c
+++ b/src/main/psxsdk/libspu/s_sav.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_sav", SpuSetAnyVoice);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_sav", SpuSetAnyVoice);

--- a/src/main/psxsdk/libspu/s_sca.c
+++ b/src/main/psxsdk/libspu/s_sca.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_sca", SpuSetCommonAttr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_sca", SpuSetCommonAttr);

--- a/src/main/psxsdk/libspu/s_si.c
+++ b/src/main/psxsdk/libspu/s_si.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_si", SpuSetIRQ);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_si", SpuSetIRQ);

--- a/src/main/psxsdk/libspu/s_sk.c
+++ b/src/main/psxsdk/libspu/s_sk.c
@@ -1,3 +1,3 @@
 #include "common.h"
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_sk", SpuSetKey);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_sk", SpuSetKey);

--- a/src/main/psxsdk/libspu/s_srmp.c
+++ b/src/main/psxsdk/libspu/s_srmp.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libspu_internal.h"
 

--- a/src/main/psxsdk/libspu/s_stsa.c
+++ b/src/main/psxsdk/libspu/s_stsa.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 #include "libspu_internal.h"
 

--- a/src/main/psxsdk/libspu/s_sva.c
+++ b/src/main/psxsdk/libspu/s_sva.c
@@ -4,4 +4,4 @@
 
 void SpuSetVoiceAttr(SpuVoiceAttr* arg) { _SpuSetVoiceAttr(arg, 0, 0x17, 0); }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/s_sva", _SpuSetVoiceAttr);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/s_sva", _SpuSetVoiceAttr);

--- a/src/main/psxsdk/libspu/spu.c
+++ b/src/main/psxsdk/libspu/spu.c
@@ -21,9 +21,9 @@ s32 _spu_reset(void) {
     return 0;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/spu", _spu_init);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/spu", _spu_init);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/spu", _spu_writeByIO);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/spu", _spu_writeByIO);
 
 void _spu_FiDMA(void) {
     volatile s32 sp0;
@@ -79,7 +79,7 @@ void _spu_r_(s32 arg0, u16 arg1, s32 arg2) {
     *D_80033510 = 0x01000200;
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/spu", _spu_t);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/spu", _spu_t);
 
 s32 _spu_write(u32 arg0, u32 arg1) {
 
@@ -110,6 +110,6 @@ void _spu_FsetRXX(s32 arg0, u32 arg1, s32 arg2) {
     _spu_RXX->raw[arg0] = (arg1 >> _spu_mem_mode_plus);
 }
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/spu", _spu_FsetRXXa);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/spu", _spu_FsetRXXa);
 
-INCLUDE_ASM("asm/us/main/nonmatchings/psxsdk/libspu/spu", _spu_FgetRXXa);
+INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/spu", _spu_FgetRXXa);

--- a/src/main/psxsdk/libspu/sr_gaks.c
+++ b/src/main/psxsdk/libspu/sr_gaks.c
@@ -1,4 +1,3 @@
-#define INCLUDE_ASM_NEW
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libspu/sr_gaks", SpuRGetAllKeysStatus);

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -360,7 +360,7 @@ void CheckHighJumpInput(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", UpdateEntityRichter);
+INCLUDE_ASM("ric/nonmatchings/1AC60", UpdateEntityRichter);
 
 void func_801587C0() { D_80175956 = 0; }
 
@@ -1281,7 +1281,7 @@ void func_8015A7D0(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/1AC60", func_8015A9B0);
+INCLUDE_ASM("ric/nonmatchings/1AC60", func_8015A9B0);
 
 void func_8015AFE0(void) {
     if (PLAYER.step_s == 0) {

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -79,7 +79,7 @@ bool func_80162E9C(Entity* entity) {
     return false;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80162EF8);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80162EF8);
 
 void func_801641A0(Entity* entity) {
     POLY_GT4* poly;
@@ -141,11 +141,11 @@ void func_801641A0(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80164444);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80164444);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80164DF8);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80164DF8);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_801656B0);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_801656B0);
 
 void func_80165DD8(
     POLY_GT4* poly, s32 colorIntensity, s32 y, s32 radius, bool arg4) {
@@ -244,9 +244,9 @@ void func_80166044() {
     PLAYER.blendMode = 0;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80166060);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80166060);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80166784);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80166784);
 
 void func_8016779C(Entity* entity) {
     if (g_Player.unk46 == 0) {
@@ -321,11 +321,11 @@ void func_80167A60(Entity* self) {}
 
 void func_80167A68(Entity* self) {}
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80167A70);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80167A70);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80167EC4);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80167EC4);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_801682B4);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_801682B4);
 
 s32 func_8016840C(s16 x, s16 y) {
     Collider collider;
@@ -350,15 +350,15 @@ s32 func_8016840C(s16 x, s16 y) {
     return 2;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_801684D8);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_801684D8);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80168A20);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80168A20);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016902C);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016902C);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80169470);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80169470);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80169704);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80169704);
 
 void func_80169C10(Entity* entity) {
     POLY_GT4* poly;
@@ -448,13 +448,13 @@ void func_80169D74(Entity* entity) {
         (entity->ext.generic.unk80.modeS16.unk0 + 1) & 0x3F;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_80169F04);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_80169F04);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016A26C);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016A26C);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016A974);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016A974);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016B0C0);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016B0C0);
 
 void func_8016B8E8(s32 arg0) {
     g_CurrentEntity->ext.generic.unk7C.s =
@@ -474,9 +474,9 @@ void func_8016B92C(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016B97C);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016B97C);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016C1BC);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016C1BC);
 
 s32 func_8016C6C4(Unkstruct_80128BBC* arg0, u8 value) {
     u8 ret = 0;
@@ -498,9 +498,9 @@ s32 func_8016C6C4(Unkstruct_80128BBC* arg0, u8 value) {
     return ret;
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016C734);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016C734);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016CC74);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016CC74);
 
 void func_8016D328(Entity* entity) {
     s16 primIndex;
@@ -550,7 +550,7 @@ void func_8016D328(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016D4D8);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016D4D8);
 
 void func_8016D920(Entity* entity) {
     switch (entity->step) {
@@ -571,6 +571,6 @@ void func_8016D920(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016D9C4);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016D9C4);
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/26C84", func_8016DF74);
+INCLUDE_ASM("ric/nonmatchings/26C84", func_8016DF74);

--- a/src/ric/32324.c
+++ b/src/ric/32324.c
@@ -39,7 +39,7 @@ void func_8016E324(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/ric/nonmatchings/32324", func_8016E46C);
+INCLUDE_ASM("ric/nonmatchings/32324", func_8016E46C);
 
 void func_8016E9E4(Entity* self) {
     Primitive* prim;

--- a/src/servant/tt_000/10E8.c
+++ b/src/servant/tt_000/10E8.c
@@ -1213,7 +1213,7 @@ void func_80174038(Entity* entity) {
 }
 
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/servant/tt_000/nonmatchings/10E8", func_80174210);
+INCLUDE_ASM("servant/tt_000/nonmatchings/10E8", func_80174210);
 #else
 typedef struct {
     u32 unk0;

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -1,7 +1,7 @@
 #include "cen.h"
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", TestCollisions);
+INCLUDE_ASM("st/cen/nonmatchings/11280", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", EntityNumericDamage);
+INCLUDE_ASM("st/cen/nonmatchings/11280", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -201,7 +201,7 @@ void func_80193088(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80193184);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80193184);
 
 void InitRoomEntities(s32 objLayoutId) {
     u16* pObjLayoutStart = D_801801EC[objLayoutId];
@@ -244,7 +244,7 @@ void InitRoomEntities(s32 objLayoutId) {
     func_80192FE4(tilemap->cameraY.i.hi + 0x120);
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80193410);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80193410);
 
 void CreateEntityFromCurrentEntity(u16 entityId, Entity* entity) {
     DestroyEntity(entity);
@@ -277,7 +277,7 @@ bool func_801935B4(Entity* self) {
 }
 
 // Red door (ID 05)
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", EntityRedDoor);
+INCLUDE_ASM("st/cen/nonmatchings/11280", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -299,7 +299,7 @@ void PreventEntityFromRespawning(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80194394);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80194394);
 
 u8 func_8019444C(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;
@@ -615,7 +615,7 @@ void func_80194EE0(u16 arg0, u16 arg1) {
     g_CurrentEntity->step_s = 0;
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", InitializeEntity);
+INCLUDE_ASM("st/cen/nonmatchings/11280", InitializeEntity);
 
 void func_80195070(Entity* entity) {
     if (entity->step == 0) {
@@ -688,7 +688,7 @@ void func_801951C0(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80195318);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80195318);
 
 #include "../replace_breakable_with_item_drop.h"
 
@@ -714,7 +714,7 @@ void func_80195714(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80195798);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80195798);
 
 void CollectHeart(u16 index) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
@@ -780,7 +780,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", func_80195B68);
+INCLUDE_ASM("st/cen/nonmatchings/11280", func_80195B68);
 
 void func_80195C0C(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
@@ -790,12 +790,12 @@ void func_80195C0C(void) {
 
 void func_80195C5C(void) { DestroyEntity(g_CurrentEntity); }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", EntityPrizeDrop);
+INCLUDE_ASM("st/cen/nonmatchings/11280", EntityPrizeDrop);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", EntityExplosion);
+INCLUDE_ASM("st/cen/nonmatchings/11280", EntityExplosion);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", BlinkItem);
+INCLUDE_ASM("st/cen/nonmatchings/11280", BlinkItem);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/11280", EntityEquipItemDrop);
+INCLUDE_ASM("st/cen/nonmatchings/11280", EntityEquipItemDrop);
 
 #include "../blit_char.h"

--- a/src/st/cen/18084.c
+++ b/src/st/cen/18084.c
@@ -1,6 +1,6 @@
 #include "cen.h"
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80198084);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80198084);
 
 extern u16 D_80180440[];
 void EntityUnkId13(Entity* entity) {
@@ -30,18 +30,18 @@ void EntityUnkId13(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80198284);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80198284);
 
 #include "../entity_unkId15_spawner.h"
 
 // ID 14
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", EntityExplosion14);
+INCLUDE_ASM("st/cen/nonmatchings/18084", EntityExplosion14);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", EntityUnkId15);
+INCLUDE_ASM("st/cen/nonmatchings/18084", EntityUnkId15);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80198680);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80198680);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_801988B0);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_801988B0);
 
 u8 func_801989AC(s32 arg0) {
     Collider collider;
@@ -218,9 +218,9 @@ u8 func_801989AC(s32 arg0) {
 // ID 06
 #include "../entity_intense_explosion.h"
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_8019902C);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_8019902C);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_801990F8);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_801990F8);
 
 void func_801991C0(void) {
     Entity* entity;
@@ -239,11 +239,11 @@ void func_801991C0(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80199278);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80199278);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80199450);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80199450);
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", func_80199A30);
+INCLUDE_ASM("st/cen/nonmatchings/18084", func_80199A30);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -369,4 +369,4 @@ void func_8019A420(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/18084", EntityStageNamePopup);
+INCLUDE_ASM("st/cen/nonmatchings/18084", EntityStageNamePopup);

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -32,7 +32,7 @@ void EntityBackgroundBlock(Entity* self) {
     func_80194394(obj->unk10, self);
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", EntityUnkId12);
+INCLUDE_ASM("st/cen/nonmatchings/D600", EntityUnkId12);
 
 void EntityUnkId01(Entity* self) {
     Entity* newEntity;
@@ -462,7 +462,7 @@ void func_8018E6C4(u8 ySteps) {
     g_Dialogue.portraitAnimTimer++;
 }
 
-INCLUDE_ASM("asm/us/st/cen/nonmatchings/D600", EntityUnkId16);
+INCLUDE_ASM("st/cen/nonmatchings/D600", EntityUnkId16);
 
 void func_8018F890(s16 arg0) {
     s16 temp_v0 = arg0 - g_Tilemap.height;

--- a/src/st/dre/14774.c
+++ b/src/st/dre/14774.c
@@ -266,7 +266,7 @@ void func_80194FF4(u8 ySteps) {
 }
 
 // dialogue with mother opens as alucard walks right ID 20
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/14774", EntitySuccubusCutscene);
+INCLUDE_ASM("st/dre/nonmatchings/14774", EntitySuccubusCutscene);
 
 void func_801961DC(s16 arg0) {
     s16 temp_v0 = arg0 - *(s16*)D_8009740C;
@@ -280,7 +280,7 @@ void func_801961DC(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/14774", EntityUnkId21);
+INCLUDE_ASM("st/dre/nonmatchings/14774", EntityUnkId21);
 
 // appears to load from the CD and freeze the game
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/14774", EntityUnkId23);
+INCLUDE_ASM("st/dre/nonmatchings/14774", EntityUnkId23);

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -1,7 +1,7 @@
 #include "dre.h"
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", TestCollisions);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", EntityNumericDamage);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -105,9 +105,9 @@ void func_80198EC0(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", func_80198F18);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", func_80198F18);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", func_80199014);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", func_80199014);
 
 void func_80199128(s16 arg0) {
     while (1) {
@@ -129,9 +129,9 @@ void func_80199174(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", func_801991CC);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", func_801991CC);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", func_801992C8);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", func_801992C8);
 
 void InitRoomEntities(s32 objLayoutId) {
     u16* pObjLayoutStart = D_80180220[objLayoutId];
@@ -229,7 +229,7 @@ s32 func_801996F8(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", EntityRedDoor);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -712,7 +712,7 @@ void func_8019B304(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", func_8019B45C);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", func_8019B45C);
 
 #include "../replace_breakable_with_item_drop.h"
 
@@ -869,7 +869,7 @@ void CollectLifeVessel(void) {
 
 void DestroyCurrentEntity(void) { DestroyEntity(g_CurrentEntity); }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/173C4", EntityPrizeDrop);
+INCLUDE_ASM("st/dre/nonmatchings/173C4", EntityPrizeDrop);
 
 void EntityExplosion(Entity* entity) {
     u32 temp_v0;

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -1,6 +1,6 @@
 #include "dre.h"
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019E1C8);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019E1C8);
 
 void EntityUnkId13(Entity* entity) {
     switch (entity->step) {
@@ -30,7 +30,7 @@ void EntityUnkId13(Entity* entity) {
 }
 
 // DECOMP_ME_WIP func_8019E3C8 https://decomp.me/scratch/lcx4I
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019E3C8);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019E3C8);
 
 #include "../entity_unkId15_spawner.h"
 
@@ -97,7 +97,7 @@ void EntityUnkId15(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019E7C4);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019E7C4);
 
 bool func_8019E9F4(Point16* arg0) {
     Collider collider;
@@ -366,11 +366,11 @@ void func_8019F304(void) {
 }
 
 // DECOMP_ME_WIP func_8019F3BC https://decomp.me/scratch/Hfk9n
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019F3BC);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019F3BC);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019F594);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019F594);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_8019FB74);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_8019FB74);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -496,7 +496,7 @@ void func_801A0564(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", EntityStageNamePopup);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", EntityStageNamePopup);
 
 // The white flying orbs of energy that Alucard summons as part of the Soul
 // Steal spell
@@ -757,7 +757,7 @@ void BottomCornerText(u8* str, u8 lower_left) {
 // DECOMP_ME_WIP func_801A25FC https://decomp.me/scratch/IIvQX a0 -> v0 register
 // swap
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A25FC);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_801A25FC);
 #else
 POLY_GT4* func_801A25FC(POLY_GT4* poly, s32 arg1) {
     s32 i;
@@ -824,14 +824,14 @@ void func_801A2764(POLY_GT4* poly) {
 
 #include "../unk_loop_func.h"
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A2848);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_801A2848);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A2A58);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_801A2A58);
 
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", func_801A2C9C);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", func_801A2C9C);
 
 // DECOMP_ME_WIP EntityUnkId17 https://decomp.me/scratch/nNfXk 95.28%
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", EntityUnkId17);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", EntityUnkId17);
 
 // 3D house object in background ID 0x16
-INCLUDE_ASM("asm/us/st/dre/nonmatchings/1E1C8", Entity3DBackgroundHouse);
+INCLUDE_ASM("st/dre/nonmatchings/1E1C8", Entity3DBackgroundHouse);

--- a/src/st/mad/mad.h
+++ b/src/st/mad/mad.h
@@ -6,6 +6,7 @@
 #undef _internal_version_us
 #define _internal_version_beta
 #define VERSION_BETA
+#define INCLUDE_ASM_OLD
 
 #include "stage.h"
 

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -134,7 +134,7 @@ void EntityUnkId16(Entity* self) {
 }
 
 // lightning and sound for background
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/377D4", EntityBackgroundLightning);
+INCLUDE_ASM("st/no3/nonmatchings/377D4", EntityBackgroundLightning);
 
 // window that opens and shuts in the background
 void EntityShuttingWindow(Entity* self) {
@@ -388,7 +388,7 @@ void EntityCastleDoor(Entity* self) {
 }
 
 // bushes in parallax background
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/377D4", EntityBackgroundBushes);
+INCLUDE_ASM("st/no3/nonmatchings/377D4", EntityBackgroundBushes);
 
 void EntityUnkId1C(Entity* self, s16 primIndex) {
     volatile char pad[8]; //! FAKE
@@ -570,7 +570,7 @@ void EntityTransparentWater(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/377D4", func_801B94F0);
+INCLUDE_ASM("st/no3/nonmatchings/377D4", func_801B94F0);
 
 // lever and platform to open caverns door
 void EntityCavernDoorLever(Entity* entity) {
@@ -1492,7 +1492,7 @@ void EntityFallingRock(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/377D4", func_801BB548);
+INCLUDE_ASM("st/no3/nonmatchings/377D4", func_801BB548);
 
 // sky animation during death cutscene
 void EntityDeathSkySwirl(Entity* self) {

--- a/src/st/no3/3C4EC.c
+++ b/src/st/no3/3C4EC.c
@@ -265,7 +265,7 @@ void EntityUnkId50(Entity* self) {
 }
 
 // part of parallax background with pine trees
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3C4EC", EntityBackgroundPineTrees);
+INCLUDE_ASM("st/no3/nonmatchings/3C4EC", EntityBackgroundPineTrees);
 
 void EntityUnkId52(Entity* self) {
     Tilemap* tilemap = &g_Tilemap;
@@ -324,7 +324,7 @@ void EntityUnkId52(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3C4EC", EntityCastleBridge);
+INCLUDE_ASM("st/no3/nonmatchings/3C4EC", EntityCastleBridge);
 
 // ID 0x55
 void EntityBackgroundTrees(Entity* self) {

--- a/src/st/no3/3E134.c
+++ b/src/st/no3/3E134.c
@@ -364,6 +364,6 @@ void func_801BECCC(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", func_801BEDAC);
+INCLUDE_ASM("st/no3/nonmatchings/3E134", func_801BEDAC);
 // seems to cause a room transition
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/3E134", EntityRoomTransition1);
+INCLUDE_ASM("st/no3/nonmatchings/3E134", EntityRoomTransition1);

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -1,7 +1,7 @@
 #include "no3.h"
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/41C80", TestCollisions);
+INCLUDE_ASM("st/no3/nonmatchings/41C80", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/41C80", EntityNumericDamage);
+INCLUDE_ASM("st/no3/nonmatchings/41C80", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -328,7 +328,7 @@ s32 func_801C3FB4(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/41C80", EntityRedDoor);
+INCLUDE_ASM("st/no3/nonmatchings/41C80", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -761,7 +761,7 @@ void func_801C5BC0(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/41C80", func_801C5D18);
+INCLUDE_ASM("st/no3/nonmatchings/41C80", func_801C5D18);
 
 #include "../replace_breakable_with_item_drop.h"
 

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -120,7 +120,7 @@ void EntityUnkId15(Entity* arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801C9080);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801C9080);
 
 bool func_801C92B0(Point16* unk) {
     Collider collider;
@@ -381,11 +381,11 @@ void func_801C9BC0(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801C9C78);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801C9C78);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801C9E50);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801C9E50);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801CA430);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801CA430);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -511,7 +511,7 @@ void func_801CAE20(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityStageNamePopup);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityStageNamePopup);
 
 // The white flying orbs of energy that Alucard summons as part of the Soul
 // Steal spell
@@ -736,24 +736,24 @@ void func_801CC90C(Entity* arg0) {
 }
 
 // stronger version of warg with jump and flame attack
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityStrongWarg);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityStrongWarg);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityUnkId30);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityUnkId30);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityUnkId31);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityUnkId31);
 
 // some sort of explosion
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityExplosion3);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityExplosion3);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801CE740);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801CE740);
 
 // flame-like attack on ground from strong warg
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityStrongWargWaveAttack);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityStrongWargWaveAttack);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityUnkId2F);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityUnkId2F);
 
 // beams that go up when strong warg dies
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityStrongWargDeathBeams);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityStrongWargDeathBeams);
 
 void func_801CF438(Entity* entity, u8 count, u8 params, s32 xDist, s32 yDist,
                    u8 arg5, s16 xOfst) {
@@ -845,9 +845,9 @@ void func_801CF6D8(Entity* arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityWarg);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityWarg);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityUnkId4B);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityUnkId4B);
 
 // A single "puff" of the warg explosion animation, transparent
 void EntityWargExplosionPuffTransparent(Entity* entity) {
@@ -1014,10 +1014,10 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", func_801D0A2C);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", func_801D0A2C);
 
 // Alucard says "ahh" and turns blue from water contact
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityAlucardWaterEffect);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityAlucardWaterEffect);
 
 // ID 0x35
 void EntitySplashWater(Entity* self) {
@@ -1639,7 +1639,7 @@ s32 func_801D2D40(s16 yVector) {
 }
 
 // another merman variant
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityMerman3);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityMerman3);
 
 // some sort of explosion
 void EntityExplosion2(Entity* entity, s32 arg1) {
@@ -1941,9 +1941,9 @@ void EntityLargeFallingObject(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityMermanSpawner);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityMermanSpawner);
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityMerman);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityMerman);
 
 // fireball shot by merman
 void EntityMermanFireball(Entity* self) {
@@ -2008,7 +2008,7 @@ void EntityFallingObject(Entity* arg0) {
 }
 
 // part of explosion when merman dies
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityMermanExplosion);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityMermanExplosion);
 
 s32 func_801C52EC(s32*);
 s32 func_801C5A98(u16* hitSensors, s16 sensorCount);
@@ -2033,7 +2033,7 @@ void func_801D59D0(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/no3/nonmatchings/48A84", EntityBoneScimitar);
+INCLUDE_ASM("st/no3/nonmatchings/48A84", EntityBoneScimitar);
 
 // debris that rotates and falls down
 void EntityBoneScimitarParts(Entity* entity) {

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -127,7 +127,7 @@ void func_801B2830(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801B28E4);
+INCLUDE_ASM("st/np3/nonmatchings/3246C", func_801B28E4);
 
 void EntityShuttingWindow(Entity* self) {
     Primitive* prim;
@@ -326,7 +326,7 @@ void EntityCastleDoor(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801B32A8);
+INCLUDE_ASM("st/np3/nonmatchings/3246C", func_801B32A8);
 
 void func_801B3704(Entity* self, s16 primIndex) {
     volatile char pad[8]; //! FAKE
@@ -507,7 +507,7 @@ void EntityTransparentWater(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/3246C", func_801B3D24);
+INCLUDE_ASM("st/np3/nonmatchings/3246C", func_801B3D24);
 
 void EntityCavernDoorLever(Entity* entity) {
     s32 posX;

--- a/src/st/np3/36990.c
+++ b/src/st/np3/36990.c
@@ -578,7 +578,7 @@ void EntitySlograSpearProjectile(Entity* self) {
 }
 
 #ifndef NONMATCHING
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/36990", EntityGaibon);
+INCLUDE_ASM("st/np3/nonmatchings/36990", EntityGaibon);
 #else
 void EntityGaibon(Entity* self) {
     const int RetreatedInEntrance = 57;

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -1,7 +1,7 @@
 #include "np3.h"
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/394F0", TestCollisions);
+INCLUDE_ASM("st/np3/nonmatchings/394F0", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/394F0", EntityNumericDamage);
+INCLUDE_ASM("st/np3/nonmatchings/394F0", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -315,7 +315,7 @@ s32 func_801BB824(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/394F0", EntityRedDoor);
+INCLUDE_ASM("st/np3/nonmatchings/394F0", EntityRedDoor);
 
 void DestroyEntity(Entity* item) {
     s32 i;
@@ -752,7 +752,7 @@ void func_801BD430(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/394F0", func_801BD588);
+INCLUDE_ASM("st/np3/nonmatchings/394F0", func_801BD588);
 
 #include "../replace_breakable_with_item_drop.h"
 

--- a/src/st/np3/402F4.c
+++ b/src/st/np3/402F4.c
@@ -504,9 +504,9 @@ void func_801C14E8(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/402F4", func_801C16C0);
+INCLUDE_ASM("st/np3/nonmatchings/402F4", func_801C16C0);
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/402F4", func_801C1CA0);
+INCLUDE_ASM("st/np3/nonmatchings/402F4", func_801C1CA0);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -632,7 +632,7 @@ void func_801C2690(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/402F4", EntityStageNamePopup);
+INCLUDE_ASM("st/np3/nonmatchings/402F4", EntityStageNamePopup);
 
 // The white flying orbs of energy that Alucard summons as part of the Soul
 // Steal spell
@@ -884,7 +884,7 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/402F4", func_801C4144);
+INCLUDE_ASM("st/np3/nonmatchings/402F4", func_801C4144);
 
 // ID 0x2C
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/402F4", func_801C424C);
+INCLUDE_ASM("st/np3/nonmatchings/402F4", func_801C424C);

--- a/src/st/np3/4B018.c
+++ b/src/st/np3/4B018.c
@@ -1,10 +1,10 @@
 #include "np3.h"
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4B018", EntityOwl);
+INCLUDE_ASM("st/np3/nonmatchings/4B018", EntityOwl);
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4B018", func_801CBF18);
+INCLUDE_ASM("st/np3/nonmatchings/4B018", func_801CBF18);
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4B018", EntityOwlKnight);
+INCLUDE_ASM("st/np3/nonmatchings/4B018", EntityOwlKnight);
 
 void func_801CD540(Entity* self) {
     s8* hitbox;
@@ -132,7 +132,7 @@ void func_801CDA6C(Entity* self, s32 arg1) {
                   temp_s0->ext.GH_Props.unk9C, arg1);
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4B018", func_801CDAC8);
+INCLUDE_ASM("st/np3/nonmatchings/4B018", func_801CDAC8);
 
 bool func_801CDC80(s16* arg0, s16 arg1, s16 arg2) {
     s32 var_v1 = *arg0 - arg1;

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -1,12 +1,12 @@
 #include "np3.h"
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", EntityHammer);
+INCLUDE_ASM("st/np3/nonmatchings/4E69C", EntityHammer);
 
 // DECOMP_ME_WIP func_801CF254 https://decomp.me/scratch/EpZEL
 // minor regalloc
 // has jumptable
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", EntityGurkhaBodyParts);
+INCLUDE_ASM("st/np3/nonmatchings/4E69C", EntityGurkhaBodyParts);
 #else
 extern u16 D_80180B8C[];
 extern u16 D_80180BA4[];
@@ -235,7 +235,7 @@ int func_801CF7A0(Entity* ent) {
 }
 
 // DECOMP_ME_WIP EntityGurkha https://decomp.me/scratch/51iIJ
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", EntityGurkha);
+INCLUDE_ASM("st/np3/nonmatchings/4E69C", EntityGurkha);
 
 void EntityGurkhaSword(Entity* self) {
     s16 angle;
@@ -416,7 +416,7 @@ s32 func_801D0B78(void) {
     return ret;
 }
 
-INCLUDE_ASM("asm/us/st/np3/nonmatchings/4E69C", EntityBlade);
+INCLUDE_ASM("st/np3/nonmatchings/4E69C", EntityBlade);
 
 void EntityBladeSword(Entity* self) {
     Primitive *prim, *prim2;

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -37,7 +37,7 @@ bool func_801B0A20(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/30958", func_801B0AA4);
+INCLUDE_ASM("st/nz0/nonmatchings/30958", func_801B0AA4);
 
 void EntityBreakable(Entity* self) {
     u16 params = self->params >> 0xC;

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -125,7 +125,7 @@ typedef enum {
 // DECOMP_ME_WIP EntityCloseBossRoom https://decomp.me/scratch/bqgN9 95.04 %
 // figuring out D_80181014 struct might help
 // trigger to stop music and close slogra/gaibon room
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/33FCC", EntityCloseBossRoom);
+INCLUDE_ASM("st/nz0/nonmatchings/33FCC", EntityCloseBossRoom);
 
 // blocks that move to close slogra/gaibon room
 void EntityBossRoomBlock(Entity* self) {
@@ -684,7 +684,7 @@ void EntitySlograSpearProjectile(Entity* self) {
 // Mostly regalloc, instruction reordering
 // https://decomp.me/scratch/QGtpG
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/33FCC", EntityGaibon);
+INCLUDE_ASM("st/nz0/nonmatchings/33FCC", EntityGaibon);
 #else
 void EntityGaibon(Entity* self) {
     s32 slograGaibonDistX;

--- a/src/st/nz0/36DE4.c
+++ b/src/st/nz0/36DE4.c
@@ -465,7 +465,7 @@ void func_801B7C54(u8 ySteps) {
 }
 
 // cutscene where alucard and maria discuss castle changing
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/36DE4", EntityMariaCutscene);
+INCLUDE_ASM("st/nz0/nonmatchings/36DE4", EntityMariaCutscene);
 
 void func_801B8E0C(Entity* self) {
     switch (self->step) {
@@ -511,4 +511,4 @@ void func_801B8E0C(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/36DE4", func_801B8F94);
+INCLUDE_ASM("st/nz0/nonmatchings/36DE4", func_801B8F94);

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -1,7 +1,7 @@
 #include "nz0.h"
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/39908", TestCollisions);
+INCLUDE_ASM("st/nz0/nonmatchings/39908", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/39908", EntityNumericDamage);
+INCLUDE_ASM("st/nz0/nonmatchings/39908", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -321,7 +321,7 @@ s32 func_801BBC3C(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/39908", EntityRedDoor);
+INCLUDE_ASM("st/nz0/nonmatchings/39908", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -759,7 +759,7 @@ void func_801BD848(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/39908", func_801BD9A0);
+INCLUDE_ASM("st/nz0/nonmatchings/39908", func_801BD9A0);
 
 #include "../replace_breakable_with_item_drop.h"
 

--- a/src/st/nz0/4070C.c
+++ b/src/st/nz0/4070C.c
@@ -539,9 +539,9 @@ void func_801C1900(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/4070C", func_801C1AD8);
+INCLUDE_ASM("st/nz0/nonmatchings/4070C", func_801C1AD8);
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/4070C", func_801C20B8);
+INCLUDE_ASM("st/nz0/nonmatchings/4070C", func_801C20B8);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];

--- a/src/st/nz0/43F9C.c
+++ b/src/st/nz0/43F9C.c
@@ -49,7 +49,7 @@ void func_801C3F9C(Unkstruct_801C3F9C** self) {
 }
 
 // Called by EntityAxeKnight
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/43F9C", func_801C4198);
+INCLUDE_ASM("st/nz0/nonmatchings/43F9C", func_801C4198);
 
 void func_801C4550(void) {
     if (g_CurrentEntity->ext.generic.unk80.modeS16.unk2 > 0) {

--- a/src/st/nz0/47CF0.c
+++ b/src/st/nz0/47CF0.c
@@ -21,4 +21,4 @@ s32 func_801C7CF0(Entity* e) {
 }
 
 // sealed door that displays "Magically Sealed" prompt
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/47CF0", EntityMagicallySealedDoor);
+INCLUDE_ASM("st/nz0/nonmatchings/47CF0", EntityMagicallySealedDoor);

--- a/src/st/nz0/48ADC.c
+++ b/src/st/nz0/48ADC.c
@@ -56,4 +56,4 @@ void func_801C8ADC(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/48ADC", EntityStageNamePopup);
+INCLUDE_ASM("st/nz0/nonmatchings/48ADC", EntityStageNamePopup);

--- a/src/st/nz0/49930.c
+++ b/src/st/nz0/49930.c
@@ -75,4 +75,4 @@ void func_801CA07C(Primitive* poly) {
 
 // particle effect that spawns life up item
 // Probably it's own file
-INCLUDE_ASM("asm/us/st/nz0/nonmatchings/49930", EntityLifeUpSpawn);
+INCLUDE_ASM("st/nz0/nonmatchings/49930", EntityLifeUpSpawn);

--- a/src/st/rwrp/113A0.c
+++ b/src/st/rwrp/113A0.c
@@ -1,20 +1,20 @@
 #include "rwrp.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_801913A0);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_801913A0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80191490);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80191490);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_801915A0);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_801915A0);
 
 #include "../entity_unkId15_spawner.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_801917B8);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_801917B8);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", EntityUnkId15);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", EntityUnkId15);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_8019199C);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_8019199C);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80191BCC);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80191BCC);
 
 u8 func_80191CC8(s32 arg0) {
     Collider collider;
@@ -190,9 +190,9 @@ u8 func_80191CC8(s32 arg0) {
 
 #include "../entity_intense_explosion.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192348);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80192348);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192414);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80192414);
 
 void func_801924DC(void) {
     Entity* entity;
@@ -210,11 +210,11 @@ void func_801924DC(void) {
         }
     }
 }
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192594);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80192594);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_8019276C);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_8019276C);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80192D4C);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80192D4C);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -253,8 +253,8 @@ void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_80193644);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_80193644);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_8019373C);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_8019373C);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/113A0", func_8019390C);
+INCLUDE_ASM("st/rwrp/nonmatchings/113A0", func_8019390C);

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -110,7 +110,7 @@ void func_80194DD4(Entity* entity) {
     func_8018D6B0(objInit->unk10, entity);
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", BottomCornerText);
+INCLUDE_ASM("st/rwrp/nonmatchings/14590", BottomCornerText);
 
 #include "../unk_prim_helper.h"
 
@@ -118,7 +118,7 @@ INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", BottomCornerText);
 
 #include "../find_first_unk_prim.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/14590", func_801957D4);
+INCLUDE_ASM("st/rwrp/nonmatchings/14590", func_801957D4);
 
 void func_8019585C(Primitive* prim) {
     prim->p1 = 0;

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -7,9 +7,9 @@
 #include "game.h"
 #include "rwrp.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80188DF0);
+INCLUDE_ASM("st/rwrp/nonmatchings/8DF0", func_80188DF0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80188ED0);
+INCLUDE_ASM("st/rwrp/nonmatchings/8DF0", func_80188ED0);
 
 extern u8* D_801805B8[];
 extern Entity D_8007D858;
@@ -42,6 +42,6 @@ void EntityBreakable(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_801891C0);
+INCLUDE_ASM("st/rwrp/nonmatchings/8DF0", func_801891C0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/8DF0", func_80189E9C);
+INCLUDE_ASM("st/rwrp/nonmatchings/8DF0", func_80189E9C);

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -1,7 +1,7 @@
 #include "rwrp.h"
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", TestCollisions);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018B6B4);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018B6B4);
 
 #include "../create_entity_from_layout.h"
 
@@ -104,9 +104,9 @@ void func_8018C098(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C0F0);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C0F0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C1EC);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C1EC);
 
 void func_8018C300(s16 arg0) {
     while (true) {
@@ -127,13 +127,13 @@ void func_8018C34C(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C3A4);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C3A4);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C4A0);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C4A0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C5B4);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C5B4);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C72C);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C72C);
 
 void CreateEntityFromCurrentEntity(u16 entityId, Entity* entity) {
     DestroyEntity(entity);
@@ -151,13 +151,13 @@ void CreateEntityFromEntity(u16 entityId, Entity* source, Entity* entity) {
     entity->posY.i.hi = source->posY.i.hi;
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C8D0);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C8D0);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018C948);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C948);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", DestroyEntity);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", DestroyEntity);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018D5EC);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018D5EC);
 
 void PreventEntityFromRespawning(Entity* entity) {
     if (entity->entityRoomIndex) {
@@ -168,7 +168,7 @@ void PreventEntityFromRespawning(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018D6B0);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018D6B0);
 
 u8 func_8018D768(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;
@@ -231,7 +231,7 @@ void FallEntity(void) {
         g_CurrentEntity->velocityY += FALL_GRAVITY;
     }
 }
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018D990);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018D990);
 
 s32 func_8018DC08(s16* posX) {
     Collider collider;
@@ -330,7 +330,7 @@ s32 func_8018DF84(s32 arg0, s32 arg1) {
 
 #include "../adjust_value_within_threshold.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", UnkEntityFunc0);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", UnkEntityFunc0);
 
 u16 func_8018E0B0(s16 arg0, s16 arg1) { return ratan2(arg1, arg0); }
 
@@ -382,9 +382,9 @@ void SetSubStep(u8 step_s) {
     g_CurrentEntity->animFrameDuration = 0;
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018E1FC);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018E1FC);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", InitializeEntity);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", InitializeEntity);
 
 void EntityDummy(Entity* entity) {
     if (entity->step == 0) {
@@ -392,11 +392,11 @@ void EntityDummy(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018E3B4);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018E3B4);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018E4DC);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018E4DC);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018E634);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018E634);
 
 #include "../replace_breakable_with_item_drop.h"
 
@@ -422,9 +422,9 @@ void func_8018EA30(void) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018EAB4);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018EAB4);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018EC10);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018EC10);
 
 void CollectGold(u16 goldSize) {
     s32 *gold, *unk;
@@ -481,7 +481,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018EE84);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018EE84);
 
 void CollectLifeVessel(void) {
     g_api_PlaySfx(NA_SE_PL_COLLECT_HEART);
@@ -491,12 +491,12 @@ void CollectLifeVessel(void) {
 
 void DestroyCurrentEntity(void) { DestroyEntity(g_CurrentEntity); }
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", EntityPrizeDrop);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", EntityPrizeDrop);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", func_8018F814);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018F814);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", BlinkItem);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", BlinkItem);
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/A59C", EntityEquipItemDrop);
+INCLUDE_ASM("st/rwrp/nonmatchings/A59C", EntityEquipItemDrop);
 
 #include "../blit_char.h"

--- a/src/st/rwrp/entity_heart_drop.c
+++ b/src/st/rwrp/entity_heart_drop.c
@@ -1,3 +1,3 @@
 #include "rwrp.h"
 
-INCLUDE_ASM("asm/us/st/rwrp/nonmatchings/entity_heart_drop", EntityHeartDrop);
+INCLUDE_ASM("st/rwrp/nonmatchings/entity_heart_drop", EntityHeartDrop);

--- a/src/st/sel/33164.c
+++ b/src/st/sel/33164.c
@@ -201,7 +201,7 @@ s32 TryLoadSaveData(void) {
     return 0;
 }
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/33164", func_801B38B4);
+INCLUDE_ASM("st/sel/nonmatchings/33164", func_801B38B4);
 
 void func_801B3A54(s32 arg0, s32 arg1) {
     char pad[0x20];

--- a/src/st/sel/3642C.c
+++ b/src/st/sel/3642C.c
@@ -236,7 +236,7 @@ void func_801B690C(u8 ySteps, Entity* self) {
     g_Dialogue.portraitAnimTimer++;
 }
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/3642C", func_801B69F8);
+INCLUDE_ASM("st/sel/nonmatchings/3642C", func_801B69F8);
 
 s32 func_801B76F0(const char* msg) {
     const int PRIM = -5;
@@ -327,4 +327,4 @@ u16* func_801B78BC(char ch) {
     return g_api.func_80106A28(jCh, 0);
 }
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/3642C", func_801B79D4);
+INCLUDE_ASM("st/sel/nonmatchings/3642C", func_801B79D4);

--- a/src/st/sel/stream.c
+++ b/src/st/sel/stream.c
@@ -98,11 +98,11 @@ void func_801B994C(DECENV* dec) {
 }
 
 void func_801B99E4(void);
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/stream", func_801B99E4);
+INCLUDE_ASM("st/sel/nonmatchings/stream", func_801B99E4);
 
 // func_801B9B7C(Unkstruct_801B9B7C* arg0, s16 arg1, s16 arg2, s16 arg3, s32
 // arg4);
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/stream", func_801B9B7C);
+INCLUDE_ASM("st/sel/nonmatchings/stream", func_801B9B7C);
 
 void func_801B9C18(s32 unused, void (*callback)()) {
     const int START_FRAME = 1;
@@ -115,7 +115,7 @@ void func_801B9C18(s32 unused, void (*callback)()) {
     StSetStream(g_StreamIsRGB24, START_FRAME, -1, NULL, NULL);
 }
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/stream", func_801B9C80);
+INCLUDE_ASM("st/sel/nonmatchings/stream", func_801B9C80);
 
 void func_801BA460(s32 option) {
     if (option == 0) {
@@ -310,6 +310,6 @@ int MDEC_print_error(const char* funcName) {
     return 0;
 }
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/stream", func_801BAB70);
+INCLUDE_ASM("st/sel/nonmatchings/stream", func_801BAB70);
 
-INCLUDE_ASM("asm/us/st/sel/nonmatchings/stream", DecDCTvlc);
+INCLUDE_ASM("st/sel/nonmatchings/stream", DecDCTvlc);

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -33,7 +33,7 @@ bool func_801A7E2C(Entity* self) {
 }
 
 #ifndef NON_EQUIVALENT
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/27D64", EntityLockCamera);
+INCLUDE_ASM("st/st0/nonmatchings/27D64", EntityLockCamera);
 #else
 extern u16 D_801805B0[];
 extern u8 D_8018065C[];

--- a/src/st/st0/28BF8.c
+++ b/src/st/st0/28BF8.c
@@ -170,7 +170,7 @@ void func_801A910C(u8 ySteps) {
     g_Dialogue.portraitAnimTimer++;
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/28BF8", EntityDialogue);
+INCLUDE_ASM("st/st0/nonmatchings/28BF8", EntityDialogue);
 
 void func_801AA218(s16 arg0) {
     s16 temp_a1 = ((0xE0 - arg0) / 2) + 0x80;

--- a/src/st/st0/2B0C8.c
+++ b/src/st/st0/2B0C8.c
@@ -381,7 +381,7 @@ void EntityStageTitleCard(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2B0C8", func_801ABBBC);
+INCLUDE_ASM("st/st0/nonmatchings/2B0C8", func_801ABBBC);
 
 s32 func_801AC458(s16 arg0) {
     s32 ret = arg0;

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -703,10 +703,10 @@ bool func_801ADAC8(s32 arg0) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2C564", func_801ADB10);
+INCLUDE_ASM("st/st0/nonmatchings/2C564", func_801ADB10);
 
 // DECOMP_ME_WIP EntityDraculaFinalForm https://decomp.me/scratch/kUpoj
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2C564", EntityDraculaFinalForm);
+INCLUDE_ASM("st/st0/nonmatchings/2C564", EntityDraculaFinalForm);
 
 void EntityDraculaMegaFireball(Entity* self) {
     s16 angle;
@@ -811,8 +811,8 @@ void EntityDraculaRainAttack(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2C564", func_801AF380);
+INCLUDE_ASM("st/st0/nonmatchings/2C564", func_801AF380);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2C564", func_801AF6D0);
+INCLUDE_ASM("st/st0/nonmatchings/2C564", func_801AF6D0);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/2C564", func_801AF774);
+INCLUDE_ASM("st/st0/nonmatchings/2C564", func_801AF774);

--- a/src/st/st0/30030.c
+++ b/src/st/st0/30030.c
@@ -107,9 +107,9 @@ u16 func_801B0414(void) {
     return ret;
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/30030", func_801B0464);
+INCLUDE_ASM("st/st0/nonmatchings/30030", func_801B0464);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/30030", func_801B101C);
+INCLUDE_ASM("st/st0/nonmatchings/30030", func_801B101C);
 
 void func_801B1198(s16 arg0) {
     RECT rect;
@@ -145,4 +145,4 @@ u16* func_801B11E8(char ch) {
     return g_api.func_80106A28(jCh, 0);
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/30030", func_801B1298);
+INCLUDE_ASM("st/st0/nonmatchings/30030", func_801B1298);

--- a/src/st/st0/31CA0.c
+++ b/src/st/st0/31CA0.c
@@ -1,7 +1,7 @@
 #include "st0.h"
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", TestCollisions);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", TestCollisions);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", EntityNumericDamage);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -322,7 +322,7 @@ s32 func_801B3C58(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", EntityRedDoor);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -486,9 +486,9 @@ s32 func_801B4D5C(u16* sensors) {
     return 0;
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", func_801B4FD4);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", func_801B4FD4);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", func_801B51E4);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", func_801B51E4);
 
 Entity* AllocEntity(Entity* start, Entity* end) {
     Entity* current = start;
@@ -720,7 +720,7 @@ void func_801B5A98(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/31CA0", func_801B5BF0);
+INCLUDE_ASM("st/st0/nonmatchings/31CA0", func_801B5BF0);
 
 #include "../replace_breakable_with_item_drop.h"
 

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -263,9 +263,9 @@ void func_801B6C5C(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", EntityEquipItemDrop);
+INCLUDE_ASM("st/st0/nonmatchings/36358", EntityEquipItemDrop);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801B7308);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801B7308);
 
 u8 func_801B7B0C(s16* arg0, u8 facing) {
     u8 ret = 0;
@@ -316,7 +316,7 @@ void func_801B7BFC(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801B7D0C);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801B7D0C);
 
 #include "../entity_unkId15_spawner.h"
 
@@ -374,7 +374,7 @@ void EntityUnkId15(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801B8108);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801B8108);
 
 bool func_801B8338(Point16* unk) {
     Collider collider;
@@ -693,9 +693,9 @@ void func_801B8D00(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801B8ED8);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801B8ED8);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801B94B8);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801B94B8);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -1019,11 +1019,11 @@ void BottomCornerText(u8* str, u8 lower_left) {
     g_BottomCornerTextTimer = 0x130;
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", EntityClouds);
+INCLUDE_ASM("st/st0/nonmatchings/36358", EntityClouds);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", EntityClockTower3D);
+INCLUDE_ASM("st/st0/nonmatchings/36358", EntityClockTower3D);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", EntityCutscenePhotograph);
+INCLUDE_ASM("st/st0/nonmatchings/36358", EntityCutscenePhotograph);
 
 void EntityCutscenePhotographFire(Entity* entity) {
     switch (entity->step) {
@@ -1052,7 +1052,7 @@ void EntityCutscenePhotographFire(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BC5C0);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801BC5C0);
 
 #include "../unk_prim_helper.h"
 
@@ -1126,6 +1126,6 @@ void func_801BD80C(POLY_GT4* arg0) {
 
 #include "../unk_loop_func.h"
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", func_801BD8F0);
+INCLUDE_ASM("st/st0/nonmatchings/36358", func_801BD8F0);
 
-INCLUDE_ASM("asm/us/st/st0/nonmatchings/36358", EntityBackgroundVortex);
+INCLUDE_ASM("st/st0/nonmatchings/36358", EntityBackgroundVortex);

--- a/src/st/wrp/6FD0.c
+++ b/src/st/wrp/6FD0.c
@@ -1181,7 +1181,7 @@ void EntityBreakable(Entity* entity) {
 }
 
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/6FD0", EntityWarpRoom);
+INCLUDE_ASM("st/wrp/nonmatchings/6FD0", EntityWarpRoom);
 #else
 extern u8 D_8003BEBC[];
 extern s32 D_8003C8B8;
@@ -1456,7 +1456,7 @@ void EntityWarpRoom(Entity* self) {
 // TODO this is matching, but EntityWarpRoom needs to match first due to the
 // jump table.
 #ifndef NON_MATCHING
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/6FD0", EntityWarpSmallRocks);
+INCLUDE_ASM("st/wrp/nonmatchings/6FD0", EntityWarpSmallRocks);
 #else
 
 void EntityWarpSmallRocks(Entity* entity) {

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -17,10 +17,10 @@ extern u8 D_80193ABC;
 extern LayoutEntity* g_pStObjLayout[];
 
 // DECOMP_ME_WIP TestCollisions https://decomp.me/scratch/Nq66t
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/861C", TestCollisions);
+INCLUDE_ASM("st/wrp/nonmatchings/861C", TestCollisions);
 
 // DECOMP_ME_WIP EntityNumericDamage https://decomp.me/scratch/m0PKE
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/861C", EntityNumericDamage);
+INCLUDE_ASM("st/wrp/nonmatchings/861C", EntityNumericDamage);
 
 #include "../create_entity_from_layout.h"
 
@@ -344,7 +344,7 @@ s32 func_8018A950(Entity* e) {
     return diff;
 }
 
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/861C", EntityRedDoor);
+INCLUDE_ASM("st/wrp/nonmatchings/861C", EntityRedDoor);
 
 #include "../../destroy_entity.h"
 
@@ -770,7 +770,7 @@ void func_8018C55C(u16* hitSensors, s16 sensorCount) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/861C", func_8018C6B4);
+INCLUDE_ASM("st/wrp/nonmatchings/861C", func_8018C6B4);
 
 #include "../replace_breakable_with_item_drop.h"
 

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -590,10 +590,10 @@ void func_80190614(Entity* self) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/F420", func_801907EC);
+INCLUDE_ASM("st/wrp/nonmatchings/F420", func_801907EC);
 
 u16 D_8018107C[] = {0, 1, 3, 4, 1, 2, 4, 5, 3, 4, 6, 7, 4, 5, 7, 8, 0, 0};
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/F420", func_80190DCC);
+INCLUDE_ASM("st/wrp/nonmatchings/F420", func_80190DCC);
 
 void ClutLerp(RECT* rect, u16 palIdxA, u16 palIdxB, s32 steps, u16 offset) {
     u16 buf[COLORS_PER_PAL];
@@ -719,7 +719,7 @@ void func_801917BC(Primitive* prim) {
     }
 }
 
-INCLUDE_ASM("asm/us/st/wrp/nonmatchings/F420", EntityStageNamePopup);
+INCLUDE_ASM("st/wrp/nonmatchings/F420", EntityStageNamePopup);
 
 u16 D_801810A0[] = {
     /* 10A0 */ 0x0820,

--- a/src/weapon/weapon_private.h
+++ b/src/weapon/weapon_private.h
@@ -1,7 +1,6 @@
 #ifndef WEAPON_PRIVATE_H
 #define WEAPON_PRIVATE_H
 
-#define INCLUDE_ASM_NEW
 #include <weapon.h>
 
 #define WEAPON0 // forces WEAPON0 for the time being


### PR DESCRIPTION
The new `INCLUDE_ASM_NEW` was a test when I decided to slowly import DRA HD. It essentially removes the need of specifying `asm/us` or `asm/hd`. which is dictated by `VERSION` found in `include/common.h`.

This PR make the use of `INCLUDE_ASM_NEW` the default. To fall to the old behaviour, `INCLUDE_ASM_OLD` is required. This is only used by the overlay MAD, which sets `VERSION` as `beta`.