### PR TITLE
Allow spritesheet to be extracted from the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ $(BUILD_DIR)/$(ASSETS_DIR)/%.tiledef.json.o: $(ASSETS_DIR)/%.tiledef.json
 	./tools/splat_ext/tiledef.py $< $(BUILD_DIR)/$(ASSETS_DIR)/$*.s
 	$(AS) $(AS_FLAGS) -o $(BUILD_DIR)/$(ASSETS_DIR)/$*.o $(BUILD_DIR)/$(ASSETS_DIR)/$*.s
 $(BUILD_DIR)/$(ASSETS_DIR)/%.spritesheet.json.o: $(ASSETS_DIR)/%.spritesheet.json
-	./tools/splat_ext/spritesheet.py $< $(BUILD_DIR)/$(ASSETS_DIR)/$*.s
+	./tools/splat_ext/spritesheet.py encode $< $(BUILD_DIR)/$(ASSETS_DIR)/$*.s
 	$(AS) $(AS_FLAGS) -o $(BUILD_DIR)/$(ASSETS_DIR)/$*.o $(BUILD_DIR)/$(ASSETS_DIR)/$*.s
 $(BUILD_DIR)/$(ASSETS_DIR)/%.animset.json.o: $(ASSETS_DIR)/%.animset.json
 	./tools/splat_ext/animset.py gen-asm $< $(BUILD_DIR)/$(ASSETS_DIR)/$*.s

--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -30,7 +30,7 @@ segments:
     subalign: 4
     subsegments:
       - [0x0, data]
-      - [0x20, spritesheet, richter, disks/us/BIN/F_GAME2.BIN, 0x40400]
+      - [0x20, spritesheet, richter, disks/us/BIN/F_GAME2.BIN, 32]
       - [0x170AC, .data, spriteparts]
       - [0x18568, data]
       - [0x18688, assets, subweapondefs, D_80154688]


### PR DESCRIPTION
A side-project I've been working on that helped me understanding some structures that are now a bit better documented in #1034 . Richter sprites are extracted as usual. Doing `python3 tools/splat_ext/spritesheet.py decode disks/us/BIN/ARC_F.BIN assets/arc alucard disks/us/BIN/F_GAME.BIN 1` can extract Alucard sprites too. There is no repacking yet as I want to avoid using splat for this one. 