### PR TITLE
Decompile w16 func_ptr_80170014; change type

### DIFF
--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -18,7 +18,7 @@ void func_ptr_80170004(Entity* self);
 void func_ptr_80170008(Entity* self);
 void func_ptr_8017000C(Entity* self);
 void func_ptr_80170010(Entity* self);
-void func_ptr_80170014(Entity* self);
+s32 func_ptr_80170014(Entity* self);
 int GetWeaponId(void);
 void LoadWeaponPalette(s32 clutIndex);
 void EntityWeaponShieldSpell(Entity* self);

--- a/src/pc/stubs.c
+++ b/src/pc/stubs.c
@@ -654,7 +654,7 @@ void func_ptr_80170004(Entity* self) { NOT_IMPLEMENTED; }
 void func_ptr_80170008(Entity* self) { NOT_IMPLEMENTED; }
 void func_ptr_8017000C(Entity* self) { NOT_IMPLEMENTED; }
 void func_ptr_80170010(Entity* self) { NOT_IMPLEMENTED; }
-void func_ptr_80170014(Entity* self) { NOT_IMPLEMENTED; }
+s32 func_ptr_80170014(Entity* self) { NOT_IMPLEMENTED; }
 int GetWeaponId(void) {
     NOT_IMPLEMENTED;
     return 0;

--- a/src/weapon/w_000.c
+++ b/src/weapon/w_000.c
@@ -248,7 +248,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 0; }
 

--- a/src/weapon/w_001.c
+++ b/src/weapon/w_001.c
@@ -60,7 +60,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 1; }
 

--- a/src/weapon/w_002.c
+++ b/src/weapon/w_002.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 2; }
 

--- a/src/weapon/w_003.c
+++ b/src/weapon/w_003.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 3; }
 

--- a/src/weapon/w_004.c
+++ b/src/weapon/w_004.c
@@ -65,7 +65,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 4; }
 

--- a/src/weapon/w_005.c
+++ b/src/weapon/w_005.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 5; }
 

--- a/src/weapon/w_006.c
+++ b/src/weapon/w_006.c
@@ -15,7 +15,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 6; }
 

--- a/src/weapon/w_007.c
+++ b/src/weapon/w_007.c
@@ -15,7 +15,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 7; }
 

--- a/src/weapon/w_008.c
+++ b/src/weapon/w_008.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 8; }
 

--- a/src/weapon/w_009.c
+++ b/src/weapon/w_009.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 9; }
 

--- a/src/weapon/w_010.c
+++ b/src/weapon/w_010.c
@@ -35,7 +35,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 10; }
 

--- a/src/weapon/w_011.c
+++ b/src/weapon/w_011.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 11; }
 

--- a/src/weapon/w_012.c
+++ b/src/weapon/w_012.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 12; }
 

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -38,7 +38,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_013", func_ptr_8017000C);
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 13; }
 

--- a/src/weapon/w_014.c
+++ b/src/weapon/w_014.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 14; }
 

--- a/src/weapon/w_015.c
+++ b/src/weapon/w_015.c
@@ -38,7 +38,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_015", func_ptr_80170010);
 extern SpriteParts D_6D000_8017A2B0[];
 extern AnimationFrame D_6D000_8017A770[];
 
