### PR TITLE
Support Single BIN CUE Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ define link
 		-T $(CONFIG_DIR)/undefined_funcs_auto.$(VERSION).$(1).txt
 endef
 
+SOTNDISK_SOURCES := $(shell find tools/sotn-disk -name '*.go')
+
 .PHONY: build
 
 all: build check
@@ -421,8 +423,8 @@ $(GO):
 	curl -L -o go1.19.7.linux-amd64.tar.gz https://go.dev/dl/go1.19.7.linux-amd64.tar.gz
 	tar -C $(HOME) -xzf go1.19.7.linux-amd64.tar.gz
 	rm go1.19.7.linux-amd64.tar.gz
-$(SOTNDISK): $(GO)
-	$(GO) install github.com/xeeynamo/sotn-decomp/tools/sotn-disk@latest
+$(SOTNDISK): $(GO) $(SOTNDISK_SOURCES)
+	cd tools/sotn-disk; $(GO) install
 
 $(BUILD_DIR)/%.s.o: %.s
 	$(AS) $(AS_FLAGS) -o $@ $<

--- a/tools/sotn-disk/cue.go
+++ b/tools/sotn-disk/cue.go
@@ -35,7 +35,7 @@ func performCueAction(cuePath string, action imageAction) error {
 	case "MODE2/2352":
 		mode = iso9660.TrackMode2_2352
 	default:
-		return fmt.Errorf("unrecognized TRACK mode '%s'", mode)
+		return fmt.Errorf("unrecognized TRACK mode '%s'", mainTrack.mode)
 	}
 
 	baseDir, _ := path.Split(cuePath)
@@ -75,6 +75,7 @@ func parseTracks(cuePath string) ([]cueTrack, error) {
 	lines := strings.Split(string(content), "\n")
 
 	tracks := make([]cueTrack, 0)
+	var file = ""
 	var track *cueTrack = nil
 	for _, line := range lines {
 		tokens := tokenizeCueLine(line)
@@ -87,17 +88,17 @@ func parseTracks(cuePath string) ([]cueTrack, error) {
 			if len(tokens) < 3 {
 				return nil, fmt.Errorf("cue line '%s' invalid", line)
 			}
+			file = tokens[1]
+		case "TRACK":
+			if len(tokens) < 3 {
+				return nil, fmt.Errorf("cue line '%s' invalid", line)
+			}
 			if track != nil {
 				tracks = append(tracks, *track)
 			}
 
 			track = &cueTrack{}
-			track.file = tokens[1]
-		case "TRACK":
-			if len(tokens) < 3 {
-				return nil, fmt.Errorf("cue line '%s' invalid", line)
-			}
-
+			track.file = file
 			track.id = tokens[1]
 			track.mode = tokens[2]
 		}


### PR DESCRIPTION
In CUE files `FILE` is a stateful, global declaration that applies to all following `TRACK`s. `sotn-disk` was treating `FILE` declarations as `TRACK` delimiters which would result in incorrect parsing of CUE files with a single `FILE`, but multiple tracks.

Now when reading a `FILE` declaration, the path is stored and processing continues. A `TRACK` declaration will use the previously defined path, and if a previous track had been started, append that previous track to the list.

This also builds `sotn-disk` using the local repository instead of pulling the latest commit from GitHub. The target depends on `sotn-disk` sources and will rebuild as necessary (or with `make ~/go/bin/sotn-disk`).

As an aside, [pull/232](https://github.com/Xeeynamo/sotn-decomp/pull/232) ran into this same error, but fixes in a slightly different way that leaves side effects that may make supporting things like `INDEX` (for extracting the placeholder audio, for example) more error prone in the future.