### PR TITLE
Decompile `libgs` Wrappers

### DIFF
--- a/include/psxsdk/libapi.h
+++ b/include/psxsdk/libapi.h
@@ -82,5 +82,8 @@ extern long EnableEvent(long);
 extern void _96_remove(void);
 extern long SetRCnt(unsigned long, unsigned short, long);
 extern long StartRCnt(unsigned long);
+extern long GetRCnt(unsigned long);
+extern long StopRCnt(unsigned long);
+extern long ResetRCnt(unsigned long);
 
 #endif

--- a/src/main/psxsdk/libgs/gs_007.c
+++ b/src/main/psxsdk/libgs/gs_007.c
@@ -1,3 +1,7 @@
 #include "common.h"
+#include "kernel.h"
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_007", GsInitVcount);
+void GsInitVcount(void) {
+    SetRCnt(RCntCNT1, 0xFFFFU, RCntMdNOINTR);
+    StartRCnt(RCntCNT1);
+}

--- a/src/main/psxsdk/libgs/gs_008.c
+++ b/src/main/psxsdk/libgs/gs_008.c
@@ -1,3 +1,4 @@
 #include "common.h"
+#include "kernel.h"
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_008", GsGetVcount);
+long GsGetVcount() { return GetRCnt(RCntCNT1); }

--- a/src/main/psxsdk/libgs/gs_009.c
+++ b/src/main/psxsdk/libgs/gs_009.c
@@ -1,3 +1,4 @@
 #include "common.h"
+#include "kernel.h"
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgs/gs_009", GsClearVcount);
+void GsClearVcount() { return ResetRCnt(RCntCNT1); }


### PR DESCRIPTION
`GsInitVcount`, `GsGetVcount`, `GsClearVcount` were all small wrappers around calls to respective root counter functions using the vsync counter spec. This provides implementations for all, replacing the previous ASM imports.