-void func_ptr_80170014(Entity* self) {
+s32 func_ptr_80170014(Entity* self) {
     s16 angle;
 
     if (self->step == 0) {

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -46,7 +46,7 @@ s32 func_ptr_80170014(Entity* self) {
     u16 tempEffects;
     s16 xShift;
     s16 yShift;
-    
+
     switch (self->step) {
     case 0:
         SetSpriteBank1(&D_74000_8017A040);
@@ -63,7 +63,7 @@ s32 func_ptr_80170014(Entity* self) {
         self->zPriority = PLAYER.zPriority - 2;
         self->flags = FLAG_UNK_08000000;
         self->velocityY = FIX(-2.25) - (rand() & 0x7FFF); // -2.5 +- 0.25
-        SetSpeedX((rand() & 0x7FFF) + FIX(1.25)); // 1.5 +- 0.25
+        SetSpeedX((rand() & 0x7FFF) + FIX(1.25));         // 1.5 +- 0.25
         self->posY.i.hi = PLAYER.posY.i.hi + PLAYER.hitboxOffY;
         SetWeaponProperties(self, 0);
         DestroyEntityWeapon(true);
@@ -95,7 +95,7 @@ s32 func_ptr_80170014(Entity* self) {
             } else {
                 self->posX.i.hi += collider.unk4;
             }
-            self->velocityX /= - 2;
+            self->velocityX /= -2;
             self->facingLeft = (self->facingLeft + 1) & 1;
         }
         collX = self->posX.i.hi;
@@ -121,9 +121,9 @@ s32 func_ptr_80170014(Entity* self) {
             self->velocityY = FIX(-1.125);
             self->velocityX /= 2;
             self->ext.weapon.lifetime++;
-            // Create factory with blueprint 31. Blueprint 31 has child entity 2, 
-            // which is func_8011B5A4.
-            g_api.CreateEntFactoryFromEntity(self, FACTORY(0x900,31), 0);
+            // Create factory with blueprint 31. Blueprint 31 has child entity
+            // 2, which is func_8011B5A4.
+            g_api.CreateEntFactoryFromEntity(self, FACTORY(0x900, 31), 0);
         }
         return;
     case 2:
@@ -144,8 +144,7 @@ s32 func_ptr_80170014(Entity* self) {
             g_api.CheckCollision(collX, collY, &collider, 0);
             if (!(collider.effects & EFFECT_SOLID)) {
                 self->posY.i.hi = yShift + self->posY.i.hi;
-            }
-            else if (!(collider.effects & EFFECT_UNK_8000)) {
+            } else if (!(collider.effects & EFFECT_UNK_8000)) {
                 self->step = 1;
                 self->velocityY = 0;
                 self->hitboxWidth = 8;
@@ -154,16 +153,18 @@ s32 func_ptr_80170014(Entity* self) {
                 self->posY.i.hi += 3 + (yShift + collider.unk18);
                 tempEffects = collider.effects;
             }
-            tempEffects &= 0xF000; //mask off just a couple effects
+            tempEffects &= 0xF000; // mask off just a couple effects
             if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000) {
                 self->facingLeft = 0;
                 self->velocityX += 0x400;
             }
-            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_1000) {
+            if (tempEffects ==
+                EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_1000) {
                 self->facingLeft = 0;
                 self->velocityX += 0x300;
             }
-            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_2000) {
+            if (tempEffects ==
+                EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_2000) {
                 self->facingLeft = 0;
                 self->velocityX += 0x200;
             }
@@ -185,7 +186,7 @@ s32 func_ptr_80170014(Entity* self) {
             if (self->velocityX < FIX(-1)) {
                 self->velocityX = FIX(-1);
             }
-            
+
             if (!(tempEffects & EFFECT_UNK_8000)) {
                 if (self->velocityX < 0) {
                     xShift = -5;
@@ -206,7 +207,7 @@ s32 func_ptr_80170014(Entity* self) {
                         self->posX.i.hi += collider.unk4;
                     }
                 }
-                DecelerateX(FIX(1.0/128));
+                DecelerateX(FIX(1.0 / 128));
             }
         } else {
             self->step = 1;

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -37,7 +37,198 @@ INCLUDE_ASM("weapon/nonmatchings/w_016", func_ptr_8017000C);
 
 INCLUDE_ASM("weapon/nonmatchings/w_016", func_ptr_80170010);
 
-INCLUDE_ASM("weapon/nonmatchings/w_016", func_ptr_80170014);
+extern SpriteParts D_74000_8017A040;
+
+s32 func_ptr_80170014(Entity* self) {
+    Collider collider;
+    s16 collX;
+    s16 collY;
+    u16 tempEffects;
+    s16 xShift;
+    s16 yShift;
+    
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(&D_74000_8017A040);
+        self->animSet = ANIMSET_OVL(0x10);
+        self->unk5A = 100;
+        self->palette = 0x11D;
+        if (g_HandId != 0) {
+            self->palette = 0x135;
+            self->unk5A += 2;
+            self->animSet += 2;
+        }
+        self->animCurFrame = 17;
+        self->facingLeft = PLAYER.facingLeft;
+        self->zPriority = PLAYER.zPriority - 2;
+        self->flags = FLAG_UNK_08000000;
+        self->velocityY = FIX(-2.25) - (rand() & 0x7FFF); // -2.5 +- 0.25
+        SetSpeedX((rand() & 0x7FFF) + FIX(1.25)); // 1.5 +- 0.25
+        self->posY.i.hi = PLAYER.posY.i.hi + PLAYER.hitboxOffY;
+        SetWeaponProperties(self, 0);
+        DestroyEntityWeapon(true);
+        self->hitboxHeight = self->hitboxWidth = 8;
+        g_api.PlaySfx(0x6EE);
+        self->ext.weapon.unk7E = 0x40;
+        g_Player.D_80072F00[10] = 4;
+        self->step++;
+        return;
+    case 1:
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        if (self->velocityY < FIX(7)) {
+            self->velocityY += FIX(0.125);
+        }
+        if (self->velocityX < 0) {
+            xShift = -5;
+        } else {
+            xShift = 5;
+        }
+        collX = xShift + self->posX.i.hi;
+        collY = self->posY.i.hi;
+        g_api.CheckCollision(collX, collY, &collider, 0);
+        if (collider.effects & EFFECT_UNK_0002) {
+            g_api.PlaySfx(0x655);
+            g_api.func_80102CD8(4);
+            if (xShift < 0) {
+                self->posX.i.hi += collider.unkC;
+            } else {
+                self->posX.i.hi += collider.unk4;
+            }
+            self->velocityX /= - 2;
+            self->facingLeft = (self->facingLeft + 1) & 1;
+        }
+        collX = self->posX.i.hi;
+        collY = self->posY.i.hi - 6;
+        g_api.CheckCollision(collX, collY, &collider, 0);
+        if (collider.effects & EFFECT_SOLID) {
+            g_api.PlaySfx(0x655);
+            g_api.func_80102CD8(4);
+            self->posY.i.hi += collider.unk20 + 1;
+            self->velocityX /= 2;
+            self->velocityY = FIX(1);
+        }
+        collX = self->posX.i.hi;
+        collY = self->posY.i.hi + 7;
+        g_api.CheckCollision(collX, collY, &collider, 0);
+        if (collider.effects & EFFECT_SOLID) {
+            g_api.PlaySfx(0x655);
+            g_api.func_80102CD8(4);
+            self->posY.i.hi += collider.unk18;
+            if (self->ext.weapon.lifetime != 0) {
+                self->step++;
+            }
+            self->velocityY = FIX(-1.125);
+            self->velocityX /= 2;
+            self->ext.weapon.lifetime++;
+            // Create factory with blueprint 31. Blueprint 31 has child entity 2, 
+            // which is func_8011B5A4.
+            g_api.CreateEntFactoryFromEntity(self, FACTORY(0x900,31), 0);
+        }
+        return;
+    case 2:
+        if (self->velocityX == 0) {
+            if (--self->ext.weapon.unk7E == 0) {
+                self->step = 3;
+                self->ext.weapon.unk7E = 0x20;
+                self->drawFlags = FLAG_DRAW_UNK80;
+            }
+        }
+        collX = self->posX.i.hi;
+        collY = self->posY.i.hi + 11;
+        g_api.CheckCollision(collX, collY, &collider, 0);
+        tempEffects = collider.effects;
+        if (tempEffects & 1) {
+            yShift = collider.unk18 + 4;
+            collY = collY + yShift - 5;
+            g_api.CheckCollision(collX, collY, &collider, 0);
+            if (!(collider.effects & EFFECT_SOLID)) {
+                self->posY.i.hi = yShift + self->posY.i.hi;
+            }
+            else if (!(collider.effects & EFFECT_UNK_8000)) {
+                self->step = 1;
+                self->velocityY = 0;
+                self->hitboxWidth = 8;
+                return;
+            } else {
+                self->posY.i.hi += 3 + (yShift + collider.unk18);
+                tempEffects = collider.effects;
+            }
+            tempEffects &= 0xF000; //mask off just a couple effects
+            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000) {
+                self->facingLeft = 0;
+                self->velocityX += 0x400;
+            }
+            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_1000) {
+                self->facingLeft = 0;
+                self->velocityX += 0x300;
+            }
+            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_4000 + EFFECT_UNK_2000) {
+                self->facingLeft = 0;
+                self->velocityX += 0x200;
+            }
+            if (tempEffects == EFFECT_UNK_8000) {
+                self->facingLeft = 1;
+                self->velocityX -= 0x400;
+            }
+            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_1000) {
+                self->facingLeft = 1;
+                self->velocityX -= 0x300;
+            }
+            if (tempEffects == EFFECT_UNK_8000 + EFFECT_UNK_2000) {
+                self->facingLeft = 1;
+                self->velocityX -= 0x200;
+            }
+            if (self->velocityX > FIX(1)) {
+                self->velocityX = FIX(1);
+            }
+            if (self->velocityX < FIX(-1)) {
+                self->velocityX = FIX(-1);
+            }
+            
+            if (!(tempEffects & EFFECT_UNK_8000)) {
+                if (self->velocityX < 0) {
+                    xShift = -5;
+                } else {
+                    xShift = 5;
+                }
+                collX = xShift + self->posX.i.hi;
+                collY = self->posY.i.hi;
+                g_api.CheckCollision(collX, collY, &collider, 0);
+                if (collider.effects & EFFECT_UNK_0002) {
+                    if (self->velocityX != 0) {
+                        g_api.PlaySfx(0x655);
+                        g_api.func_80102CD8(1);
+                    }
+                    if (xShift < 0) {
+                        self->posX.i.hi += collider.unkC;
+                    } else {
+                        self->posX.i.hi += collider.unk4;
+                    }
+                }
+                DecelerateX(FIX(1.0/128));
+            }
+        } else {
+            self->step = 1;
+            self->velocityY = 0;
+            self->hitboxWidth = 4;
+        }
+        self->posX.val += self->velocityX;
+        if (ABS(self->velocityX) >= FIX(0.5)) {
+            self->hitboxWidth = 8;
+            return;
+        }
+        self->hitboxWidth = 0;
+        return;
+    case 3:
+        if (--self->ext.weapon.unk7E == 0) {
+            DestroyEntity(self);
+        }
+        break;
+    case 4:
+        break;
+    }
+}
 
 int GetWeaponId(void) { return 16; }
 

--- a/src/weapon/w_017.c
+++ b/src/weapon/w_017.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 17; }
 

--- a/src/weapon/w_018.c
+++ b/src/weapon/w_018.c
@@ -36,7 +36,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 18; }
 

