### PR TITLE
Refactor DRA func_800FD5BC

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1174,6 +1174,13 @@ typedef struct {
 } Dialogue;                                  // size = 0x44
 
 typedef struct {
+    u32 unk0;
+    u32 damageKind;
+    s32 damageTaken;
+    s32 unkC;
+} DamageParam;
+
+typedef struct {
     /* 8003C774 */ Overlay o;
     /* 8003C7B4 */ void (*FreePrimitives)(s32);
     /* 8003C7B8 */ s16 (*AllocPrimitives)(PrimitiveType type, s32 count);
@@ -1237,7 +1244,7 @@ typedef struct {
     /* 8003C888 */ bool (*func_800F27F4)(s32 arg0);
     /* 8003C88C */ s32 (*func_800FF110)(s32 arg0);
     /* 8003C890 */ s32 (*func_800FD664)(s32 arg0);
-    /* 8003C894 */ s32 (*func_800FD5BC)(Unkstruct_800FD5BC* arg0);
+    /* 8003C894 */ s32 (*func_800FD5BC)(DamageParam* arg0);
     /* 8003C898 */ void (*LearnSpell)(s32 spellId);
     /* 8003C89C */ void (*DebugInputWait)(const char* str);
     /* 8003C8A0 */ void* unused12C;
@@ -1300,7 +1307,7 @@ extern bool (*g_api_func_80133950)(void);
 extern bool (*g_api_func_800F27F4)(s32 arg0);
 extern s32 (*g_api_func_800FF110)(s32 arg0);
 extern s32 (*g_api_func_800FD664)(s32 arg0);
-extern s32 (*g_api_func_800FD5BC)(Unkstruct_800FD5BC* arg0);
+extern s32 (*g_api_func_800FD5BC)(DamageParam* arg0);
 extern void (*g_api_LearnSpell)(s32 spellId);
 extern void (*g_api_func_800E2438)(const char* str);
 /***************************/

--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -86,12 +86,6 @@ typedef struct {
 } SfxRingBufferItem;
 
 typedef struct {
-    /* 0x00 */ s32 unk0;
-    /* 0x04 */ s32 unk4;
-    /* 0x08 */ s32 unk8;
-} Unkstruct_800FD5BC;
-
-typedef struct {
     /* 0x00 */ u8 unk00[3];
     /* 0x03 */ char unk03[9];
 } Unkstruct_80128BBC_Sub;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -287,13 +287,6 @@ typedef struct {
 } Vram;
 
 typedef struct {
-    u32 unk0;
-    u32 damageKind;
-    s32 damageTaken;
-    s32 unkC;
-} DamageParam;
-
-typedef struct {
     /* 8013761C */ MenuContext menus[NUM_MENU]; // 761C, 763A, 7658, 7676
 } MenuData;
 

--- a/src/dra/dra_header.c
+++ b/src/dra/dra_header.c
@@ -61,7 +61,7 @@ bool func_80133950(void);
 bool func_800F27F4(s32 arg0);
 s32 func_800FF110(s32 arg0);
 s32 func_800FD664(s32 arg0);
-bool func_800FD5BC(Unkstruct_800FD5BC* arg0);
+bool func_800FD5BC(DamageParam* arg0);
 void LearnSpell(s32 spellId);
 void DebugInputWait(const char* msg);
 

--- a/src/dra/menu.c
+++ b/src/dra/menu.c
@@ -3871,29 +3871,22 @@ s32 TimeAttackController(TimeAttackEvents eventId, TimeAttackActions action) {
     }
 }
 
-bool func_800FD5BC(Unkstruct_800FD5BC* arg0) {
-    s32 temp;
-
-    if (arg0->unk4 != 5) {
-        if (((u32)arg0->unk4) >= 0x10U) {
-            temp = g_Status.hpMax;
-            if (g_Status.hpMax < 0) {
-                temp += 7;
-            }
-            arg0->unk8 = temp >> 3;
-        } else if (g_Status.hpMax >= (arg0->unk8 * 0x14)) {
-            arg0->unk4 = 3;
+bool func_800FD5BC(DamageParam* arg0) {
+    if (arg0->damageKind != 5) {
+        if (arg0->damageKind >= 16) {
+            arg0->damageTaken = g_Status.hpMax / 8;
+        } else if (g_Status.hpMax >= (arg0->damageTaken * 20)) {
+            arg0->damageKind = 3;
         } else {
-            arg0->unk4 = 2;
+            arg0->damageKind = 2;
         }
     }
-    if (g_Status.hp <= arg0->unk8) {
+    if (g_Status.hp <= arg0->damageTaken) {
         g_Status.hp = 0;
         return true;
-    } else {
-        g_Status.hp -= arg0->unk8;
-        return false;
     }
+    g_Status.hp -= arg0->damageTaken;
+    return false;
 }
 
 s32 func_800FD664(s32 arg0) {

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -912,7 +912,7 @@ void func_80159C04(void) {
 }
 
 void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
-    Unkstruct_800FD5BC sp10;
+    DamageParam sp10;
     s32 xShift;
     s32 i;
     bool step_s_zero = false;
@@ -1104,8 +1104,8 @@ void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
             PLAYER.velocityY = 0;
             PLAYER.step_s = 5;
             sp10.unk0 = 0;
-            sp10.unk4 = 1;
-            sp10.unk8 = g_Player.unk5A;
+            sp10.damageKind = 1;
+            sp10.damageTaken = g_Player.unk5A;
             if (g_api.func_800FD5BC(&sp10) != 0) {
                 SetPlayerStep(Player_Kill);
                 func_8015A9B0(0, 2, 10, 2);
@@ -1145,8 +1145,8 @@ void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
                     g_api.func_80102CD8(2);
                     PLAYER.step_s = 1;
                     sp10.unk0 = 0;
-                    sp10.unk4 = 1;
-                    sp10.unk8 = g_Player.unk5A;
+                    sp10.damageKind = 1;
+                    sp10.damageTaken = g_Player.unk5A;
                     if (g_api.func_800FD5BC(&sp10) != 0) {
                         SetPlayerStep(Player_Kill);
                         func_8015A9B0(0, 2, 10, 2);
@@ -1163,8 +1163,8 @@ void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
             CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x800, 75), 0);
         }
         sp10.unk0 = 0;
-        sp10.unk4 = 1;
-        sp10.unk8 = g_Player.unk5A;
+        sp10.damageKind = 1;
+        sp10.damageTaken = g_Player.unk5A;
         if (g_api.func_800FD5BC(&sp10) != 0) {
             SetPlayerStep(Player_Kill);
             func_8015A9B0(0, 2, 10, 2);
@@ -1239,7 +1239,7 @@ void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
 const s32 rodata_padding_1A784 = 0;
 
 void func_8015A7D0(void) {
-    Unkstruct_800FD5BC sp10;
+    DamageParam sp10;
     switch (g_CurrentEntity->step_s) {
     case 0:
         func_80159BC8();
@@ -1257,8 +1257,8 @@ void func_8015A7D0(void) {
         // Effectively a switch on g_Player.unk60
         if (g_Player.unk60 == 3) {
             sp10.unk0 = 0;
-            sp10.unk4 = 1;
-            sp10.unk8 = g_Player.unk5A;
+            sp10.damageKind = 1;
+            sp10.damageTaken = g_Player.unk5A;
             if (g_api.func_800FD5BC(&sp10)) {
                 SetPlayerStep(Player_Kill);
                 func_8015A9B0(0, 2, 12, 1);


### PR DESCRIPTION
Came across this function today and found several improvements for it.

- Unkstruct_800FD5BC is a duplicate of DamageParam. Therefore, I have changed all instances of Unkstruct_800FD5BC to DamageParam. The fields make sense in context and everything.
- Because func_800FD5BC is in GameApi, which is defined in `game.h`, its argument (now a DamageParam) needs to be accessible in `game.h`. Therefore, DamageParam moves from dra.h to game.h.
- We had a fake division being done with using a `temp` and checking a comparison to zero; this has been changed to be a normal division. This is a common pattern I see in initial m2c output and I'm sure it exists in other places in the repo, would be nice if we could find an automated way to search for this type of structure to simplify the code.
- Changed a 0x14 to 20 since it makes way more sense that way
- Changed an `if(){return} else{morestuff} to just if(){return} morestuff, eliminating the `else`

I think this function should not be in `menu.c` since it has no close connection to any kind of menu. It would also be nice if we could figure out what damageKind actually is, and maybe make an enum for it.

Overall, no new decompiling here, but lots of improvement to the readability of the code. This might actually be a good PR to keep in mind as an example for people who are interested in the project but aren't comfortable with assembly, since this is a lot of improvement and change, without touching assembly at all.