### PR TITLE
Decompile RIC EntityHydroStorm

### DIFF
--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -33,6 +33,8 @@ segments:
       - [0x20, spritesheet, richter, disks/us/BIN/F_GAME2.BIN, 0x40400]
       - [0x170AC, .data, spriteparts]
       - [0x18568, data]
+      - [0x18688, assets, subweapondefs, D_80154688]
+      - [0x188F4, data]
       - [0x1895C, .data, 21250]
       - [0x18A6C, assets, factory_blueprint, g_RicFactoryBlueprints]
       - [0x18C40, data]

--- a/include/game.h
+++ b/include/game.h
@@ -74,49 +74,7 @@ typedef struct Prim {
     struct Vertex v[4];
 } Prim;
 
-#define blendMode drawMode // maintained to easily migrate existing scratches
-typedef struct Primitive {
-    /* 0x00 */ struct Primitive* next;
-#ifdef VERSION_PC
-    u_long dummy;
-#endif
-    /* 0x04 */ u8 r0;
-    /* 0x05 */ u8 g0;
-    /* 0x06 */ u8 b0;
-    /* 0x07 */ u8 type; // PrimitiveType
-    /* 0x08 */ s16 x0;
-    /* 0x0A */ s16 y0;
-    /* 0x0C */ u8 u0;    // w for PrimitiveType::TILE
-    /* 0x0D */ u8 v0;    // h for PrimitiveType::TILE
-    /* 0x0E */ u16 clut; // TODO not verified
-    /* 0x10 */ u8 r1;
-    /* 0x11 */ u8 g1;
-    /* 0x12 */ u8 b1;
-    /* 0x13 */ u8 p1; // TODO not verified
-    /* 0x14 */ s16 x1;
-    /* 0x16 */ s16 y1;
-    /* 0x18 */ u8 u1;     // TODO not verified
-    /* 0x19 */ u8 v1;     // TODO not verified
-    /* 0x1A */ u16 tpage; // TODO not verified
-    /* 0x1C */ u8 r2;
-    /* 0x1D */ u8 g2;
-    /* 0x1E */ u8 b2;
-    /* 0x1F */ u8 p2; // TODO not verified
-    /* 0x20 */ s16 x2;
-    /* 0x22 */ s16 y2;
-    /* 0x24 */ u8 u2; // TODO not verified
-    /* 0x25 */ u8 v2; // TODO not verified
-    /* 0x26 */ u16 priority;
-    /* 0x28 */ u8 r3;
-    /* 0x29 */ u8 g3;
-    /* 0x2A */ u8 b3;
-    /* 0x2B */ u8 p3; // TODO not verified
-    /* 0x2C */ s16 x3;
-    /* 0x2E */ s16 y3;
-    /* 0x30 */ u8 u3; // TODO not verified
-    /* 0x31 */ u8 v3; // TODO not verified
-    /* 0x32 */ u16 drawMode;
-} Primitive; /* size=0x34 */
+#include "primitive.h"
 
 #define DRAW_DEFAULT 0x00
 #define DRAW_TRANSP 0x01   // make it semi transparent

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -1,0 +1,107 @@
+/**
+ * Standard Primitive and its variants
+ */
+
+#include "common.h"
+
+#define blendMode drawMode // maintained to easily migrate existing scratches
+typedef struct Primitive {
+    /* 0x00 */ struct Primitive* next;
+#ifdef VERSION_PC
+    u_long dummy;
+#endif
+    /* 0x04 */ u8 r0;
+    /* 0x05 */ u8 g0;
+    /* 0x06 */ u8 b0;
+    /* 0x07 */ u8 type; // PrimitiveType
+    /* 0x08 */ s16 x0;
+    /* 0x0A */ s16 y0;
+    /* 0x0C */ u8 u0;    // w for PrimitiveType::TILE
+    /* 0x0D */ u8 v0;    // h for PrimitiveType::TILE
+    /* 0x0E */ u16 clut; // TODO not verified
+    /* 0x10 */ u8 r1;
+    /* 0x11 */ u8 g1;
+    /* 0x12 */ u8 b1;
+    /* 0x13 */ u8 p1; // TODO not verified
+    /* 0x14 */ s16 x1;
+    /* 0x16 */ s16 y1;
+    /* 0x18 */ u8 u1;     // TODO not verified
+    /* 0x19 */ u8 v1;     // TODO not verified
+    /* 0x1A */ u16 tpage; // TODO not verified
+    /* 0x1C */ u8 r2;
+    /* 0x1D */ u8 g2;
+    /* 0x1E */ u8 b2;
+    /* 0x1F */ u8 p2; // TODO not verified
+    /* 0x20 */ s16 x2;
+    /* 0x22 */ s16 y2;
+    /* 0x24 */ u8 u2; // TODO not verified
+    /* 0x25 */ u8 v2; // TODO not verified
+    /* 0x26 */ u16 priority;
+    /* 0x28 */ u8 r3;
+    /* 0x29 */ u8 g3;
+    /* 0x2A */ u8 b3;
+    /* 0x2B */ u8 p3; // TODO not verified
+    /* 0x2C */ s16 x3;
+    /* 0x2E */ s16 y3;
+    /* 0x30 */ u8 u3; // TODO not verified
+    /* 0x31 */ u8 v3; // TODO not verified
+    /* 0x32 */ u16 drawMode;
+} Primitive; /* size=0x34 */
+
+// FakePrim is really the wrong name for this.
+// But it's an alternate use of the Primitive structure.
+typedef struct FakePrim {
+    struct FakePrim* next;
+    /* 0x04 */ u8 r0;
+    /* 0x05 */ u8 g0;
+    /* 0x06 */ u8 b0;
+    /* 0x07 */ u8 type; // PrimitiveType
+    /* 0x08 */ s16 x0;
+    /* 0x0A */ s16 y0;
+    /* 0x0C */ u8 w;
+    /* 0x0D */ u8 h;
+    /* 0x0E */ u16 clut;
+    /* 0x10 */ f32 posX;
+    /* 0x14 */ f32 posY;
+    /* 0x18 */ f32 velocityX;
+    /* 0x1C */ f32 velocityY;
+    /* 0x20 */ s16 x2;
+    /* 0x22 */ s16 y2;
+    /* 0x24 */ s16 delay;
+    /* 0x26 */ u16 priority;
+    /* 0x28 */ f32 accelerationX;
+    /* 0x2C */ f32 accelerationY;
+    /* 0x30 */ s16 timer;
+    /* 0x32 */ u16 drawMode;
+} FakePrim;
+
+// Not actually sure if this is for LineG2, but the only time LineG2
+// is used is also the only time this struct is used, so we will call
+// it this for now. That one use is in EntityHydroStorm.
+typedef struct {
+    struct PrimLineG2* next;
+    /* 0x04 */ u8 r0;
+    /* 0x05 */ u8 g0;
+    /* 0x06 */ u8 b0;
+    /* 0x07 */ u8 type;
+    /* 0x08 */ s16 x0;
+    /* 0x0A */ s16 y0;
+    /* 0x0C */ s16 xLength;
+    /* 0x0E */ s16 yLength;
+    /* 0x10 */ u8 r1;
+    /* 0x11 */ u8 g1;
+    /* 0x12 */ u8 b1;
+    /* 0x13 */ u8 p1;
+    /* 0x14 */ s16 x1;
+    /* 0x16 */ s16 y1;
+    /* 0x18 */ f32 velocityX;
+    /* 0x1C */ f32 velocityY;
+    /* 0x20 */ s16 x2;
+    /* 0x22 */ s16 y2;
+    /* 0x24 */ s16 delay;
+    /* 0x26 */ u16 priority;
+    /* 0x28 */ f32 preciseX;
+    /* 0x2C */ f32 preciseY;
+    /* 0x30 */ s16 timer;
+    /* 0x32 */ u16 drawMode;
+} PrimLineG2;

