### PR TITLE
Use FACTORY() for all RIC factory calls

### DIFF
--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -147,15 +147,15 @@ void func_80156F40(s16 arg0) {
         prim->blendMode = 0x102 | BLEND_VISIBLE;
     }
     if (D_80097C98 == 6) {
-        CreateEntFactoryFromEntity(playerPtr, 0x1004D, 0);
+        CreateEntFactoryFromEntity(playerPtr, FACTORY(0x100, 77), 0);
         func_8015CC70(1);
     }
     if (D_80097C98 == 4) {
-        CreateEntFactoryFromEntity(playerPtr, 0x3004D, 0);
+        CreateEntFactoryFromEntity(playerPtr, FACTORY(0x300, 77), 0);
         func_8015CC70(3);
     }
     if (D_80097C98 == 5) {
-        CreateEntFactoryFromEntity(playerPtr, 0x5004D, 0);
+        CreateEntFactoryFromEntity(playerPtr, FACTORY(0x500, 77), 0);
         func_8015CC70(5);
     }
 }
@@ -452,7 +452,7 @@ void func_80158B04(s32 arg0) {
 
     PLAYER.posY.i.hi -= 16;
     PLAYER.posX.i.hi = var_s0 + PLAYER.posX.i.hi;
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x10004, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x100, 4), 0);
     PLAYER.posY.i.hi += 16;
     PLAYER.posX.i.hi = PLAYER.posX.i.hi - var_s0;
 
@@ -481,7 +481,7 @@ void func_80158BFC(void) {
             }
             PLAYER.posX.i.hi = var_s0 + PLAYER.posX.i.hi;
             PLAYER.posY.i.hi -= 16;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x80004, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x800, 4), 0);
             D_8015459C = 0x60;
             PLAYER.posY.i.hi += 16;
             PLAYER.posX.i.hi = PLAYER.posX.i.hi - var_s0;
@@ -530,7 +530,8 @@ void func_80158BFC(void) {
                     g_Player.unk46 = 2;
                     PLAYER.step_s++;
                     func_8015C920(D_80155730);
-                    CreateEntFactoryFromEntity(g_CurrentEntity, 0x11, 0);
+                    CreateEntFactoryFromEntity(
+                        g_CurrentEntity, FACTORY(0, 17), 0);
                     break;
                 }
                 g_Player.unk46 = 0;
@@ -589,7 +590,8 @@ void func_80158FA4(void) {
             if (g_Player.D_80072F00[11] == 0) {
                 if (!(g_Player.pl_vram_flag & 0xC)) {
                     func_8015C920(&D_8015539C);
-                    CreateEntFactoryFromEntity(g_CurrentEntity, 0x0, 0);
+                    CreateEntFactoryFromEntity(
+                        g_CurrentEntity, FACTORY(0, 0), 0);
                 }
             } else {
                 PLAYER.velocityX = 0;
@@ -674,7 +676,7 @@ void func_801590A0(void) {
                 g_Player.unk46 = 2;
                 PLAYER.step_s += 1;
                 func_8015C920(D_80155740);
-                CreateEntFactoryFromEntity(g_CurrentEntity, 0x11U, 0);
+                CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 17), 0);
             } else {
                 g_Player.unk46 = 0;
                 PLAYER.step_s = 0;
@@ -777,7 +779,7 @@ void func_80159670(void) {
             }
             PLAYER.posX.i.hi += xShift;
             PLAYER.posY.i.hi += 2;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x80004U, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x800, 4), 0);
             D_8015459C = 0x60;
             PLAYER.posY.i.hi -= 2;
             PLAYER.posX.i.hi -= xShift;
@@ -843,7 +845,7 @@ void func_80159670(void) {
                 g_Player.unk46 = 2;
                 PLAYER.step_s++;
                 func_8015C920(D_80155738);
-                CreateEntFactoryFromEntity(g_CurrentEntity, 0x11U, 0);
+                CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 17), 0);
                 return;
             }
             g_Player.unk46 = 0;
