### PR TITLE
Create and use entity flag FLAG_DEAD

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -204,6 +204,8 @@ extern u8 g_BmpCastleMap[0x20000];
 #define FLAG_DRAW_UNK80 0x80
 
 // Flags for entity->flags
+// Signals that the entity should run its death routine
+#define FLAG_DEAD 0x100
 #define FLAG_UNK_2000 0x2000
 #define FLAG_UNK_10000 0x10000
 #define FLAG_UNK_20000 0x20000 // func_8011A9D8 will destroy if not set

--- a/src/dra/843B0.c
+++ b/src/dra/843B0.c
@@ -1720,7 +1720,7 @@ void EntitySubwpnAgunea(Entity* self) {
         if (ent->entityId == 0 ||
             self->ext.et_80128C2C.unk7C != 0 &&
                 (ent->hitPoints > 0x7000 || ent->hitPoints == 0 ||
-                 ent->flags & 0x100)) {
+                 ent->flags & FLAG_DEAD)) {
             self->step = 2;
             return;
         }

--- a/src/st/dre/13E18.c
+++ b/src/st/dre/13E18.c
@@ -12,13 +12,13 @@ void EntityUnkId1C(Entity* self) {
         self->flags |= 0x100;
     }
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         if (self->step != 5) {
             if (D_80180660 != 0) {
                 D_80180660--;
             }
             self->hitboxState = 0;
-            self->flags |= 0x100;
+            self->flags |= FLAG_DEAD;
             g_api.func_80134714(0x6D9, 0x54, 0);
             SetStep(5);
         }

