### PR TITLE
Migrate .rodata to functions for main.exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ PSXLIBS         := $(addprefix lib, c c2 api etc card gpu gs gte cd snd spu)
 
 # Files
 PSXLIB_DIRS     := $(addprefix psxsdk/, . $(PSXLIBS))
-MAIN_ASM_DIRS   := $(addprefix $(ASM_DIR)/$(MAIN)/,. $(PSXLIB_DIRS) data)
+PSXLIB_DATA_DIRS := $(addprefix data/, . $(PSXLIB_DIRS))
+
+MAIN_ASM_DIRS   := $(addprefix $(ASM_DIR)/$(MAIN)/,. $(PSXLIB_DIRS) data $(PSXLIB_DATA_DIRS))
 MAIN_SRC_DIRS   := $(addprefix $(SRC_DIR)/$(MAIN)/,. $(PSXLIB_DIRS))
 
 MAIN_S_FILES    := $(wildcard $(addsuffix /*.s, $(MAIN_ASM_DIRS)))

--- a/config/splat.us.main.yaml
+++ b/config/splat.us.main.yaml
@@ -16,12 +16,12 @@ options:
   undefined_syms_auto_path:  config/undefined_syms_auto.us.main.txt
   find_file_boundaries: yes
   use_legacy_include_asm: no
-  migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   section_order:
     - ".rodata"
     - ".text"
     - ".data"
+    - ".bss"
 segments:
   - [0x800, header]
   - name: main
@@ -30,26 +30,28 @@ segments:
     vram:  0x80010000
     subalign: 4
     subsegments:
-      - [0x800, rodata]
-      - [0x874, rodata] # jpt_80011B20
+      - [0x800, .rodata, main]
+      - [0x874, .rodata, psxsdk/libgpu/font]
       - [0x8F8, .rodata, psxsdk/libgpu/prim]
-      - [0x9C8, rodata]
-      - [0xA10, .rodata, psxsdk/libgpu/sys]
-      - [0xB60, rodata]
-      - [0xC94, rodata] # jpt_800163F4
-      - [0xD48, rodata]
-      - [0xEB4, rodata]
-      - [0xF18, rodata] # jpt_80019DE8
-      - [0xF2C, rodata]
-      - [0x1260, .rodata, psxsdk/libsnd/seqread] # jpt_8001DE24 _SsSetControlChange
-      - [0x1448, rodata] # jpt_8001EECC
-      - [0x14A8, rodata] # jpt_8001EFB8
-      - [0x14D4, .rodata, psxsdk/libsnd/sstick] # jpt_80020818, SsSetTickMode
-      - [0x14EC, rodata]
-      - [0x1574, rodata] # jpt_8002A518
-      - [0x1594, rodata] # jpt_8002A5E8
-      - [0x15B4, rodata] # jpt_8002ADFC
-      - [0x15D4, rodata] # jpt_8002AEC4
+      - [0x9C8, .rodata, psxsdk/libgpu/sys]
+      - [0xBC4, rodata, psxsdk/libapi/a22] # aVsyncTimeout
+      - [0xC08, .rodata, psxsdk/libapi/l10]
+      - [0xC40, .rodata, psxsdk/libetc/intr_dma]
+      - [0xC6C, .rodata, psxsdk/libc/sprintf]
+      - [0xD48, .rodata, psxsdk/libcd/event]
+      - [0xD60, .rodata, psxsdk/libcd/sys]
+      - [0xD68, rodata] # referenced indirectly by libcd functions (see 1BCE0.data.s)
+      - [0xEB4, .rodata, psxsdk/libcd/bios]
+      - [0xFB8, .rodata, psxsdk/libcd/iso9660]
+      - [0x11A4, .rodata, psxsdk/libcd/cdread]
+      - [0x11E8, .rodata, psxsdk/libcd/c_011]
+      - [0x1200, .rodata, psxsdk/libsnd/seqinit]
+      - [0x1260, .rodata, psxsdk/libsnd/seqread]
+      - [0x14D4, .rodata, psxsdk/libsnd/sstick]
+      - [0x14EC, .rodata, psxsdk/libspu/spu]
+      - [0x1534, .rodata, psxsdk/libspu/s_si]
+      - [0x1574, .rodata, psxsdk/libspu/s_sva]
+      - [0x15B4, .rodata, psxsdk/libspu/s_sca]
       - [0x15F4, asm, psxsdk/2mbyte]
       - [0x16B8, c, main]
       - [0x192C, c, psxsdk/libgpu/ext]

--- a/config/symbols.us.main.txt
+++ b/config/symbols.us.main.txt
@@ -1,0 +1,2 @@
+D_80010960 = 0x80010960; // force_migration:True
+D_80010964 = 0x80010964; // force_migration:True

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -4,30 +4,34 @@
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
+#define ASM_RODATA __asm__(".section .rodata")
+
 #ifndef PERMUTER
 
 #ifndef INCLUDE_ASM
 
 #ifndef INCLUDE_ASM_OLD
 #define INCLUDE_ASM(FOLDER, NAME)                                              \
-    __asm__(".section .text\n"                                                 \
+    __asm__(".pushsection .text\n"                                             \
             "\t.align\t2\n"                                                    \
             "\t.globl\t" #NAME "\n"                                            \
             "\t.ent\t" #NAME "\n" #NAME ":\n"                                  \
             ".include \"asm/" VERSION "/" FOLDER "/" #NAME ".s\"\n"            \
             "\t.set reorder\n"                                                 \
             "\t.set at\n"                                                      \
-            "\t.end\t" #NAME)
+            "\t.end\t" #NAME "\n"                                              \
+            ".popsection");
 #else
 #define INCLUDE_ASM(FOLDER, NAME)                                              \
-    __asm__(".section .text\n"                                                 \
+    __asm__(".pushsection .text\n"                                             \
             "\t.align\t2\n"                                                    \
             "\t.globl\t" #NAME "\n"                                            \
             "\t.ent\t" #NAME "\n" #NAME ":\n"                                  \
             ".include \"" FOLDER "/" #NAME ".s\"\n"                            \
             "\t.set reorder\n"                                                 \
             "\t.set at\n"                                                      \
-            "\t.end\t" #NAME);
+            "\t.end\t" #NAME "\n"                                              \
+            ".popsection");
 #endif
 
 #endif

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1,3 +1,5 @@
 #include "common.h"
 
 INCLUDE_ASM("main/nonmatchings/main", main);
+
+const char a0123456789abcd[] = "0123456789ABCDEF\0\0\0\0";

--- a/src/main/psxsdk/libc/sprintf.c
+++ b/src/main/psxsdk/libc/sprintf.c
@@ -1,3 +1,6 @@
 #include "common.h"
 
+const char a0123456789abcd_0[] = "0123456789ABCDEF";
+const char a0123456789abcd_1[] = "0123456789abcdef";
+
 INCLUDE_ASM("main/nonmatchings/psxsdk/libc/sprintf", sprintf);

--- a/src/main/psxsdk/libcd/bios.c
+++ b/src/main/psxsdk/libcd/bios.c
@@ -1,5 +1,7 @@
 #include "common.h"
 
+const char D_800106B4[] = "%s:(%s) Sync=%s, Ready=%s\n";
+
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", getintr);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_sync);
@@ -7,6 +9,9 @@ INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_sync);
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_ready);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_cw);
+
+const char aIdBiosCV177199[] =
+    "$Id: bios.c,v 1.77 1996/05/13 06:58:16 suzu Exp $";
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_vol);
 

--- a/src/main/psxsdk/libcd/sys.c
+++ b/src/main/psxsdk/libcd/sys.c
@@ -20,6 +20,8 @@ INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdFlush);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdSetDebug);
 
+const char aNone[] = "none";
+
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdComstr);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/sys", CdIntstr);

--- a/src/main/psxsdk/libgpu/sys.c
+++ b/src/main/psxsdk/libgpu/sys.c
@@ -20,8 +20,9 @@ typedef struct {
     /* 0x3C */ void (*sync)(int);           // _sync
 } gpu;                                      // size = 0x40
 
-extern const char
-    aIdSysCV1831995[]; // "$Id: sys.c,v 1.83 1995/05/25 13:43:27 suzu Exp $"
+const char aIdSysCV1831995[] =
+    "$Id: sys.c,v 1.83 1995/05/25 13:43:27 suzu Exp $";
+
 extern const char D_800101FC[]; // "ResetGraph(%d)...\n"
 extern const char D_80010360[]; // "PutDispEnv(%08x)...\n"
 extern const char D_80010378[]; // "GPU_exeque: null func.\n"

--- a/src/main/psxsdk/libsnd/seqinit.c
+++ b/src/main/psxsdk/libsnd/seqinit.c
@@ -4,7 +4,6 @@ s16 _SsInitSoundSeq(s16, s16, u32);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libsnd/seqinit", _SsInitSoundSeq);
 
-extern s8 D_80010A3C;
 extern u32 _snd_openflag;
 
 s16 SsSeqOpen(u32 addr, s16 vab_id) {
@@ -14,7 +13,7 @@ s16 SsSeqOpen(u32 addr, s16 vab_id) {
     u8 found;
     open_bits = _snd_openflag;
     if (open_bits == 0xFFFFFFFF) {
-        printf(&D_80010A3C);
+        printf("Can't Open Sequence data any more\n\n");
         return -1;
     }
     bit_pos = 0;

--- a/src/main/psxsdk/libspu/spu.c
+++ b/src/main/psxsdk/libspu/spu.c
@@ -21,7 +21,6 @@ s32 _spu_reset(void) {
     return 0;
 }
 
-extern s32 D_80010CEC;
 extern s32 D_800334FC;
 extern s32* D_80033514;
 extern s32 D_80033540;
@@ -29,7 +28,6 @@ extern s32 _spu_addrMode;
 extern s32 _spu_mem_mode;
 extern s32 _spu_mem_mode_unit;
 extern s32 _spu_mem_mode_unitM;
-extern s32 aWaitReset;
 
 s32 _spu_init(s32 arg0) {
     volatile s32 sp0;
@@ -54,7 +52,7 @@ s32 _spu_init(s32 arg0) {
             wait_count = D_800334FC + 1;
             D_800334FC = wait_count;
             if (wait_count > 5000) {
-                printf(&D_80010CEC, &aWaitReset);
+                printf("SPU:T/O [%s]\n", "wait (reset)");
                 break;
             }
         } while (_spu_RXX->rxx.spustat & 0x7FF);
@@ -111,9 +109,6 @@ s32 _spu_init(s32 arg0) {
     return 0;
 }
 
-extern s32 aWaitDmafClearW;
-extern s32 aWaitWrdyHL;
-
 s32 _spu_writeByIO(s32 addr, s32 size) {
     volatile s32 sp0;
     volatile s32 sp4;
@@ -160,7 +155,7 @@ s32 _spu_writeByIO(s32 addr, s32 size) {
                 wait_count = D_800334FC + 1;
                 D_800334FC = wait_count;
                 if (wait_count > 5000) {
-                    printf(&D_80010CEC, &aWaitWrdyHL);
+                    printf("SPU:T/O [%s]\n", "wait (wrdy H -> L)");
                     break;
                 }
             } while (_spu_RXX->rxx.spustat & 0x400);
@@ -181,7 +176,7 @@ s32 _spu_writeByIO(s32 addr, s32 size) {
             wait_count = D_800334FC + 1;
             D_800334FC = wait_count;
             if (wait_count > 5000) {
-                printf(&D_80010CEC, &aWaitDmafClearW);
+                printf("SPU:T/O [%s]\n", "wait (dmaf clear/W)");
                 return;
             }
             spustat_cur = _spu_RXX->rxx.spustat & 0x7FF;


### PR DESCRIPTION
I feel like getting all the rodata migrated will make it easier to update splat (also makes it easier to match functions that use rodata).