### PR TITLE
Decompile duplicates of weapon helper

### DIFF
--- a/src/weapon/w_037.c
+++ b/src/weapon/w_037.c
@@ -55,9 +55,34 @@ s32 func_107000_8017ADF8(Primitive* prim, s32 x, s32 y) {
     return 0;
 }
 
-INCLUDE_ASM("weapon/nonmatchings/w_037", func_107000_8017AEF0);
-
 extern s16 D_107000_8017A714[];
+
+void func_107000_8017AEF0(Entity* ent, Point16* outPoint, bool arg2) {
+    s32 idx;
+
+    idx = PLAYER.ext.player.unkAC - 0xA7;
+    if (PLAYER.facingLeft) {
+        ent->posX.i.hi = PLAYER.posX.i.hi - D_107000_8017A714[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = -(D_107000_8017A714[idx * 4 + 2] * 3 / 4);
+        } else {
+            outPoint->x = -(D_107000_8017A714[idx * 4 + 2] * 2 / 3);
+        }
+    } else {
+        ent->posX.i.hi = PLAYER.posX.i.hi + D_107000_8017A714[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = D_107000_8017A714[idx * 4 + 2] * 3 / 4;
+        } else {
+            outPoint->x = D_107000_8017A714[idx * 4 + 2] * 2 / 3;
+        }
+    }
+    ent->posY.i.hi = PLAYER.posY.i.hi + D_107000_8017A714[idx * 4 + 1];
+    if (arg2) {
+        outPoint->y = D_107000_8017A714[idx * 4 + 3] * 3 / 4;
+    } else {
+        outPoint->y = D_107000_8017A714[idx * 4 + 3] * 2 / 3;
+    }
+}
 
 void func_107000_8017B0AC(Entity* ent, Point16* outPoint, bool arg2) {
     s32 idx;
@@ -66,9 +91,9 @@ void func_107000_8017B0AC(Entity* ent, Point16* outPoint, bool arg2) {
     if (PLAYER.facingLeft) {
         ent->posX.i.hi = PLAYER.posX.i.hi - D_107000_8017A714[idx * 4 + 0];
         if (arg2) {
-            outPoint->x = D_107000_8017A714[idx * 4 + 2] * 3 / -4;
+            outPoint->x = -(D_107000_8017A714[idx * 4 + 2] * 3 / 4);
         } else {
-            outPoint->x = D_107000_8017A714[idx * 4 + 2] / -2;
+            outPoint->x = -(D_107000_8017A714[idx * 4 + 2] / 2);
         }
     } else {
         ent->posX.i.hi = PLAYER.posX.i.hi + D_107000_8017A714[idx * 4 + 0];

--- a/src/weapon/w_048.c
+++ b/src/weapon/w_048.c
@@ -5,7 +5,34 @@
 
 INCLUDE_ASM("weapon/nonmatchings/w_048", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_048", func_154000_8017B810);
+extern s16 D_154000_8017B000[];
+
+void func_154000_8017B810(Entity* ent, Point16* outPoint, bool arg2) {
+    s32 idx;
+
+    idx = PLAYER.ext.player.unkAC - 0x41;
+    if (PLAYER.facingLeft) {
+        ent->posX.i.hi = PLAYER.posX.i.hi - D_154000_8017B000[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = -(D_154000_8017B000[idx * 4 + 2] / 2);
+        } else {
+            outPoint->x = -(D_154000_8017B000[idx * 4 + 2]);
+        }
+    } else {
+        ent->posX.i.hi = PLAYER.posX.i.hi + D_154000_8017B000[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = D_154000_8017B000[idx * 4 + 2] / 2;
+        } else {
+            outPoint->x = D_154000_8017B000[idx * 4 + 2];
+        }
+    }
+    ent->posY.i.hi = PLAYER.posY.i.hi + D_154000_8017B000[idx * 4 + 1];
+    if (arg2) {
+        outPoint->y = D_154000_8017B000[idx * 4 + 3] / 2;
+    } else {
+        outPoint->y = D_154000_8017B000[idx * 4 + 3];
+    }
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_048", func_ptr_80170004);
 

--- a/src/weapon/w_049.c
+++ b/src/weapon/w_049.c
@@ -5,7 +5,34 @@
 
 INCLUDE_ASM("weapon/nonmatchings/w_049", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_049", func_15B000_8017B88C);
+extern s16 D_15B000_8017B03C[];
+
+void func_15B000_8017B88C(Entity* ent, Point16* outPoint, bool arg2) {
+    s32 idx;
+
+    idx = PLAYER.ext.player.unkAC - 0x41;
+    if (PLAYER.facingLeft) {
+        ent->posX.i.hi = PLAYER.posX.i.hi - D_15B000_8017B03C[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = -(D_15B000_8017B03C[idx * 4 + 2] * 3 / 4);
+        } else {
+            outPoint->x = -(D_15B000_8017B03C[idx * 4 + 2] * 2 / 3);
+        }
+    } else {
+        ent->posX.i.hi = PLAYER.posX.i.hi + D_15B000_8017B03C[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = D_15B000_8017B03C[idx * 4 + 2] * 3 / 4;
+        } else {
+            outPoint->x = D_15B000_8017B03C[idx * 4 + 2] * 2 / 3;
+        }
+    }
+    ent->posY.i.hi = PLAYER.posY.i.hi + D_15B000_8017B03C[idx * 4 + 1];
+    if (arg2) {
+        outPoint->y = D_15B000_8017B03C[idx * 4 + 3] * 3 / 4;
+    } else {
+        outPoint->y = D_15B000_8017B03C[idx * 4 + 3] * 2 / 3;
+    }
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_049", func_ptr_80170004);
 

--- a/src/weapon/w_050.c
+++ b/src/weapon/w_050.c
@@ -7,9 +7,61 @@ INCLUDE_ASM("weapon/nonmatchings/w_050", EntityWeaponAttack);
 
 INCLUDE_ASM("weapon/nonmatchings/w_050", func_162000_8017B784);
 
-INCLUDE_ASM("weapon/nonmatchings/w_050", func_162000_8017B87C);
+extern s16 D_162000_8017B030[];
 
-INCLUDE_ASM("weapon/nonmatchings/w_050", func_162000_8017BA38);
+void func_162000_8017B87C(Entity* ent, Point16* outPoint, bool arg2) {
+    s32 idx;
+
+    idx = PLAYER.ext.player.unkAC - 0x41;
+    if (PLAYER.facingLeft) {
+        ent->posX.i.hi = PLAYER.posX.i.hi - D_162000_8017B030[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = -(D_162000_8017B030[idx * 4 + 2] * 3 / 4);
+        } else {
+            outPoint->x = -(D_162000_8017B030[idx * 4 + 2] * 2 / 3);
+        }
+    } else {
+        ent->posX.i.hi = PLAYER.posX.i.hi + D_162000_8017B030[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = D_162000_8017B030[idx * 4 + 2] * 3 / 4;
+        } else {
+            outPoint->x = D_162000_8017B030[idx * 4 + 2] * 2 / 3;
+        }
+    }
+    ent->posY.i.hi = PLAYER.posY.i.hi + D_162000_8017B030[idx * 4 + 1];
+    if (arg2) {
+        outPoint->y = D_162000_8017B030[idx * 4 + 3] * 3 / 4;
+    } else {
+        outPoint->y = D_162000_8017B030[idx * 4 + 3] * 2 / 3;
+    }
+}
+
+void func_162000_8017BA38(Entity* ent, Point16* outPoint, bool arg2) {
+    s32 idx;
+
+    idx = PLAYER.ext.player.unkAC - 0x41;
+    if (PLAYER.facingLeft) {
+        ent->posX.i.hi = PLAYER.posX.i.hi - D_162000_8017B030[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = -(D_162000_8017B030[idx * 4 + 2] * 3 / 4);
+        } else {
+            outPoint->x = -(D_162000_8017B030[idx * 4 + 2] / 2);
+        }
+    } else {
+        ent->posX.i.hi = PLAYER.posX.i.hi + D_162000_8017B030[idx * 4 + 0];
+        if (arg2) {
+            outPoint->x = D_162000_8017B030[idx * 4 + 2] * 3 / 4;
+        } else {
+            outPoint->x = D_162000_8017B030[idx * 4 + 2] / 2;
+        }
+    }
+    ent->posY.i.hi = PLAYER.posY.i.hi + D_162000_8017B030[idx * 4 + 1];
+    if (arg2) {
+        outPoint->y = D_162000_8017B030[idx * 4 + 3] * 3 / 4;
+    } else {
+        outPoint->y = D_162000_8017B030[idx * 4 + 3] / 2;
+    }
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_050", func_ptr_80170004);
 


### PR DESCRIPTION
After decompiling `func_107000_8017B0AC`, I moved on to more weapon helper functions, and was surprised to find several more copies of nearly identical functions. The only difference between these is the fractional constants applied to the outPoint results (for example, some use 2/3, others use 3/4, and others still use 1/2).

Given the fact that these are all substantially the same, we could probably do some de-duplicating by pulling in a header file, but for now I'm decompiling each one in place, so that we can have all the functions done.

I believe this is all of the ones that match this structure; hopefully I didn't miss any!