@@ -1303,21 +1305,21 @@ void func_8015AFE0(void) {
 
 void func_8015B098(void) {
     if ((PLAYER.animCurFrame == 0xB5) && (PLAYER.animFrameDuration == 1)) {
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x23, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 35), 0);
         g_api.PlaySfx(NA_SE_UNK_62F);
     }
 
     if (PLAYER.animFrameDuration < 0) {
         func_8015CD98(0);
         g_Player.unk46 = 0;
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x450021, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x4500, 33), 0);
         g_Player.D_80072F00[0] = 0x800;
     }
 
     if (!(g_Player.pl_vram_flag & 1)) {
         func_8015CF08();
         g_Player.unk46 = 0;
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x450021, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x4500, 33), 0);
         g_Player.D_80072F00[0] = 0x800;
     }
 }

--- a/src/ric/1F348.c
+++ b/src/ric/1F348.c
@@ -10,8 +10,8 @@ void func_8015B348(void) {
         if (PLAYER.velocityX == 0) {
             func_8015C920(&D_80155748);
             g_Player.D_80072F00[13] = 4;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x1D, 0);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x90021, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 29), 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x900, 33), 0);
             D_801545AC = 0;
             PLAYER.step_s++;
         }
@@ -27,7 +27,7 @@ void func_8015B348(void) {
             if ((D_801545AC) == 0) {
                 PLAYER.drawFlags = 0;
                 PLAYER.rotY = 0x100;
-                CreateEntFactoryFromEntity(g_CurrentEntity, 0x17, 0);
+                CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 23), 0);
                 D_801545A8 = 0x90;
                 PLAYER.step_s++;
             }
@@ -40,7 +40,7 @@ void func_8015B348(void) {
             func_8015C920(&D_801558B4);
             PLAYER.palette = 0x814E;
             g_CurrentEntity->velocityY = FIX(-1);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x16, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 22), 0);
             D_801545A8 = 0x30;
             g_api.PlaySfx(0x6E2);
             D_80174F78 = 0xA0;
@@ -53,10 +53,10 @@ void func_8015B348(void) {
         if ((D_801545A8) == 0) {
             PLAYER.velocityY = 0;
             D_801545A8 = 0xC0;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x24, 0);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x20025, 0);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x30026, 0);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x40027, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 36), 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x200, 37), 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x300, 38), 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x400, 39), 0);
             PLAYER.palette = 0x813D;
             g_Player.D_80072F00[13] = 0;
             PLAYER.step_s++;
@@ -67,7 +67,7 @@ void func_8015B348(void) {
         }
 
         D_80174F78--;
-        if ((D_80174F78 >= 0) && (D_80174F78 == (((D_80174F78) / 20) * 0x14))) {
+        if ((D_80174F78 >= 0) && (D_80174F78 % 20 == 0)) {
             g_api.PlaySfx(NA_SE_PL_RIC_UNK_6E2);
         }
         break;
@@ -84,7 +84,7 @@ void func_8015B348(void) {
         }
 
         D_80174F78--;
-        if ((D_80174F78 >= 0) && (D_80174F78 == (((D_80174F78) / 20) * 0x14))) {
+        if ((D_80174F78 >= 0) && (D_80174F78 % 20 == 0)) {
             g_api.PlaySfx(NA_SE_PL_RIC_UNK_6E2);
         }
         break;
@@ -93,13 +93,13 @@ void func_8015B348(void) {
         if (D_801545A8 == 5) {
             PLAYER.animFrameIdx = 6;
             PLAYER.palette = 0x8120;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x1C, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 28), 0);
         }
         D_801545A8--;
         if (D_801545A8 == 0) {
             func_8015C920(&D_801558D4);
             g_api.PlaySfx(NA_SE_UNK_62F);
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x1B, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 27), 0);
             PLAYER.step_s++;
             break;
         }