--- a/src/weapon/w_019.c
+++ b/src/weapon/w_019.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 19; }
 

--- a/src/weapon/w_020.c
+++ b/src/weapon/w_020.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 20; }
 

--- a/src/weapon/w_021.c
+++ b/src/weapon/w_021.c
@@ -22,7 +22,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 21; }
 

--- a/src/weapon/w_022.c
+++ b/src/weapon/w_022.c
@@ -54,7 +54,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 22; }
 

--- a/src/weapon/w_023.c
+++ b/src/weapon/w_023.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 23; }
 

--- a/src/weapon/w_024.c
+++ b/src/weapon/w_024.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 24; }
 

--- a/src/weapon/w_025.c
+++ b/src/weapon/w_025.c
@@ -22,7 +22,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 25; }
 

--- a/src/weapon/w_026.c
+++ b/src/weapon/w_026.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 26; }
 

--- a/src/weapon/w_027.c
+++ b/src/weapon/w_027.c
@@ -37,7 +37,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 27; }
 

--- a/src/weapon/w_028.c
+++ b/src/weapon/w_028.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 28; }
 

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -195,7 +195,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 29; }
 

--- a/src/weapon/w_030.c
+++ b/src/weapon/w_030.c
@@ -13,7 +13,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_030", func_ptr_8017000C);
 
 INCLUDE_ASM("weapon/nonmatchings/w_030", func_ptr_80170010);
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 30; }
 

