### PR TITLE
Decompile RIC EntitySubwpnReboundStone

### DIFF
--- a/src/dra/86ECC.c
+++ b/src/dra/86ECC.c
@@ -484,7 +484,7 @@ void EntitySubwpnReboundStone(Entity* self) {
     Collider collider;
     u16 playerX;
     u16 playerY;
-    Primitive* prim;
+    PrimLineG2* prim;
     s32 colliderFlags;
     s32 i;
     s32 deltaX;
@@ -518,7 +518,7 @@ void EntitySubwpnReboundStone(Entity* self) {
             }
             prim->x0 = prim->x1 = playerX;
             prim->y0 = prim->y1 = playerY;
-            LOH(prim->u3) = 0x14;
+            prim->timer = 0x14;
         }
         self->flags = FLAG_UNK_08000000 | FLAG_UNK_04000000 | FLAG_HAS_PRIMS;
         self->zPriority = PLAYER.zPriority + 2;
@@ -720,7 +720,7 @@ void EntitySubwpnReboundStone(Entity* self) {
         }
         prim = &g_PrimBuf[self->primIndex];
         while (prim != NULL) {
-            LOH(prim->u3) = 0;
+            prim->timer = 0;
             prim = prim->next;
         }
         break;
@@ -747,8 +747,8 @@ void EntitySubwpnReboundStone(Entity* self) {
             prim->y1 = self->posY.i.hi;
         }
         if (!(prim->drawMode & DRAW_HIDE)) {
-            if (LOH(prim->u3) != 0) {
-                LOH(prim->u3)--;
+            if (prim->timer != 0) {
+                prim->timer--;
             } else {
                 // again not colliderFlags, seems to control stone fading
                 if (colliderFlags < prim->b1) {

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -1367,7 +1367,7 @@ PfnEntityUpdate g_RicEntityTbl[] = {
     func_80160D2C,
     EntityHitByIce,
     EntityHitByLightning,
-    func_8016B97C,
+    EntitySubwpnReboundStone,
     func_8016C1BC,
     func_8016C734,
     func_8016CC74,

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -118,7 +118,7 @@ void func_8016B0C0(Entity* self);
 void func_80160D2C(Entity* self);
 void EntityHitByIce(Entity* self);
 void EntityHitByLightning(Entity* self);
-void func_8016B97C(Entity* self);
+void EntitySubwpnReboundStone(Entity* self);
 void func_8016C1BC(Entity* self);
 void func_8016C734(Entity* self);
 void func_8016CC74(Entity* self);


### PR DESCRIPTION
I did the DRA version of the rebound stone a little while ago; this one is quite similar.

The rebound stone line is drawn using a series of PRIM_LINE_G2 primitives. It turns out that the new PrimLineG2 variant in `primitives.h` matches perfectly. The DRA version was using `LOH()` macros, but now it is clear that we don't need that, now that we understand the alternate primitive. It's very cool to find multiple places in the code using this struct as an alternative to the normal Primitive.

This also has two identical helper functions, so I have renamed those to match the DRA versions as well.