### PR TITLE
Small logic cleanup on func_8010EDB8

### DIFF
--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -868,14 +868,10 @@ block_32:
         goto block_38c;
     }
     var_s2 = equipped_item->specialMove;
-    if (var_s2 == 0) {
-        goto block_38c;
-    }
-    // Sword of Dawn
-    if ((equipped_id == 0x11) && ((g_Player.pl_vram_flag & 0x41) != 1)) {
-        goto block_38c;
-    }
-    if (!(g_Player.pl_vram_flag & 1)) {
+    if (var_s2 == 0 ||
+        // Sword of Dawn
+        ((equipped_id == 0x11) && ((g_Player.pl_vram_flag & 0x41) != 1)) ||
+        !(g_Player.pl_vram_flag & 1)) {
         goto block_38c;
     }
     // Load up the item's special move as the new "virtual" equipped item since

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -900,10 +900,9 @@ block_32:
         }
         equipped_id = g_Status.equipment[hand];
         equipped_item = &g_EquipDefs[g_Status.equipment[hand]];
-        if (CheckChainLimit(equipped_id, hand) >= 0) {
-            goto block_45;
+        if (CheckChainLimit(equipped_id, hand) < 0) {
+            return 0;
         }
-        return 0;
     }
 block_45:
     if (equipped_id != 0) {

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -882,10 +882,8 @@ block_32:
     // we're attacking with the special
     equipped_item = &g_EquipDefs[var_s2];
     equipped_id = var_s2;
-    if (CheckChainLimit(equipped_id, hand) < 0) {
-        goto block_38c;
-    }
-    if (HasEnoughMp(g_EquipDefs[equipped_id].mpUsage, 0)) {
+    if (CheckChainLimit(equipped_id, hand) < 0 ||
+        HasEnoughMp(g_EquipDefs[equipped_id].mpUsage, 0)) {
     block_38c:
         equipped_item = &g_EquipDefs[g_Status.equipment[hand]];
         if (D_80138FC8 == 0xFF) {


### PR DESCRIPTION
I'm working on tracing the logic involved in using weapons. `func_8010EDB8` is a core part of that process.

I noticed a small improvement that could be made to the control flow, removing one `goto` statement.

This function could use more work on its overall control flow (there are so many uses of `goto`), but even a small improvement is still an improvement.