@@ -123,7 +123,7 @@ void func_8015B348(void) {
             func_8015CF08();
             func_8015C920(&D_801558DC);
             g_Player.D_80072F00[13] = 4;
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x90021, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x900, 33), 0);
         }
         break;
     }

--- a/src/ric/1FCD0.c
+++ b/src/ric/1FCD0.c
@@ -8,7 +8,8 @@ void func_8015BCD0(void) {
     switch (PLAYER.step_s) {
     case 0:
         if (PLAYER.animFrameIdx == 5 && PLAYER.animFrameDuration == 1 &&
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x4D, 0) == NULL) {
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 77), 0) ==
+                NULL) {
             PLAYER.animFrameDuration = 2;
         }
         if (PLAYER.animFrameDuration < 0) {
@@ -19,7 +20,8 @@ void func_8015BCD0(void) {
     case 2:
         func_8015BB80();
         if (PLAYER.animFrameIdx == 5 && PLAYER.animFrameDuration == 1 &&
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x2004D, 0) == NULL) {
+            CreateEntFactoryFromEntity(
+                g_CurrentEntity, FACTORY(0x200, 77), 0) == NULL) {
             PLAYER.animFrameDuration = 2;
         }
         if (PLAYER.animFrameDuration < 0) {
@@ -30,7 +32,8 @@ void func_8015BCD0(void) {
     case 4:
         func_8015BB80();
         if (PLAYER.animFrameIdx == 5 && PLAYER.animFrameDuration == 1 &&
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x4004D, 0) == NULL) {
+            CreateEntFactoryFromEntity(
+                g_CurrentEntity, FACTORY(0x400, 77), 0) == NULL) {
             PLAYER.animFrameDuration = 2;
         }
         if (PLAYER.animFrameDuration < 0) {
@@ -68,7 +71,7 @@ void func_8015BE84(void) {
 
     if (g_Player.pl_vram_flag & 1) {
         g_CurrentEntity->velocityX /= 2;
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x0, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 0), 0);
         PLAYER.facingLeft = (PLAYER.facingLeft + 1) & 1;
         func_8015CCC8(3, PLAYER.velocityX);
         g_api.PlaySfx(0x64B);
@@ -121,12 +124,12 @@ void func_8015C178(void) {
     } else {
         if (!(g_GameTimer & 3) && PLAYER.animFrameIdx < 0x12 &&
             g_Player.pl_vram_flag & 1) {
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x20018, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x200, 24), 0);
         }
 
         if (PLAYER.animFrameIdx == 18 && PLAYER.animFrameDuration == 1 &&
             (g_Player.pl_vram_flag & 1)) {
-            CreateEntFactoryFromEntity(g_CurrentEntity, 0x0, 0);
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 0), 0);
         }
     }
 }

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -73,7 +73,7 @@ void func_8015CAAC(s32 speed) {
 
 void func_8015CAD4(s32 arg0, s16 arg1) {
     if (arg0 == 0) {
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x15002C, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x1500, 44), 0);
         if (arg1 >= g_Player.D_80072F00[13]) {
             g_Player.D_80072F00[13] = arg1;
         }
@@ -181,7 +181,7 @@ void func_8015CE7C(void) {
         SetSpeedX(0x24000);
         g_Player.D_80072F00[11] = 0x28;
         PLAYER.velocityY = 0;
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x50001, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x500, 1), 0);
     }
 }
 

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -25,13 +25,14 @@ s32 func_8015D250(s32 unused_arg) {
         return 5;
     }
 
-    CreateEntFactoryFromEntity(g_CurrentEntity, subweapon.blueprintNum, 0);
+    CreateEntFactoryFromEntity(
+        g_CurrentEntity, FACTORY(0, subweapon.blueprintNum), 0);
     g_Player.D_80072F00[10] = 4;
 
     switch (PLAYER.step) {
     case 25:
         PLAYER.step = 0;
-        CreateEntFactoryFromEntity(g_CurrentEntity, 0x0, 0);
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 0), 0);
         func_8015C920(D_801555E8);
         break;
 