--- a/src/st/dre/13E18.c
+++ b/src/st/dre/13E18.c
@@ -9,7 +9,7 @@ void EntityUnkId1C(Entity* self) {
     s32 i;
 
     if (D_80180660 == 0) {
-        self->flags |= 0x100;
+        self->flags |= FLAG_DEAD;
     }
 
     if (self->flags & FLAG_DEAD) {

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -96,7 +96,7 @@ void EntitySuccubus(Entity* self) {
         SetStep(SUCCUBUS_GET_HIT);
     }
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         if (self->step != SUCCUBUS_DYING) {
             self->hitboxState = 0;
             SetStep(SUCCUBUS_DYING);
@@ -969,7 +969,7 @@ void EntitySuccubusPetal(Entity* self) {
         D_80180668 = 1;
     }
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, newEntity);
@@ -1049,16 +1049,16 @@ void EntitySuccubusClone(Entity* self) {
     s32 i;
 
     if (D_80180660 == 0) {
-        self->flags |= 0x100;
+        self->flags |= FLAG_DEAD;
     }
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         if (self->step != 5) {
             if (D_80180660 != 0) {
                 D_80180660--;
             }
             self->hitboxState = 0;
-            self->flags |= 0x100;
+            self->flags |= FLAG_DEAD;
             g_api.func_80134714(0x6D9, 0x54, 0);
             SetStep(5);
         }
@@ -1199,7 +1199,7 @@ void EntityPinkBallProjectile(Entity* self) {
             self->drawFlags = 0;
             self->step++;
         }
-        if (entity->flags & 0x100) {
+        if (entity->flags & FLAG_DEAD) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -963,7 +963,7 @@ void EntitySuccubusPetal(Entity* self) {
     s16 angle;
 
     if (D_80180664 & 2) {
-        self->flags |= 0x100;
+        self->flags |= FLAG_DEAD;
     }
     if (self->hitFlags & 0x80) {
         D_80180668 = 1;

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -1345,7 +1345,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
             g_api.PlaySfx(SE_NO3_ALUCARD_FLOOR_HIT);
         }
 
-        if (self->flags & 0x100) {
+        if (self->flags & FLAG_DEAD) {
             self->step++;
         }
         break;

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -1666,7 +1666,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     }
     AnimateEntity(D_80183994, entity);
     MoveEntity();
-    if (entity->flags & 0x100) {
+    if (entity->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(2, entity, newEntity);
@@ -1929,7 +1929,7 @@ void EntityMermanFireball(Entity* self) {
             self->rotY = self->rotX += 8;
         }
 
-        if (self->flags & 0x100) {
+        if (self->flags & FLAG_DEAD) {
             entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entity != NULL) {
                 CreateEntityFromEntity(2, self, entity);

--- a/src/st/no3/56264.c
+++ b/src/st/no3/56264.c
@@ -5,7 +5,7 @@ void EntityBat(Entity* entity) {
     s16 xDistance;
     s16 yDistance;
 
-    if (entity->flags & 0x100) {
+    if (entity->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(2, entity, newEntity);

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -4,7 +4,7 @@ void EntityZombie(Entity* self) {
     Entity* newEntity;
     s32 temp_a0;
 
-    if ((self->flags & 0x100) && (self->step < 4)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < 4)) {
         func_801CAD28(SE_ZOMBIE_EXPLODE);
         self->hitboxState = 0;
         // Spawn Zombie explosion

--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -1288,7 +1288,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
             g_api.PlaySfx(0x64B);
         }
 
-        if (self->flags & 0x100) {
+        if (self->flags & FLAG_DEAD) {
             self->step++;
         }
         break;

--- a/src/st/np3/36990.c
+++ b/src/st/np3/36990.c
@@ -545,7 +545,7 @@ void EntitySlograSpear(Entity* self) {
 void EntitySlograSpearProjectile(Entity* self) {
     Entity* entity;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, entity);
@@ -608,7 +608,7 @@ void EntityGaibon(Entity* self) {
                 }
             }
         }
-        if ((!(self->flags & 0x100) || (self->step >= GAIBON_NEAR_DEATH)) &&
+        if ((!(self->flags & FLAG_DEAD) || (self->step >= GAIBON_NEAR_DEATH)) &&
             (SLOGRA.ext.GS_Props.pickupFlag) &&
             (self->step < GAIBON_LANDING_AFTER_SHOOTING)) {
             SetStep(GAIBON_PICKUP_SLOGRA);
@@ -1203,7 +1203,7 @@ void func_801B8CC0(Entity* self) {
 
 // small red projectile from gaibon
 void EntitySmallGaibonProjectile(Entity* self) {
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->pfnUpdate = EntityExplosion;
         self->drawFlags = 0;
         self->step = 0;
@@ -1234,7 +1234,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
 void EntityLargeGaibonProjectile(Entity* self) {
     Entity* newEntity;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->pfnUpdate = EntityExplosion;
         self->entityId = 2;
         self->drawFlags = 0;

--- a/src/st/np3/44DCC.c
+++ b/src/st/np3/44DCC.c
@@ -676,7 +676,7 @@ void EntityMerman2(Entity* self) {
         SetStep(MERMAN2_7);
     }
 
-    if ((self->flags & 0x100) && (self->step < MERMAN2_DYING)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < MERMAN2_DYING)) {
         func_801C2598(0x71D);
         self->drawFlags = 0;
         if (self->flags & FLAG_HAS_PRIMS) {
@@ -1240,7 +1240,7 @@ void EntityMediumWaterSplash(Entity* entity) {
     }
     AnimateEntity(D_801822A4, entity);
     MoveEntity();
-    if (entity->flags & 0x100) {
+    if (entity->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);

--- a/src/st/np3/48238.c
+++ b/src/st/np3/48238.c
@@ -63,7 +63,7 @@ void EntityMerman(Entity* self) {
         SetStep(MERMAN_FALLING);
     }
 
-    if ((self->flags & 0x100) && (self->step < MERMAN_DYING)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < MERMAN_DYING)) {
         func_801C2598(0x71D);
         self->hitboxState = 0;
         if (self->step == MERMAN_LUNGE) {
@@ -446,7 +446,7 @@ void func_801C8DF0(Entity* self) {
             self->rotY = self->rotX += 8;
         }
 
-        if (self->flags & 0x100) {
+        if (self->flags & FLAG_DEAD) {
             entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, entity);

--- a/src/st/np3/490E8.c
+++ b/src/st/np3/490E8.c
@@ -51,7 +51,7 @@ void EntityBoneScimitar(Entity* self) {
     u8 animStatus;
     s32 i;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->step = BONE_SCIMITAR_DESTROY;
     }
 

--- a/src/st/np3/4997C.c
+++ b/src/st/np3/4997C.c
@@ -5,7 +5,7 @@ void EntityBat(Entity* entity) {
     s16 xDistance;
     s16 yDistance;
 
-    if (entity->flags & 0x100) {
+    if (entity->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, entity, newEntity);

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -4,7 +4,7 @@ void EntityZombie(Entity* self) {
     Entity* newEntity;
     s32 temp_a0;
 
-    if ((self->flags & 0x100) && (self->step < 4)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < 4)) {
         func_801C2598(NA_SE_EN_ZOMBIE_EXPLODE);
         self->hitboxState = 0;
         // Spawn Zombie explosion

--- a/src/st/np3/49F98.c
+++ b/src/st/np3/49F98.c
@@ -220,7 +220,7 @@ void EntityBloodyZombie(Entity* self) {
         SetStep(BLOODY_ZOMBIE_TAKE_HIT);
     }
 
-    if (self->flags & 0x100 && self->step < 8) {
+    if (self->flags & FLAG_DEAD && self->step < 8) {
         func_801C2598(NA_SE_EN_BLOODY_ZOMBIE_DEATH_SCREAM);
         self->hitboxState = 0;
         self->flags &= ~FLAG_UNK_20000000;

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -235,7 +235,7 @@ void EntitySlogra(Entity* self) {
         }
     }
 
-    if ((self->flags & 0x100) && (self->step != SLOGRA_DYING)) {
+    if ((self->flags & FLAG_DEAD) && (self->step != SLOGRA_DYING)) {
         SetStep(SLOGRA_DYING);
     }
 
@@ -648,7 +648,7 @@ void EntitySlograSpear(Entity* self) {
 void EntitySlograSpearProjectile(Entity* self) {
     Entity* entity;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, entity);
@@ -710,7 +710,7 @@ void EntityGaibon(Entity* self) {
         }
     }
 
-    if (self->flags & 0x100 && self->step < GAIBON_NEAR_DEATH) {
+    if (self->flags & FLAG_DEAD && self->step < GAIBON_NEAR_DEATH) {
         self->ext.GS_Props.grabedAscending = 0;
         self->unk3C = 0;
         SetStep(GAIBON_NEAR_DEATH);
@@ -1122,7 +1122,7 @@ void EntityGaibon(Entity* self) {
             if (AnimateEntity(D_801812F0, self) == 0) {
                 self->ext.GS_Props.flag = 0;
                 SetSubStep(GAIBON_NEAR_DEATH_TRANSFORM);
-                if (self->flags & 0x100) {
+                if (self->flags & FLAG_DEAD) {
                     func_801C29B0(NA_SE_EN_GAIBON_COLLAPSE);
                     SetStep(GAIBON_DYING);
                 } else {
@@ -1203,7 +1203,7 @@ void EntityGaibon(Entity* self) {
         break;
     }
 
-    if (!(self->flags & 0x100)) {
+    if (!(self->flags & FLAG_DEAD)) {
         slograGaibonDistX = self->posX.i.hi + g_Tilemap.scrollX.i.hi;
         slograGaibonDistY = self->posY.i.hi + g_Tilemap.scrollY.i.hi;
 
@@ -1260,7 +1260,7 @@ void func_801B69E8(Entity* self) {
 
 // small red projectile from gaibon
 void EntitySmallGaibonProjectile(Entity* self) {
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->pfnUpdate = EntityExplosion;
         self->drawFlags = 0;
         self->step = 0;
@@ -1292,7 +1292,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
 void EntityLargeGaibonProjectile(Entity* self) {
     Entity* newEntity;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->pfnUpdate = EntityExplosion;
         self->entityId = 2;
         self->drawFlags = 0;

--- a/src/st/nz0/43708.c
+++ b/src/st/nz0/43708.c
@@ -52,7 +52,7 @@ void EntityBoneScimitar(Entity* self) {
     u8 animStatus;
     s32 i;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->step = BONE_SCIMITAR_DESTROY;
     }
 

--- a/src/st/nz0/43F9C.c
+++ b/src/st/nz0/43F9C.c
@@ -79,7 +79,7 @@ void EntityAxeKnight(Entity* self) {
     s8* hitbox;
     s16 temp;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         if (self->step != AXE_KNIGHT_DYING) {
             func_801C29B0(NA_SE_VO_AXE_KNIGHT_SCREAM);
             func_801B3B78();
@@ -325,7 +325,7 @@ void EntityAxeKnightRotateAxe(void) {
 void EntityAxeKnightThrowingAxe(Entity* entity) {
     s32 velocityX;
 
-    if (entity->flags & 0x100) {
+    if (entity->flags & FLAG_DEAD) {
         func_801C29B0(NA_SE_EN_AXE_KNIGHT_BREAK_AXE);
         EntityExplosionSpawn(0, 0);
         return;

--- a/src/st/nz0/44EAC.c
+++ b/src/st/nz0/44EAC.c
@@ -220,7 +220,7 @@ void EntityBloodyZombie(Entity* self) {
         SetStep(BLOODY_ZOMBIE_TAKE_HIT);
     }
 
-    if (self->flags & 0x100 && self->step < 8) {
+    if (self->flags & FLAG_DEAD && self->step < 8) {
         func_801C29B0(NA_SE_EN_BLOODY_ZOMBIE_DEATH_SCREAM);
         self->hitboxState = 0;
         self->flags &= ~FLAG_UNK_20000000;

--- a/src/st/nz0/45F2C.c
+++ b/src/st/nz0/45F2C.c
@@ -24,7 +24,7 @@ void EntitySkeleton(Entity* self) {
     u8 animStatus;
     u8 i;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->step = SKELETON_DESTROY;
     }
 
@@ -204,7 +204,7 @@ void func_801C6574(Entity* entity) { // Bone Projectile from Skeleton
     u32 xDistanceToPlayer;
 
     if (entity->step) {
-        if (entity->flags & 0x100) {
+        if (entity->flags & FLAG_DEAD) {
             EntityExplosionSpawn(0, 0);
             return;
         }

--- a/src/st/nz0/4672C.c
+++ b/src/st/nz0/4672C.c
@@ -10,7 +10,7 @@ void EntitySpittleBone(Entity* self) {
     Entity* newEntity;
     s32 i;
 
-    if ((self->flags & 0x100) && (self->step < 3)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < 3)) {
         self->step = 3;
     }
 

--- a/src/st/nz0/47958.c
+++ b/src/st/nz0/47958.c
@@ -16,7 +16,7 @@ typedef enum {
 void EntityBloodSkeleton(Entity* self) {
     u8* animation;
 
-    if ((self->flags & 0x100) && (self->step < 3)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < 3)) {
         func_801C29B0(NA_SE_EN_BLOOD_SKELETON_DISASSEMBLES);
         self->hitboxState = 0;
         SetStep(BLOOD_SKELETON_DISASSEMBLE);

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -512,7 +512,7 @@ void EntityDraculaBody(Entity* self) {
 
 void EntityDraculaFireball(Entity* self) {
     if (g_isDraculaFirstFormDefeated) {
-        self->flags |= 0x100;
+        self->flags |= FLAG_DEAD;
     }
 
     if (self->flags & FLAG_DEAD) {

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -19,7 +19,7 @@ void EntityDracula(Entity* self) {
     u16 posX;
     s32 i;
 
-    if ((self->flags & 0x100) && (self->step < 8)) {
+    if ((self->flags & FLAG_DEAD) && (self->step < 8)) {
         self->hitboxState = 0;
         self[1].hitboxState = 0;
         SetStep(8);
@@ -515,7 +515,7 @@ void EntityDraculaFireball(Entity* self) {
         self->flags |= 0x100;
     }
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         self->pfnUpdate = EntityExplosion;
         self->step = 0;
         self->params = 2;

--- a/src/st/st0/2DAC8.c
+++ b/src/st/st0/2DAC8.c
@@ -87,11 +87,11 @@ void EntityDraculaFinalForm(Entity* self) {
     u16 selfzPriority;
     s32 selfParams;
 
-    if (self->flags & 0x100) { // Does this test for the entity being killed?
+    if (self->flags & FLAG_DEAD) {
         self->hitboxState = 0;
         if (self->step < 6) {
             D_8003C744 = 3;
-            SetStep(6); // Set step to 6, which is Dracula defeated?
+            SetStep(6);
         }
     }
     if (self->params == 0) {
@@ -654,7 +654,7 @@ void EntityDraculaRainAttack(Entity* self) {
     s16 angle;
     s32 i;
 
-    if (self->flags & 0x100) {
+    if (self->flags & FLAG_DEAD) {
         newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (newEntity != NULL) {
             CreateEntityFromEntity(E_EXPLOSION, self, newEntity);


### PR DESCRIPTION
Due to the discovery of the 0x100 entity flag in EntityDraculaFinalForm, I have gone ahead and created the #define for 0x100 being FLAG_DEAD. I have also searched the codebase for the string `flags & 0x100` and `flags |= 0x100` and made suitable replacements. There are likely other places that use the 0x100 flag which use different syntax, and those are not changed, but hopefully we can clean those up over time as we discover them.

Nice to expand our knowledge of the different available flags!