### PR TITLE
Shared `CollectHeartVessel` Implementation

### DIFF
--- a/config/symbols.us.stcen.txt
+++ b/config/symbols.us.stcen.txt
@@ -39,6 +39,7 @@ InitializeEntity = 0x80194F74;
 CollectHeart = 0x801958F4;
 CollectGold = 0x80195974;
 CollectSubweapon = 0x80195A50;
+CollectHeartVessel = 0x80195B68;
 EntityPrizeDrop = 0x80195C84;
 EntityExplosion = 0x801964F8;
 BlinkItem = 0x801965F4;

--- a/config/symbols.us.strwrp.txt
+++ b/config/symbols.us.strwrp.txt
@@ -30,6 +30,7 @@ EntityDummy = 0x8018E38C;
 CollectHeart = 0x8018EC10;
 CollectGold = 0x8018EC90;
 CollectSubweapon = 0x8018ED6C;
+CollectHeartVessel = 0x8018EE84;
 CollectLifeVessel = 0x8018EF28;
 DestroyCurrentEntity = 0x8018EF78;
 EntityPrizeDrop = 0x8018EFA0;

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -732,7 +732,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-INCLUDE_ASM("st/cen/nonmatchings/11280", func_80195B68);
+#include "../collect_heart_vessel.h"
 
 void func_80195C0C(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/collect_heart_vessel.h
+++ b/src/st/collect_heart_vessel.h
@@ -1,0 +1,14 @@
+void CollectHeartVessel(void) {
+    if (g_PlayableCharacter != PLAYER_ALUCARD) {
+        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
+        g_Status.hearts += HEART_VESSEL_RICHTER;
+
+        if (g_Status.heartsMax < g_Status.hearts) {
+            g_Status.hearts = g_Status.heartsMax;
+        }
+    } else {
+        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
+        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
+    }
+    DestroyEntity(g_CurrentEntity);
+}

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -802,20 +802,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-void CollectHeartVessel(void) {
-    if (g_PlayableCharacter != PLAYER_ALUCARD) {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_Status.hearts += HEART_VESSEL_RICHTER;
-
-        if (g_Status.heartsMax < g_Status.hearts) {
-            g_Status.hearts = g_Status.heartsMax;
-        }
-    } else {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
-    }
-    DestroyEntity(g_CurrentEntity);
-}
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -782,6 +782,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
+// Different from "collect_heart_vessel.h"
 void CollectHeartVessel(void) {
     g_api.PlaySfx(0x670);
     g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -838,20 +838,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-void CollectHeartVessel(void) {
-    if (g_PlayableCharacter != PLAYER_ALUCARD) {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_Status.hearts += HEART_VESSEL_RICHTER;
-
-        if (g_Status.heartsMax < g_Status.hearts) {
-            g_Status.hearts = g_Status.heartsMax;
-        }
-    } else {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
-    }
-    DestroyEntity(g_CurrentEntity);
-}
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -819,20 +819,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-void CollectHeartVessel(void) {
-    if (g_PlayableCharacter != PLAYER_ALUCARD) {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_Status.hearts += HEART_VESSEL_RICHTER;
-
-        if (g_Status.heartsMax < g_Status.hearts) {
-            g_Status.hearts = g_Status.heartsMax;
-        }
-    } else {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
-    }
-    DestroyEntity(g_CurrentEntity);
-}
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -835,20 +835,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-void CollectHeartVessel(void) {
-    if (g_PlayableCharacter != PLAYER_ALUCARD) {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_Status.hearts += HEART_VESSEL_RICHTER;
-
-        if (g_Status.heartsMax < g_Status.hearts) {
-            g_Status.hearts = g_Status.heartsMax;
-        }
-    } else {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
-    }
-    DestroyEntity(g_CurrentEntity);
-}
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -500,7 +500,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018EE84);
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api_PlaySfx(NA_SE_PL_COLLECT_HEART);

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -851,20 +851,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     DestroyEntity(g_CurrentEntity);
 }
 
-void CollectHeartVessel(void) {
-    if (g_PlayableCharacter != PLAYER_ALUCARD) {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_Status.hearts += HEART_VESSEL_RICHTER;
-
-        if (g_Status.heartsMax < g_Status.hearts) {
-            g_Status.hearts = g_Status.heartsMax;
-        }
-    } else {
-        g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);
-        g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
-    }
-    DestroyEntity(g_CurrentEntity);
-}
+#include "../collect_heart_vessel.h"
 
 void CollectLifeVessel(void) {
     g_api.PlaySfx(NA_SE_PL_COLLECT_HEART);


### PR DESCRIPTION
This follows the model of  #[`collect_hearts.h`](../blob/master/src/st/collect_heart.h) to reuse the `CollectHeartVessel` implementation across stages that use the same implementation.

This adds implementations for CEN and WRP as well.