@@ -229,7 +230,7 @@ void func_8015D9D4(void) {
     g_CurrentEntity->velocityY = 0;
     SetSpeedX(0x58000);
     func_8015CC28();
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x19, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 25), 0);
     g_api.PlaySfx(0x707);
     g_Player.D_80072F00[12] = 4;
 }
@@ -241,10 +242,10 @@ void func_8015DA60(void) {
     g_CurrentEntity->velocityY = FIX(-2);
     SetSpeedX(0x58000);
     func_8015CC28();
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x19, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 25), 0);
     g_api.PlaySfx(0x6FA);
     g_Player.D_80072F00[12] = 4;
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x1F, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 31), 0);
 }
 
 void DoBladeDash(void) {
@@ -254,7 +255,7 @@ void DoBladeDash(void) {
     SetSpeedX(FIX(5.5));
     g_Player.unk46 = 5;
     g_Player.D_80072F00[12] = 4;
-    CreateEntFactoryFromEntity(g_CurrentEntity, 0x1A, 0);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 26), 0);
     func_8015CC28();
     g_api.PlaySfx(0x6FB);
     g_api.PlaySfx(0x707);

--- a/src/ric/24788.c
+++ b/src/ric/24788.c
@@ -668,7 +668,7 @@ void func_80161C2C(Entity* self) {
         if ((self->animFrameIdx == 8) && (self->unk4C != D_80154C80)) {
             self->blendMode = 0x10;
             if (!(params & 1) && (self->animFrameDuration == step)) {
-                CreateEntFactoryFromEntity(self, 0x40004, 0);
+                CreateEntFactoryFromEntity(self, FACTORY(0x400, 4), 0);
             }
         }
 
@@ -698,7 +698,7 @@ void func_80161EF8(Entity* self) {
     case 1:
         if ((self->animFrameIdx == 6) &&
             (self->animFrameDuration == self->step) && (rand() & 1)) {
-            CreateEntFactoryFromEntity(self, 4, 0);
+            CreateEntFactoryFromEntity(self, FACTORY(0, 4), 0);
         }
         self->posY.val += self->velocityY;
         if (self->animFrameDuration < 0) {

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -36,7 +36,7 @@ void func_80162C84(Entity* entity) {
             func_8015C920(&D_80154EF8);
             entity->velocityX = 0;
             entity->step++;
-            CreateEntFactoryFromEntity(entity, 0x40000, 0);
+            CreateEntFactoryFromEntity(entity, FACTORY(0x400, 0), 0);
         }
         break;
 
@@ -51,7 +51,7 @@ void func_80162C84(Entity* entity) {
     case 3:
         entity->ext.generic.unk7C.s--;
         if ((entity->ext.generic.unk7C.s) == 0) {
-            CreateEntFactoryFromEntity(entity, 0x1E, 0);
+            CreateEntFactoryFromEntity(entity, FACTORY(0, 30), 0);
             entity->step++;
         }
         break;

--- a/src/ric/32324.c
+++ b/src/ric/32324.c
@@ -12,7 +12,7 @@ void func_8016E324(Entity* entity) {
         if ((entity->ext.generic.unk7C.s) == 0) {
         case 3:
         case 5:
-            CreateEntFactoryFromEntity(entity, 0x39, 0);
+            CreateEntFactoryFromEntity(entity, FACTORY(0, 57), 0);
             entity->step++;
         case 2:
         case 4:
@@ -22,7 +22,7 @@ void func_8016E324(Entity* entity) {
                 entity->ext.generic.unk7C.s = 0;
                 entity->posX.val = FIX(128.0);
                 entity->posY.val = 0;
-                CreateEntFactoryFromEntity(entity, 0x10004, 0);
+                CreateEntFactoryFromEntity(entity, FACTORY(0x100, 4), 0);
                 entity->step++;
             }
         }
@@ -33,7 +33,7 @@ void func_8016E324(Entity* entity) {
         if (entity->ext.generic.unk7C.s >= 16) {
             DestroyEntity(entity);
             g_Player.unk4E = 1;
-            CreateEntFactoryFromEntity(entity, 0x3A, 0);
+            CreateEntFactoryFromEntity(entity, FACTORY(0, 58), 0);
         }
         break;
     }
@@ -348,7 +348,7 @@ void func_8016F198(Entity* self) {
     }
 }
 
-// Entity ID #64, created by blueprint #72.
+// Entity ID #64, created by blueprint #72. This call is in func_801719A4.
 // When Richter has the stopwatch weapon, and uses it as a crash, it makes
 // 4 floating stopwatches. When they are done they disappear in a spinning
 // sparkle. This entity represents that sparkle. 4 copies of this entity
@@ -722,7 +722,7 @@ void func_801705EC(Entity* entity) {
     case 7:
         temp = entity->ext.generic.unk7E.modeU16 + 1;
         entity->ext.generic.unk7E.modeU16 = temp;
-        CreateEntFactoryFromEntity(entity, (temp << 0x10) | 0x3F, 0);
+        CreateEntFactoryFromEntity(entity, FACTORY(temp * 0x100, 63), 0);
         entity->ext.generic.unk7C.s = 0;
         entity->step++;
         break;
@@ -1200,7 +1200,7 @@ void func_801719A4(Entity* self) {
         prim->priority = PLAYER.zPriority + 3;
         prim->blendMode = 0x10A;
         if (self->params & 0xFF00) {
-            CreateEntFactoryFromEntity(self, 0x42U, 0);
+            CreateEntFactoryFromEntity(self, FACTORY(0, 66), 0);
             D_801758D0 = self->ext.et_801719A4.unk94 = self->params >> 8;
             if (self->ext.et_801719A4.unk94 < 4) {
                 (&D_801758D0)[self->ext.et_801719A4.unk94] = (u32)self;
@@ -1210,7 +1210,7 @@ void func_801719A4(Entity* self) {
                     D_801758CC[self->ext.et_801719A4.unk94];
             }
         } else {
-            CreateEntFactoryFromEntity(self, 0x40U, 0);
+            CreateEntFactoryFromEntity(self, FACTORY(0, 64), 0);
             self->ext.et_801719A4.unk94 = 0;
         }
         self->ext.et_801719A4.unkB0 = 6;
@@ -1289,7 +1289,7 @@ void func_801719A4(Entity* self) {
         self->ext.et_801719A4.unk7C = 0;
         if (self->ext.et_801719A4.unk94 != 0) {
             self->step = 7;
-            CreateEntFactoryFromEntity(self, 0x48U, 0);
+            CreateEntFactoryFromEntity(self, FACTORY(0, 72), 0);
         } else {
             self->step++;
         }
@@ -1308,7 +1308,7 @@ void func_801719A4(Entity* self) {
         break;
     case 6:
         if (++self->ext.et_801719A4.unk7C >= 0xF) {
-            CreateEntFactoryFromEntity(self, 0x70004U, 0);
+            CreateEntFactoryFromEntity(self, FACTORY(0x700, 4), 0);
             self->step++;
         }
         break;
@@ -1743,7 +1743,7 @@ void EntitySubwpnBible(Entity* self) {
         prim->y0 = prim->y1 = top;
         prim->y2 = prim->y3 = bottom;
         prim->priority = self->zPriority;
-        CreateEntFactoryFromEntity(self, 0x3E, 0);
+        CreateEntFactoryFromEntity(self, FACTORY(0, 62), 0);
         if (g_GameTimer % 10 == 0) {
             g_api.PlaySfx(BIBLE_SUBWPN_SWOOSH);
         }


### PR DESCRIPTION
Went through all the current calls to `CreateEntFactoryFromEntity` in RIC and changed them to use the proper `FACTORY()` syntax. This is extremely helpful for finding where entities are created since they're much more searchable.