### PR TITLE
Improve permuter behaviour with the PSP build

### DIFF
--- a/Makefile.psp.mk
+++ b/Makefile.psp.mk
@@ -35,9 +35,7 @@ bin/mwccpsp.exe: bin/wibo bin/mwccpsp_3.0.1_147
 
 $(PSP_BUILD_DIR)/%.c.o: %.c bin/mwccpsp.exe
 	mkdir -p $(dir $@)
-	$(MWCPP_APP) $< -o $<.post.c
-	$(CCPSP) -gccinc -Iinclude -D_internal_version_$(VERSION) -O0 -c -lang c -sdatathreshold 0 -o $@ $<.post.c
-	rm $<.post.c || true
+	$(MWCPP_APP) $< -o $<.post.c && (($(CCPSP) -gccinc -Iinclude -D_internal_version_$(VERSION) -O0 -c -lang c -sdatathreshold 0 -o $@ $<.post.c && rm $<.post.c) || (rm $<.post.c && exit 1))
 $(PSP_BUILD_DIR)/asm/psp%.s.o: asm/psp%.s
 	mkdir -p $(dir $@)
 	$(ASPSP) -o $@ $<


### PR DESCRIPTION
I improved the PSP Makefile to always remove `*.post.c` regardless if the compiler fails or succeeds. This also helps when invoking `differ` on a broken build.

The permuter uses the last Makefile line to create a `compiler.sh` script used to make a bunch of iterations. Previously it was using `rm $<.post.c || true` as compiler. Now that I compacted everything into a single line it can at least import a C file. The produced `compiler.sh` is still wrong  as it cannot properly take in consideration the `mwcpp.py` tool and the parameters to pass to it.

---

Before this fix:

```bash
$ ./import.py sotn-decomp/src/servant/tt_000/10E8.c sotn-decomp/asm/pspeu/servant/tt_000/nonmatchings/10E8/func_80171ED4.s
Compiler type: gcc
Function name: func_80171ED4
Compiler: python3 tools/mwcpp.py {input} -o {output}
Assembler: mips-linux-gnu-as -march=vr4300 -mabi=32 {input} -o {output}
src/servant/tt_000/10E8.c:1:10: fatal error: servant.h: No such file or directory
    1 | #include <servant.h>
      |          ^~~~~~~~~~~
compilation terminated.
Failed to preprocess input file, when running command:
cpp -P -undef src/servant/tt_000/10E8.c -D__sgi -D_LANGUAGE_C -DNON_MATCHING -DNONMATCHING -DPERMUTER '-D_Static_assert(x, y)=' '-D__attribute__(x)=' '-DGLOBAL_ASM(...)=' '-D__asm__(...)='
```

With this fix:
```bash
$ ./import.py sotn-decomp/src/servant/tt_000/10E8.c sotn-decomp/asm/pspeu/servant/tt_000/nonmatchings/10E8/func_80171ED4.s
Compiler type: gcc
Function name: func_80171ED4
Compiler: python3 tools/mwcpp.py '&&' '((MWCIncludes=bin/' bin/wibo bin/mwccpsp.exe -gccinc -Iinclude -D_internal_version_pspeu -O0 -c -lang c -sdatathreshold 0 src/servant/tt_000/10E8.c.post.c '&&' rm 'src/servant/tt_000/10E8.c.post.c)' '||' '(rm' src/servant/tt_000/10E8.c.post.c '&&' exit '1))' {input} -o {output}
Assembler: mips-linux-gnu-as -march=vr4300 -mabi=32 {input} -o {output}
In file included from include/game.h:78,
                 from include/servant.h:4,
                 from src/servant/tt_000/10E8.c:1:
include/primitive.h:146:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
  146 | #endif PRIMITIVE_H
      |        ^~~~~~~~~~~
Preserving no macros. Use --preserve-macros='<regex>' to override.
usage: mwcpp.py [-h] [--version VERSION] [-o OUTPUT] input
mwcpp.py: error: unrecognized arguments: ((MWCIncludes=bin/ bin/wibo bin/mwccpsp.exe -gccinc -Iinclude -D_internal_version_pspeu -O0 -c -lang c -sdatathreshold 0 src/servant/tt_000/10E8.c.post.c && rm src/servant/tt_000/10E8.c.post.c) || (rm src/servant/tt_000/10E8.c.post.c && exit 1)) /tmp/permutereepb8_ih.c
Warning: failed to compile .c file.
```