--- a/src/weapon/w_031.c
+++ b/src/weapon/w_031.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 31; }
 

--- a/src/weapon/w_032.c
+++ b/src/weapon/w_032.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 32; }
 

--- a/src/weapon/w_033.c
+++ b/src/weapon/w_033.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 33; }
 

--- a/src/weapon/w_034.c
+++ b/src/weapon/w_034.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 34; }
 

--- a/src/weapon/w_035.c
+++ b/src/weapon/w_035.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 35; }
 

--- a/src/weapon/w_036.c
+++ b/src/weapon/w_036.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 36; }
 

--- a/src/weapon/w_037.c
+++ b/src/weapon/w_037.c
@@ -19,7 +19,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 37; }
 

--- a/src/weapon/w_038.c
+++ b/src/weapon/w_038.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 38; }
 

--- a/src/weapon/w_039.c
+++ b/src/weapon/w_039.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 39; }
 

--- a/src/weapon/w_040.c
+++ b/src/weapon/w_040.c
@@ -234,7 +234,7 @@ void func_ptr_8017000C(Entity* self) {
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 40; }
 

--- a/src/weapon/w_041.c
+++ b/src/weapon/w_041.c
@@ -30,7 +30,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 41; }
 

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -293,7 +293,7 @@ void func_ptr_8017000C(Entity* self) {
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 42; }
 

