### PR TITLE
Decompile weapon 16 EntityWeaponAttack

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -590,6 +590,52 @@ typedef struct {
     s8 hitboxHeight;
 } FrameProperty;
 
+typedef enum {
+    Player_Stand,
+    Player_Walk,
+    Player_Crouch,
+    Player_Fall,
+    Player_Jump,
+    Player_MorphBat,
+    Player_AlucardStuck,
+    Player_MorphMist,
+    Player_HighJump,
+    Player_UnmorphBat,
+    Player_Hit,
+    Player_StatusStone,
+    Player_BossGrab, // Darkwing Bat and Akmodan II
+    Player_KillWater,
+    Player_UnmorphMist,
+    Player_SwordWarp, // Alucard Sword and Osafune Katana
+    Player_Kill,
+    Player_Unk17,
+    Player_Teleport, // also Grand Cross and Spiral Axe
+    Player_FlameWhip,
+    Player_Hydrostorm,
+    Player_ThousandBlades,
+    Player_RichterFourHolyBeasts,
+    Player_Slide,
+    Player_MorphWolf,
+    Player_UnmorphWolf,
+    Player_SlideKick,
+    Player_Unk27, // other item crashes
+    Player_SpellDarkMetamorphosis = 32,
+    Player_SpellSummonSpirit,
+    Player_SpellHellfire,
+    Player_SpellTetraSpirit,
+    Player_Spell36,
+    Player_SpellSoulSteal,
+    Player_Unk38,
+    Player_SpellSwordBrothers,
+    Player_AxearmorStand,
+    Player_AxearmorWalk,
+    Player_AxearmorJump,
+    Player_AxearmorHit,
+    Player_Unk48 = 48,
+    Player_Unk49,
+    Player_Unk50
+} PlayerSteps;
+
 typedef struct Entity {
     /* 0x00 */ f32 posX;
     /* 0x04 */ f32 posY;

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -188,52 +188,6 @@ typedef enum {
 } EntityIDs;
 
 typedef enum {
-    Player_Stand,
-    Player_Walk,
-    Player_Crouch,
-    Player_Fall,
-    Player_Jump,
-    Player_MorphBat,
-    Player_AlucardStuck,
-    Player_MorphMist,
-    Player_HighJump,
-    Player_UnmorphBat,
-    Player_Hit,
-    Player_StatusStone,
-    Player_BossGrab, // Darkwing Bat and Akmodan II
-    Player_KillWater,
-    Player_UnmorphMist,
-    Player_SwordWarp, // Alucard Sword and Osafune Katana
-    Player_Kill,
-    Player_Unk17,
-    Player_Teleport, // also Grand Cross and Spiral Axe
-    Player_FlameWhip,
-    Player_Hydrostorm,
-    Player_ThousandBlades,
-    Player_RichterFourHolyBeasts,
-    Player_Slide,
-    Player_MorphWolf,
-    Player_UnmorphWolf,
-    Player_SlideKick,
-    Player_Unk27, // other item crashes
-    Player_SpellDarkMetamorphosis = 32,
-    Player_SpellSummonSpirit,
-    Player_SpellHellfire,
-    Player_SpellTetraSpirit,
-    Player_Spell36,
-    Player_SpellSoulSteal,
-    Player_Unk38,
-    Player_SpellSwordBrothers,
-    Player_AxearmorStand,
-    Player_AxearmorWalk,
-    Player_AxearmorJump,
-    Player_AxearmorHit,
-    Player_Unk48 = 48,
-    Player_Unk49,
-    Player_Unk50
-} PlayerSteps;
-
-typedef enum {
     STATUS_AILMENT_POISON,
     STATUS_AILMENT_CURSE,
     STATUS_AILMENT_PETRIFIED,

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -8,48 +8,10 @@ typedef enum {
     E_ENTITYFACTORY,
 } EntityIDs;
 
-typedef enum {
-    Player_Stand,
-    Player_Walk,
-    Player_Crouch,
-    Player_Fall,
-    Player_Jump,
-    Player_MorphBat,
-    Player_AlucardStuck,
-    Player_MorphMist,
-    Player_HighJump,
-    Player_UnmorphBat,
-    Player_Hit,
-    Player_StatusStone,
-    Player_BossGrab, // Darkwing Bat and Akmodan II
-    Player_KillWater,
-    Player_UnmorphMist,
-    Player_SwordWarp, // Alucard Sword and Osafune Katana
-    Player_Kill,
-    Player_Unk17,
-    Player_Teleport, // also Grand Cross and Spiral Axe
-    Player_FlameWhip,
-    Player_Hydrostorm,
-    Player_ThousandBlades,
-    Player_RichterFourHolyBeasts,
-    Player_Slide,
-    Player_RichterTackle,
-    Player_RichterSprint,
-    Player_SlideKick,
-    Player_Unk27, // other item crashes
-    Player_SpellDarkMetamorphosis = 32,
-    Player_SpellSummonSpirit,
-    Player_SpellHellfire,
-    Player_SpellTetraSpirit,
-    Player_Spell36,
-    Player_SpellSoulSteal,
-    Player_Unk38,
-    Player_SpellSwordBrothers,
-    Player_AxearmorStand,
-    Player_AxearmorWalk,
-    Player_AxearmorJump,
-    Player_AxearmorHit,
-} PlayerSteps;
+// Richter mostly uses the same steps as Alucard, or uses unused Alucard steps.
+// There are a couple steps that mean one thing for Alucard, and another for
+// Richter. This enum handles Richter's version of the ones that overlap.
+typedef enum { Player_RichterSprint = 25 } Richter_PlayerSteps;
 
 extern SpriteParts* D_801530AC[];
 extern SpriteParts* D_80153AA0[];


### PR DESCRIPTION
This is mostly just another weapon function.

However, because this references PLAYER.step, we want to use the PlayerSteps enum. This enum is in `dra.h` and therefore inaccessible to weapon functions.

I ran into this problem a while ago dealing with ric.h not having access to the steps, and just duplicated PlayerSteps. Now that we have a third place, we instead move PlayerSteps to `game.h`, and adjust `ric.h` to only use the steps that we need to override. This seems like the most sustainable solution.