--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -212,31 +212,6 @@ typedef struct {
     s16 unk1C;
 } unkStr_8011E4BC;
 
-typedef struct FakePrim {
-    struct FakePrim* next;
-    /* 0x04 */ u8 r0;
-    /* 0x05 */ u8 g0;
-    /* 0x06 */ u8 b0;
-    /* 0x07 */ u8 type; // PrimitiveType
-    /* 0x08 */ s16 x0;
-    /* 0x0A */ s16 y0;
-    /* 0x0C */ u8 w;
-    /* 0x0D */ u8 h;
-    /* 0x0E */ u16 clut;
-    /* 0x10 */ f32 posX;
-    /* 0x14 */ f32 posY;
-    /* 0x18 */ f32 velocityX;
-    /* 0x1C */ f32 velocityY;
-    /* 0x20 */ s16 x2;
-    /* 0x22 */ s16 y2;
-    /* 0x24 */ s16 delay;
-    /* 0x26 */ u16 priority;
-    /* 0x28 */ f32 accelerationX;
-    /* 0x2C */ f32 accelerationY;
-    s16 timer;
-    /* 0x32 */ u16 drawMode;
-} FakePrim;
-
 typedef struct {
     u8 childId;
     u8 unk1;

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -1336,7 +1336,7 @@ PfnEntityUpdate g_RicEntityTbl[] = {
     func_80168A20,
     func_80161C2C,
     func_80166784,
-    func_80167EC4,
+    EntityHydroStorm,
     EntityGiantSpinningCross,
     func_8016902C,
     func_80167A58,

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -88,7 +88,7 @@ void func_801684D8(Entity* self);
 void func_80168A20(Entity* self);
 void func_80161C2C(Entity* self);
 void func_80166784(Entity* self);
-void func_80167EC4(Entity* self);
+void EntityHydroStorm(Entity* self);
 void EntityGiantSpinningCross(Entity* self);
 void func_8016902C(Entity* self);
 void func_80167A58(Entity* self);


### PR DESCRIPTION
Several things with this one.

1) In order to determine what this actually was, I needed to extract Richter's subweapon definitions. I decided, at least for now, to add that extraction for RIC, using the `assets.py` script.

2) In order to match this function, we need a new Primitive, which is similar to the existing one (and FakePrim) but has a few totally incompatible fields. Most importantly, we have s16's at offsets 0x0C and 0x0E, which don't match either of those. Therefore, I introduce a new primitive that I am, at least for now, calling PrimLineG2, since this is the first time we're using LineG2, and is also the first use of this struct, so those may be connected. If a different primitive is found using these fields, we can rename this.

3) Recognizing that we now have 3 different varieties of Primitive, I have taken the definitions for all of them and moved them to a dedicated `primitive.h`, which I think is a good home for them. We should rename the variations eventually, but having them in one place makes sense, I think.

Otherwise, this one is fairly straightforward. It's interesting that we have the hardcoded values for the color of the hydro storm rain in there - using this knowledge I have made a fun PR for the randomizer which randomizes the colors of the rain. That PR is here: https://github.com/3snowp7im/SotN-Randomizer/pull/121

I think that's about it!