### PR TITLE
Decompile RIC and DRA EntityHitByIce

### DIFF
--- a/config/symbols.us.dra.txt
+++ b/config/symbols.us.dra.txt
@@ -87,7 +87,6 @@ EntityEntFactory = 0x8011AC3C;
 EntityPlayerBlinkWhite = 0x8011BDA4;
 EntityMpReplenished = 0x8011D9F8;
 EntityHitByLightning = 0x8011F24C;
-EntityHitByIce = 0x8011F934;
 EntityTransparentWhiteCircle = 0x801200AC;
 EntityPlayerPinkEffect = 0x80120AF8;
 EntityPlayerDissolves = 0x80120DD0;

--- a/config/symbols.us.ric.txt
+++ b/config/symbols.us.ric.txt
@@ -5,6 +5,7 @@ GetTeleportToOtherCastle = 0x80156CCC;
 CheckBladeDashInput = 0x80157894;
 CheckHighJumpInput = 0x80157A50;
 UpdateEntityRichter = 0x80157BFC;
+RichterHandleDamage = 0x80159CE4;
 SetPlayerStep = 0x8015C908;
 SetSpeedX = 0x8015CA84;
 CreateEntFactoryFromEntity = 0x801606BC;

--- a/include/entity.h
+++ b/include/entity.h
@@ -690,6 +690,13 @@ typedef struct {
     s16 unk8A;
 } ET_RichterPowerUpRing;
 
