### PR TITLE
Decompile weapon 49 func_ptr_80170014

### DIFF
--- a/src/weapon/w_049.c
+++ b/src/weapon/w_049.c
@@ -15,7 +15,43 @@ INCLUDE_ASM("weapon/nonmatchings/w_049", func_ptr_8017000C);
 
 INCLUDE_ASM("weapon/nonmatchings/w_049", func_ptr_80170010);
 
-INCLUDE_ASM("weapon/nonmatchings/w_049", func_ptr_80170014);
+extern SpriteParts D_15B000_8017AA44[];
+extern AnimationFrame D_15B000_8017B10C[];
+
+void func_ptr_80170014(Entity* self) {
+    switch (self->step) {
+    case 0:
+        SetSpriteBank2(D_15B000_8017AA44);
+        self->animSet = ANIMSET_OVL(0x11);
+        self->unk5A = 101;
+        self->palette = 0x117;
+        if (g_HandId != 0) {
+            self->palette = 0x12F;
+            self->unk5A += 2;
+            self->animSet += 2;
+        }
+        self->unk4C = D_15B000_8017B10C;
+        self->zPriority = PLAYER.zPriority + 2;
+        self->flags =FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
+        self->rotX = self->rotY = 0x100;
+        self->drawMode = DRAW_TPAGE | 0x20;
+        self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
+        SetWeaponProperties(self, 0);
+        self->enemyId = self->ext.weapon.parent->enemyId;
+        self->hitboxHeight = self->hitboxWidth = 12;
+        self->hitboxOffY = self->hitboxOffX = 0;
+        self->velocityY = FIX(-0.375);
+        g_api.PlaySfx(0x65B);
+        self->step++;
+        return;
+    case 1:
+        self->posY.val += self->velocityY;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+        }
+    }
+}
 
 int GetWeaponId(void) { return 49; }
 

--- a/src/weapon/w_049.c
+++ b/src/weapon/w_049.c
@@ -32,7 +32,7 @@ void func_ptr_80170014(Entity* self) {
         }
         self->unk4C = D_15B000_8017B10C;
         self->zPriority = PLAYER.zPriority + 2;
-        self->flags =FLAG_UNK_08000000 | FLAG_UNK_100000;
+        self->flags = FLAG_UNK_08000000 | FLAG_UNK_100000;
         self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
         self->rotX = self->rotY = 0x100;
         self->drawMode = DRAW_TPAGE | 0x20;


### PR DESCRIPTION
My last PR was for weapon 15, this is the same function for weapon 49.

Substantially similar; interesting that this one uses a switch on the self->step while the other one just had an `if step == 0`.

Otherwise nothing much of interest here. Going to continue to leave things as externs until each weapon is done.