### PR TITLE
Decompile weapon 37 helper 8017ADF8

### DIFF
--- a/src/weapon/w_037.c
+++ b/src/weapon/w_037.c
@@ -5,7 +5,55 @@
 
 INCLUDE_ASM("weapon/nonmatchings/w_037", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_037", func_107000_8017ADF8);
+extern u8 D_107000_8017A6E4[6][8];
+
+s32 func_107000_8017ADF8(Primitive* prim, s32 x, s32 y) {
+    s32 size;
+    s32 left;
+    s32 right;
+    s32 top;
+    s32 bottom;
+    u8* uvPtr;
+
+    // Should be able to do this as an array access but nope
+    uvPtr = &D_107000_8017A6E4;
+    uvPtr += prim->b0 * 8;
+    
+    if (prim->b0 >= 3) {
+        size = 4;
+    } else {
+        size = 6;
+    }
+    if (prim->b0 == 6) {
+        return -1;
+    }
+    left = x - size;
+    top = y - size;
+    right = x + size;
+    bottom = y + size;
+    
+    prim->x0 = left;
+    prim->y0 = top;
+    prim->x1 = right;
+    prim->y1 = top;
+    prim->x2 = left;
+    prim->y2 = bottom;
+    prim->x3 = right;
+    prim->y3 = bottom;
+    
+    prim->u0 = *uvPtr++;
+    prim->v0 = *uvPtr++;
+    prim->u1 = *uvPtr++;
+    prim->v1 = *uvPtr++;
+    prim->u2 = *uvPtr++;
+    prim->v2 = *uvPtr++;
+    prim->u3 = *uvPtr++;
+    prim->v3 = *uvPtr++;
+    if (!(++prim->b1 & 1)) {
+        prim->b0++;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_037", func_107000_8017AEF0);
 

--- a/src/weapon/w_037.c
+++ b/src/weapon/w_037.c
@@ -18,7 +18,7 @@ s32 func_107000_8017ADF8(Primitive* prim, s32 x, s32 y) {
     // Should be able to do this as an array access but nope
     uvPtr = &D_107000_8017A6E4;
     uvPtr += prim->b0 * 8;
-    
+
     if (prim->b0 >= 3) {
         size = 4;
     } else {
@@ -31,7 +31,7 @@ s32 func_107000_8017ADF8(Primitive* prim, s32 x, s32 y) {
     top = y - size;
     right = x + size;
     bottom = y + size;
-    
+
     prim->x0 = left;
     prim->y0 = top;
     prim->x1 = right;
@@ -40,7 +40,7 @@ s32 func_107000_8017ADF8(Primitive* prim, s32 x, s32 y) {
     prim->y2 = bottom;
     prim->x3 = right;
     prim->y3 = bottom;
-    
+
     prim->u0 = *uvPtr++;
     prim->v0 = *uvPtr++;
     prim->u1 = *uvPtr++;


### PR DESCRIPTION
Not really certain what this one does. Given that weapon 37 is for the short sword and jewel sword, I wonder if it's related to the colorful particles that come out when you swing the jewel sword. I'm sure we'll learn more as we decompile the other functions in the overlay.