+typedef struct {
+    s16 unk7C;
+    s16 unk7E;
+    s16 unk80;
+    s16 unk82;
+} ET_HitByIce;
+
 typedef union {
     /* 0x7C */ struct Primitive* prim;
     /* 0x7C */ ET_EntFactory factory;
@@ -707,6 +714,7 @@ typedef union {
     /* 0x7C */ ET_MessageBox messageBox;
     /* 0x7C */ ET_Weapon weapon;
     /* 0x7C */ ET_Weapon29 weapon29;
+    /* 0x7C */ ET_HitByIce hitbyice;
     /* 0x7C */ ET_Bat bat;
     /* 0x7C */ ET_SoulStealOrb soulStealOrb;
     /* 0x7C */ ET_GaibonSlogra GS_Props;

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -490,7 +490,8 @@ void EntityHitByIce(Entity* self) {
         if (self->ext.hitbyice.unk80 != 0 && --self->ext.hitbyice.unk82 == 0) {
             sp18 = true;
         }
-        // Could rewrite as a series of && and || but that would probably reduce readability
+        // Could rewrite as a series of && and || but that would probably reduce
+        // readability
         if (self->ext.hitbyice.unk7E != 0) {
             if (g_Player.pl_vram_flag & 0xC) {
                 sp18 = true;

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -440,9 +440,9 @@ void EntityHitByIce(Entity* self) {
     self->posX.i.hi = PLAYER.posX.i.hi;
     self->posY.i.hi = PLAYER.posY.i.hi;
     sp18 = (g_Player.unk0C & 0x10000) == sp18;
-    switch (self->step) { /* irregular */
+    switch (self->step) {
     case 0:
-        self->primIndex = AllocPrimitives(5U, 0x18);
+        self->primIndex = AllocPrimitives(PRIM_GT3, 24);
         if (self->primIndex == -1) {
             DestroyEntity(self);
             return;

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -463,12 +463,12 @@ void EntityHitByIce(Entity* self) {
             prim = prim->next;
         }
         if (PLAYER.velocityY != 0) {
-            self->ext.factory.unk7E = 1;
+            self->ext.hitbyice.unk7E = 1;
         }
         if (PLAYER.step == 0x10) {
-            self->ext.factory.unk80 = 1;
-            self->ext.factory.unk82 = 0x14;
-            self->ext.factory.unk7E = 0;
+            self->ext.hitbyice.unk80 = 1;
+            self->ext.hitbyice.unk82 = 0x14;
+            self->ext.hitbyice.unk7E = 0;
         }
         if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft == 0) {
@@ -487,27 +487,28 @@ void EntityHitByIce(Entity* self) {
         self->step++;
         break;
     case 1:
-        if (self->ext.factory.unk80 != 0) {
-            if (--self->ext.factory.unk82 == 0) {
-                sp18 = true;
-            }
+        if (self->ext.hitbyice.unk80 != 0 && --self->ext.hitbyice.unk82 == 0) {
+            sp18 = true;
         }
-        if (self->ext.factory.unk7E != 0) {
+        // Could rewrite as a series of && and || but that would probably reduce readability
+        if (self->ext.hitbyice.unk7E != 0) {
             if (g_Player.pl_vram_flag & 0xC) {
                 sp18 = true;
             }
-            if (PLAYER.step == 10 && PLAYER.step_s == 5) {
+            // Checking PLAYER.step is pointless here, this function only runs
+            // for Player_Hit.
+            if (PLAYER.step == Player_Hit && PLAYER.step_s == 5) {
                 sp18 = true;
             }
         }
         if (sp18) {
-            self->ext.factory.unk7C = 0x40;
+            self->ext.hitbyice.unk7C = 0x40;
             PlaySfx(0x61A);
             self->step++;
         }
         break;
     case 2:
-        if (--self->ext.factory.unk7C == 0) {
+        if (--self->ext.hitbyice.unk7C == 0) {
             DestroyEntity(self);
             return;
         }

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -465,7 +465,7 @@ void EntityHitByIce(Entity* self) {
         if (PLAYER.velocityY != 0) {
             self->ext.hitbyice.unk7E = 1;
         }
-        if (PLAYER.step == 0x10) {
+        if (PLAYER.step == Player_Kill) {
             self->ext.hitbyice.unk80 = 1;
             self->ext.hitbyice.unk82 = 0x14;
             self->ext.hitbyice.unk7E = 0;
@@ -495,8 +495,6 @@ void EntityHitByIce(Entity* self) {
             if (g_Player.pl_vram_flag & 0xC) {
                 sp18 = true;
             }
-            // Checking PLAYER.step is pointless here, this function only runs
-            // for Player_Hit.
             if (PLAYER.step == Player_Hit && PLAYER.step_s == 5) {
                 sp18 = true;
             }

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -413,6 +413,7 @@ extern AnimationFrame D_800AD5FC[];
 extern AnimationFrame D_800ADBD4[];
 extern AnimationFrame D_800ADC10[];
 extern s32 D_800ADC44;
+extern s16_pair* D_800ADCC8[72];
 extern RECT D_800AE130;
 extern s32 D_800AE270[];
 extern AnimationFrame* D_800AE294;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -911,7 +911,8 @@ void func_80159C04(void) {
     }
 }
 
-void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
+
+void RichterHandleDamage(s32 arg0, u32 arg1, s16 arg2) {
     DamageParam damage;
     s32 xShift;
     s32 i;
@@ -1051,6 +1052,7 @@ void func_80159CE4(s32 arg0, u32 arg1, s16 arg2) {
                 g_Player.D_80072F00[2] = 0x10;
                 break;
             } else if (arg0 & 0x2000) {
+                // Creates EntityHitByIce
                 CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 47), 0);
                 g_Player.D_80072F00[2] = 0xC;
                 g_Player.unk40 = 0x8169;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -911,7 +911,6 @@ void func_80159C04(void) {
     }
 }
 
-
 void RichterHandleDamage(s32 arg0, u32 arg1, s16 arg2) {
     DamageParam damage;
     s32 xShift;

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -1364,7 +1364,7 @@ PfnEntityUpdate g_RicEntityTbl[] = {
     func_8016A974,
     func_8016B0C0,
     func_80160D2C,
-    func_80164DF8,
+    EntityHitByIce,
     func_801656B0,
     func_8016B97C,
     func_8016C1BC,

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -333,6 +333,8 @@ void EntityShrinkingPowerUpRing(Entity* self) {
 // Entity ID #40. Created by blueprint 47. That factory comes from
 // func_80159CE4, which runs when UpdateEntityRichter happens with
 // PLAYER.step set to 10, for PlayerHit.
+// Same spot in AlucardHandleDamage creates DRA blueprint 46.
+// That creates DRA child ID 33, which is EntityHitByIce.
 
 void func_80164DF8(Entity* self) {
     s32 i;
@@ -378,8 +380,11 @@ void func_80164DF8(Entity* self) {
             prim->priority = PLAYER.zPriority + 2;
             prim = prim->next;
         }
-        if ((PLAYER.velocityY != 0) &&
-            (self->ext.factory.unk7E = 1, (PLAYER.velocityY != 0))) {
+        // Weird repeated conditional
+        if (PLAYER.velocityY != 0){
+            self->ext.factory.unk7E = 1;
+        }
+        if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft == 0) {
                 self->rotZ = -0x100;
             } else {

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -330,7 +330,9 @@ void EntityShrinkingPowerUpRing(Entity* self) {
     }
 }
 
-// Entity ID #40. Created by blueprint 47. 
+// Entity ID #40. Created by blueprint 47. That factory comes from
+// func_80159CE4, which runs when UpdateEntityRichter happens with
+// PLAYER.step set to 10, for PlayerHit.
 
 void func_80164DF8(Entity* self) {
     s32 i;

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -336,7 +336,7 @@ void EntityShrinkingPowerUpRing(Entity* self) {
 // Same spot in AlucardHandleDamage creates DRA blueprint 46.
 // That creates DRA child ID 33, which is EntityHitByIce.
 
-void func_80164DF8(Entity* self) {
+void EntityHitByIce(Entity* self) {
     s32 i;
     Primitive* prim;
     s16 angle;
@@ -382,7 +382,7 @@ void func_80164DF8(Entity* self) {
         }
         // Weird repeated conditional
         if (PLAYER.velocityY != 0) {
-            self->ext.factory.unk7E = 1;
+            self->ext.hitbyice.unk7E = 1;
         }
         if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft == 0) {
@@ -403,12 +403,12 @@ void func_80164DF8(Entity* self) {
             } else {
                 self->rotZ = 0x180;
             }
-            self->ext.factory.unk80 = 1;
-            self->ext.factory.unk82 = 0x3C;
+            self->ext.hitbyice.unk80 = 1;
+            self->ext.hitbyice.unk82 = 0x3C;
             if (self->params & 0x7F00) {
-                self->ext.factory.unk82 = 0x14;
+                self->ext.hitbyice.unk82 = 0x14;
             }
-            self->ext.factory.unk7E = 0;
+            self->ext.hitbyice.unk7E = 0;
         }
         self->step++;
         break;
@@ -436,22 +436,22 @@ void func_80164DF8(Entity* self) {
                 }
             }
         }
-        if (self->ext.factory.unk80 != 0 && --self->ext.factory.unk82 == 0) {
+        if (self->ext.hitbyice.unk80 != 0 && --self->ext.hitbyice.unk82 == 0) {
             sp18 = true;
         }
-        if ((self->ext.factory.unk7E != 0) && (g_Player.pl_vram_flag & 0xC)) {
+        if ((self->ext.hitbyice.unk7E != 0) && (g_Player.pl_vram_flag & 0xC)) {
             sp18 = true;
         }
         if (sp18) {
-            self->ext.factory.unk7C = 0x40;
-            if (self->ext.factory.unk80 != 0) {
-                self->ext.factory.unk7C = 0x80;
+            self->ext.hitbyice.unk7C = 0x40;
+            if (self->ext.hitbyice.unk80 != 0) {
+                self->ext.hitbyice.unk7C = 0x80;
             }
             self->step++;
         }
         break;
     case 2:
-        if (--self->ext.factory.unk7C == 0) {
+        if (--self->ext.hitbyice.unk7C == 0) {
             DestroyEntity(self);
             return;
         }
@@ -496,7 +496,7 @@ void func_80164DF8(Entity* self) {
         if ((prim->u0 == 0) && (sp18 != 0)) {
             prim->u0++;
             prim->v0 = (rand() & 15) + 1;
-            if (self->ext.factory.unk80 != 0) {
+            if (self->ext.hitbyice.unk80 != 0) {
                 prim->v0 = (rand() % 60) + 1;
             }
         }
@@ -505,7 +505,7 @@ void func_80164DF8(Entity* self) {
                 prim->v0 = 0x20;
                 prim->u2 = 0xF0;
                 prim->u0++;
-                if (self->ext.factory.unk80 != 0) {
+                if (self->ext.hitbyice.unk80 != 0) {
                     prim->v0 = (rand() & 31) + 0x28;
                 }
             }
@@ -515,7 +515,7 @@ void func_80164DF8(Entity* self) {
                 prim->u2 += 4;
             }
             primYshift = (s8)prim->u2 >> 4;
-            if (self->ext.factory.unk80 != 0) {
+            if (self->ext.hitbyice.unk80 != 0) {
                 primYshift /= 2;
             }
             prim->y0 = primYshift + prim->y0;

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -381,7 +381,7 @@ void func_80164DF8(Entity* self) {
             prim = prim->next;
         }
         // Weird repeated conditional
-        if (PLAYER.velocityY != 0){
+        if (PLAYER.velocityY != 0) {
             self->ext.factory.unk7E = 1;
         }
         if (PLAYER.velocityY != 0) {
@@ -465,7 +465,8 @@ void func_80164DF8(Entity* self) {
         offset = D_80155244[i * 3];
         if (prim->u0 < 2) {
             size = SquareRoot12(
-                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2))
+                << 0xC);
             angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
             xShift1 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
             yShift1 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;
@@ -474,7 +475,8 @@ void func_80164DF8(Entity* self) {
 
             offset = D_80155244[i * 3 + 1];
             size = SquareRoot12(
-                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2))
+                << 0xC);
             angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
             xShift2 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
             yShift2 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;
@@ -483,7 +485,8 @@ void func_80164DF8(Entity* self) {
 
             offset = D_80155244[i * 3 + 2];
             size = SquareRoot12(
-                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2))
+                << 0xC);
             angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
             xShift3 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
             yShift3 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -331,10 +331,7 @@ void EntityShrinkingPowerUpRing(Entity* self) {
 }
 
 // Entity ID #40. Created by blueprint 47. That factory comes from
-// func_80159CE4, which runs when UpdateEntityRichter happens with
-// PLAYER.step set to 10, for PlayerHit.
-// Same spot in AlucardHandleDamage creates DRA blueprint 46.
-// That creates DRA child ID 33, which is EntityHitByIce.
+// RichterHandleDamage.
 
 void EntityHitByIce(Entity* self) {
     s32 i;

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -330,7 +330,209 @@ void EntityShrinkingPowerUpRing(Entity* self) {
     }
 }
 
-INCLUDE_ASM("ric/nonmatchings/26C84", func_80164DF8);
+// Entity ID #40. Created by blueprint 47. 
+
+void func_80164DF8(Entity* self) {
+    s32 i;
+    Primitive* prim;
+    s16 angle;
+    s32 xShift1;
+    s32 xShift2;
+    s32 xShift3;
+    s32 yShift1;
+    s32 yShift2;
+    s32 yShift3;
+    s32 size;
+    u32 primYshift;
+    u16 selfX;
+    u16 selfY;
+    s16_pair* offset;
+    bool sp18 = false;
+
+    self->posX.i.hi = PLAYER.posX.i.hi;
+    self->posY.i.hi = PLAYER.posY.i.hi;
+    // This is badly written but it checks if 0x10000 is unset.
+    sp18 = ((g_Player.unk0C & 0x10000) == sp18);
+    switch (self->step) {
+    case 0:
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT3, 24);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
+        }
+
+        self->flags = FLAG_HAS_PRIMS | FLAG_UNK_40000 | FLAG_UNK_20000;
+        prim = &g_PrimBuf[self->primIndex];
+        while (prim != NULL) {
+            prim->r0 = prim->r1 = prim->r2 = prim->r3 = (rand() & 0xF) + 0x30;
+            prim->b0 = prim->b1 = prim->b2 = prim->b3 = rand() | 0x80;
+            prim->g0 = prim->g1 = prim->g2 = prim->g3 = (rand() & 0x1F) + 0x30;
+            if (rand() & 1) {
+                prim->blendMode = 0x335;
+            } else {
+                prim->blendMode = 0x315;
+            }
+            prim->type = 3;
+            prim->priority = PLAYER.zPriority + 2;
+            prim = prim->next;
+        }
+        if ((PLAYER.velocityY != 0) &&
+            (self->ext.factory.unk7E = 1, (PLAYER.velocityY != 0))) {
+            if (PLAYER.facingLeft == 0) {
+                self->rotZ = -0x100;
+            } else {
+                self->rotZ = 0x100;
+            }
+        } else {
+            if (PLAYER.velocityX <= 0) {
+                self->rotZ = 0xF80;
+            } else {
+                self->rotZ = 0x80;
+            }
+        }
+        if (PLAYER.step == 0x10) {
+            if (PLAYER.facingLeft == 0) {
+                self->rotZ = -0x180;
+            } else {
+                self->rotZ = 0x180;
+            }
+            self->ext.factory.unk80 = 1;
+            self->ext.factory.unk82 = 0x3C;
+            if (self->params & 0x7F00) {
+                self->ext.factory.unk82 = 0x14;
+            }
+            self->ext.factory.unk7E = 0;
+        }
+        self->step++;
+        break;
+    case 1:
+        if (PLAYER.step == 0x10) {
+            if ((PLAYER.animCurFrame & 0x7FFF) == 0x21) {
+                if (PLAYER.facingLeft == 0) {
+                    self->rotZ = -0x280;
+                } else {
+                    self->rotZ = 0x280;
+                }
+            }
+            if ((PLAYER.animCurFrame & 0x7FFF) == 0x22) {
+                if (PLAYER.facingLeft == 0) {
+                    self->rotZ = -0x380;
+                } else {
+                    self->rotZ = 0x380;
+                }
+            }
+            if ((PLAYER.animCurFrame & 0x7FFF) == 0x20) {
+                if (PLAYER.facingLeft == 0) {
+                    self->rotZ = -0x180;
+                } else {
+                    self->rotZ = 0x180;
+                }
+            }
+        }
+        if (self->ext.factory.unk80 != 0 && --self->ext.factory.unk82 == 0) {
+            sp18 = true;
+        }
+        if ((self->ext.factory.unk7E != 0) && (g_Player.pl_vram_flag & 0xC)) {
+            sp18 = true;
+        }
+        if (sp18) {
+            self->ext.factory.unk7C = 0x40;
+            if (self->ext.factory.unk80 != 0) {
+                self->ext.factory.unk7C = 0x80;
+            }
+            self->step++;
+        }
+        break;
+    case 2:
+        if (--self->ext.factory.unk7C == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+
+    selfX = self->posX.i.hi;
+    selfY = self->posY.i.hi;
+    prim = &g_PrimBuf[self->primIndex];
+    for (i = 0; i < 24; i++) {
+        offset = D_80155244[i * 3];
+        if (prim->u0 < 2) {
+            size = SquareRoot12(
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+            angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
+            xShift1 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
+            yShift1 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;
+            prim->x0 = selfX + xShift1;
+            prim->y0 = selfY + yShift1;
+
+            offset = D_80155244[i * 3 + 1];
+            size = SquareRoot12(
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+            angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
+            xShift2 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
+            yShift2 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;
+            prim->x1 = selfX + xShift2;
+            prim->y1 = selfY + yShift2;
+
+            offset = D_80155244[i * 3 + 2];
+            size = SquareRoot12(
+                ((offset->unk0 * offset->unk0) + (offset->unk2 * offset->unk2)) << 0xC);
+            angle = self->rotZ + ratan2(offset->unk2, offset->unk0);
+            xShift3 = (((rcos(angle) >> 4) * size) + 0x80000) >> 0x14;
+            yShift3 = (((rsin(angle) >> 4) * size) + 0x80000) >> 0x14;
+            prim->x2 = prim->x3 = selfX + xShift3;
+            prim->y2 = prim->y3 = selfY + yShift3;
+        }
+        if ((prim->u0 == 0) && (sp18 != 0)) {
+            prim->u0++;
+            prim->v0 = (rand() & 15) + 1;
+            if (self->ext.factory.unk80 != 0) {
+                prim->v0 = (rand() % 60) + 1;
+            }
+        }
+        if (prim->u0 == 1) {
+            if (--prim->v0 == 0) {
+                prim->v0 = 0x20;
+                prim->u2 = 0xF0;
+                prim->u0++;
+                if (self->ext.factory.unk80 != 0) {
+                    prim->v0 = (rand() & 31) + 0x28;
+                }
+            }
+        }
+        if (prim->u0 == 2) {
+            if ((prim->u2 < 0x70) || (prim->u2 > 0xD0)) {
+                prim->u2 += 4;
+            }
+            primYshift = (s8)prim->u2 >> 4;
+            if (self->ext.factory.unk80 != 0) {
+                primYshift /= 2;
+            }
+            prim->y0 = primYshift + prim->y0;
+            prim->y1 = primYshift + prim->y1;
+            prim->y2 = primYshift + prim->y2;
+            prim->y3 = primYshift + prim->y3;
+            if (prim->r3 < 4) {
+                prim->r3 -= 4;
+            }
+            if (prim->g3 < 4) {
+                prim->g3 -= 4;
+            }
+            if (prim->b3 < 4) {
+                prim->b3 -= 4;
+            }
+            prim->r0 = prim->r1 = prim->r2 = prim->r3;
+            prim->b0 = prim->b1 = prim->b2 = prim->b3;
+            prim->g0 = prim->g1 = prim->g2 = prim->g3;
+            prim->blendMode |= 2;
+            prim->blendMode &= ~0x300;
+            if (--prim->v0 == 0) {
+                prim->blendMode |= 8;
+            }
+        }
+        prim = prim->next;
+    }
+}
 
 INCLUDE_ASM("ric/nonmatchings/26C84", func_801656B0);
 

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -116,7 +116,7 @@ void func_8016A26C(Entity* self);
 void func_8016A974(Entity* self);
 void func_8016B0C0(Entity* self);
 void func_80160D2C(Entity* self);
-void func_80164DF8(Entity* self);
+void EntityHitByIce(Entity* self);
 void func_801656B0(Entity* self);
 void func_8016B97C(Entity* self);
 void func_8016C1BC(Entity* self);

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -171,6 +171,7 @@ extern AnimationFrame* D_80154924;
 extern PfnEntityUpdate D_8015495C[];
 extern s32 D_80154ED4;
 extern s32 D_80154EF8;
+extern s16_pair* D_80155244[72];
 extern s32 D_80155368[];
 extern FactoryBlueprint g_RicFactoryBlueprints[];
 extern u8 D_80154C40[];


### PR DESCRIPTION
Originally decompiled this for RIC, then in the process of figuring out what this entity was, I realized it was a duplicate of one in DRA which was already named EntityHitByIce. Therefore, I have gone ahead and decompiled it for DRA as well.

I think there are a whole lot more functions that are duplicated between RIC and DRA, but there are enough subtle differences that the duplicate-finder script misses them.

Because of the close relation between this and AlucardHandleDamage and a previously-unnamed RIC function, I have named that function RichterHandleDamage to match.