--- a/src/weapon/w_043.c
+++ b/src/weapon/w_043.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 43; }
 

--- a/src/weapon/w_044.c
+++ b/src/weapon/w_044.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 44; }
 

--- a/src/weapon/w_045.c
+++ b/src/weapon/w_045.c
@@ -43,7 +43,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_045", func_ptr_8017000C);
 
 INCLUDE_ASM("weapon/nonmatchings/w_045", func_ptr_80170010);
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 45; }
 

--- a/src/weapon/w_046.c
+++ b/src/weapon/w_046.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 46; }
 

--- a/src/weapon/w_047.c
+++ b/src/weapon/w_047.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 47; }
 

--- a/src/weapon/w_048.c
+++ b/src/weapon/w_048.c
@@ -15,7 +15,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 48; }
 

--- a/src/weapon/w_049.c
+++ b/src/weapon/w_049.c
@@ -18,7 +18,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_049", func_ptr_80170010);
 extern SpriteParts D_15B000_8017AA44[];
 extern AnimationFrame D_15B000_8017B10C[];
 
-void func_ptr_80170014(Entity* self) {
+s32 func_ptr_80170014(Entity* self) {
     switch (self->step) {
     case 0:
         SetSpriteBank2(D_15B000_8017AA44);

--- a/src/weapon/w_050.c
+++ b/src/weapon/w_050.c
@@ -19,7 +19,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_050", func_ptr_8017000C);
 
 INCLUDE_ASM("weapon/nonmatchings/w_050", func_ptr_80170010);
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 50; }
 

--- a/src/weapon/w_051.c
+++ b/src/weapon/w_051.c
@@ -561,7 +561,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 51; }
 

--- a/src/weapon/w_052.c
+++ b/src/weapon/w_052.c
@@ -11,7 +11,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 52; }
 

--- a/src/weapon/w_053.c
+++ b/src/weapon/w_053.c
@@ -14,7 +14,7 @@ INCLUDE_ASM("weapon/nonmatchings/w_053", func_ptr_8017000C);
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 53; }
 

--- a/src/weapon/w_054.c
+++ b/src/weapon/w_054.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 54; }
 

--- a/src/weapon/w_055.c
+++ b/src/weapon/w_055.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 55; }
 

--- a/src/weapon/w_056.c
+++ b/src/weapon/w_056.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 56; }
 

--- a/src/weapon/w_057.c
+++ b/src/weapon/w_057.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 s32 GetWeaponId(void) { return 0; }
 

--- a/src/weapon/w_058.c
+++ b/src/weapon/w_058.c
@@ -13,7 +13,7 @@ void func_ptr_8017000C(Entity* self) {}
 
 void func_ptr_80170010(Entity* self) {}
 
-void func_ptr_80170014(Entity* self) {}
+s32 func_ptr_80170014(Entity* self) {}
 
 s32 GetWeaponId(void) { return 52; }
 

--- a/src/weapon/weapon_private.h
+++ b/src/weapon/weapon_private.h
@@ -21,7 +21,7 @@ void func_ptr_80170004(Entity* self);
 void func_ptr_80170008(Entity* self);
 void func_ptr_8017000C(Entity* self);
 void func_ptr_80170010(Entity* self);
-void func_ptr_80170014(Entity* self);
+s32 func_ptr_80170014(Entity* self);
 int GetWeaponId(void);
 void EntityWeaponShieldSpell(Entity* self);
 void func_ptr_80170024(Entity* self);


### PR DESCRIPTION
This is the last of the weapons using func_ptr_80170014. It needs a non-void return type in order to match, so we also had to change the type for all the other instances so we don't get issues with declaration mismatches.