### PR TITLE
Render the explored castle map

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -161,6 +161,7 @@ typedef struct Prim {
 #define WEAPON_0_END (WEAPON_1_START - 1)
 #define WEAPON_1_START 0xF0
 
+#ifndef VERSION_PC
 #define RIC_PRG_PTR 0x8013C000
 #define FAMILIAR_PTR 0x80170000
 #define WEAPON0_PTR 0x8017A000
@@ -173,6 +174,24 @@ typedef struct Prim {
 #define SIM_CHR0 0x80280000
 #define SIM_CHR1 0x80284000
 #define SIM_PTR 0x80280000
+
+#else
+#define RIC_PRG_PTR 0x8013C000
+#define FAMILIAR_PTR 0x80170000
+#define WEAPON0_PTR 0x8017A000
+#define WEAPON1_PTR 0x8017D000
+#define STAGE_PRG_PTR 0x80180000
+#define CASTLE_MAP_PTR g_BmpCastleMap
+#ifndef DEMO_KEY_PTR
+#define DEMO_KEY_PTR 0x801E8000
+#endif
+#define SIM_CHR0 0x80280000
+#define SIM_CHR1 0x80284000
+#define SIM_PTR 0x80280000
+
+extern u8 g_BmpCastleMap[0x20000];
+
+#endif
 
 // Flags for entity->drawFlags
 #define FLAG_DRAW_ROTX 0x01

--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -596,8 +596,6 @@ u8 func_800F17C8(s8 arg0[], s32 arg1, s32 arg2) {
 }
 
 void func_800F180C(s32 x, s32 y, u8* dst) {
-// TODO fix CASTLE_MAP_PTR
-#ifndef VERSION_PC
     s32 i, j;
     u8 *start, *curSrc, *src;
 
@@ -612,12 +610,9 @@ void func_800F180C(s32 x, s32 y, u8* dst) {
             dst[4 * i + j] = curSrc[j];
         }
     }
-#endif
 }
 
 void func_800F1868(s32 x, s32 y, u8* src) {
-// TODO fix CASTLE_MAP_PTR
-#ifndef VERSION_PC
     s32 i;
     s32 j;
     u8* dst;
@@ -635,26 +630,25 @@ void func_800F1868(s32 x, s32 y, u8* src) {
             curDst[j] = src[4 * i + j];
         }
     }
-#endif
 }
 
-void func_800F18C4(s32 arg0, s32 arg1) {
-    s8 sp10[20];
+void func_800F18C4(s32 x, s32 y) {
+    u8 sp10[4 * 5];
     s32 i;
     s32 j;
 
-    func_800F180C(arg0, arg1, &sp10);
+    func_800F180C(x, y, &sp10);
 
     for (i = 0; i < 4; i++) {
         for (j = 0; j < 5; j++) {
             func_800F1770(sp10, j, i, false);
         }
     }
-    func_800F1868(arg0, arg1, &sp10);
+    func_800F1868(x, y, sp10);
 }
 
 void func_800F1954(s32 x, s32 y, s32 arg2) {
-    u8 sp10[20];
+    u8 sp10[4 * 5];
     s32 i;
     s32 j;
 

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -58,6 +58,8 @@ GfxBank** g_GfxStageBank[0x40] = {
 };
 extern u_long* D_800A3BB8[];
 
+u8 g_BmpCastleMap[0x20000];
+
 #define MAX_SIZE_FOR_COMPRESSED_GFX 8192
 u8 D_800C217C[MAX_SIZE_FOR_COMPRESSED_GFX];
 u8 D_800C27B0[MAX_SIZE_FOR_COMPRESSED_GFX];


### PR DESCRIPTION
![image](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/fad98e8c-ff42-4944-b54f-7e97f46dd98c)

This. It still misses the texture and I do not know what the green lines are about. All the stuff within the `#else` and `#endif` are placeholders that will hopefully be fixed later on the same way.

To get the same result from the screenshot I had to use the [func_800F1B08](https://decomp.me/scratch/nW7lV) scratch, comment  `g_CastleMap[i] = 0;` from `InitStatsAndGear` and use the following to read the map from a memory card's save:

```c
if (!FileRead(LoadMemcardSave, "memcard1.mcd")) {
    WARNF("unable to correctly load the save file");
}
```
```c
s32 LoadSaveData(SaveData* save);
bool LoadMemcardSave(FILE* f) {
    const int slot = 0;
    SaveData save;

    fseek(f, 0x2000 + slot * 0x2000, SEEK_SET);
    fread(&save, sizeof(SaveData), 1, f);
    return LoadSaveData(&save) == 0;
}
```