### PR TITLE
Decompile duplicates of weapon primitive helper function

### DIFF
--- a/src/weapon/w_006.c
+++ b/src/weapon/w_006.c
@@ -7,7 +7,55 @@ INCLUDE_ASM("weapon/nonmatchings/w_006", EntityWeaponAttack);
 
 INCLUDE_ASM("weapon/nonmatchings/w_006", func_ptr_80170004);
 
-INCLUDE_ASM("weapon/nonmatchings/w_006", func_2E000_8017B6A0);
+extern u8 D_2E000_8017AC04[6][8];
+
+s32 func_2E000_8017B6A0(Primitive* prim, s32 x, s32 y) {
+    s32 size;
+    s32 left;
+    s32 right;
+    s32 top;
+    s32 bottom;
+    u8* uvPtr;
+
+    // Should be able to do this as an array access but nope
+    uvPtr = &D_2E000_8017AC04;
+    uvPtr += prim->b0 * 8;
+
+    if (prim->b0 >= 3) {
+        size = 4;
+    } else {
+        size = 6;
+    }
+    if (prim->b0 == 6) {
+        return -1;
+    }
+    left = x - size;
+    top = y - size;
+    right = x + size;
+    bottom = y + size;
+
+    prim->x0 = left;
+    prim->y0 = top;
+    prim->x1 = right;
+    prim->y1 = top;
+    prim->x2 = left;
+    prim->y2 = bottom;
+    prim->x3 = right;
+    prim->y3 = bottom;
+
+    prim->u0 = *uvPtr++;
+    prim->v0 = *uvPtr++;
+    prim->u1 = *uvPtr++;
+    prim->v1 = *uvPtr++;
+    prim->u2 = *uvPtr++;
+    prim->v2 = *uvPtr++;
+    prim->u3 = *uvPtr++;
+    prim->v3 = *uvPtr++;
+    if (!(++prim->b1 & 1)) {
+        prim->b0++;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_006", func_ptr_80170008);
 

--- a/src/weapon/w_007.c
+++ b/src/weapon/w_007.c
@@ -7,7 +7,55 @@ INCLUDE_ASM("weapon/nonmatchings/w_007", EntityWeaponAttack);
 
 INCLUDE_ASM("weapon/nonmatchings/w_007", func_ptr_80170004);
 
-INCLUDE_ASM("weapon/nonmatchings/w_007", func_35000_8017B604);
+extern u8 D_35000_8017AC64[6][8];
+
+s32 func_35000_8017B604(Primitive* prim, s32 x, s32 y) {
+    s32 size;
+    s32 left;
+    s32 right;
+    s32 top;
+    s32 bottom;
+    u8* uvPtr;
+
+    // Should be able to do this as an array access but nope
+    uvPtr = &D_35000_8017AC64;
+    uvPtr += prim->b0 * 8;
+
+    if (prim->b0 >= 3) {
+        size = 2;
+    } else {
+        size = 3;
+    }
+    if (prim->b0 == 6) {
+        return -1;
+    }
+    left = x - size;
+    top = y - size;
+    right = x + size;
+    bottom = y + size;
+
+    prim->x0 = left;
+    prim->y0 = top;
+    prim->x1 = right;
+    prim->y1 = top;
+    prim->x2 = left;
+    prim->y2 = bottom;
+    prim->x3 = right;
+    prim->y3 = bottom;
+
+    prim->u0 = *uvPtr++;
+    prim->v0 = *uvPtr++;
+    prim->u1 = *uvPtr++;
+    prim->v1 = *uvPtr++;
+    prim->u2 = *uvPtr++;
+    prim->v2 = *uvPtr++;
+    prim->u3 = *uvPtr++;
+    prim->v3 = *uvPtr++;
+    if (!(++prim->b1 & 1)) {
+        prim->b0++;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_007", func_ptr_80170008);
 

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -3,7 +3,55 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_013", func_5F000_8017A9CC);
+extern u8 D_5F000_8017A5B0[6][8];
+
+s32 func_5F000_8017A9CC(Primitive* prim, s32 x, s32 y) {
+    s32 size;
+    s32 left;
+    s32 right;
+    s32 top;
+    s32 bottom;
+    u8* uvPtr;
+
+    // Should be able to do this as an array access but nope
+    uvPtr = &D_5F000_8017A5B0;
+    uvPtr += prim->b0 * 8;
+
+    if (prim->b0 >= 3) {
+        size = 4;
+    } else {
+        size = 6;
+    }
+    if (prim->b0 == 6) {
+        return -1;
+    }
+    left = x - size;
+    top = y - size;
+    right = x + size;
+    bottom = y + size;
+
+    prim->x0 = left;
+    prim->y0 = top;
+    prim->x1 = right;
+    prim->y1 = top;
+    prim->x2 = left;
+    prim->y2 = bottom;
+    prim->x3 = right;
+    prim->y3 = bottom;
+
+    prim->u0 = *uvPtr++;
+    prim->v0 = *uvPtr++;
+    prim->u1 = *uvPtr++;
+    prim->v1 = *uvPtr++;
+    prim->u2 = *uvPtr++;
+    prim->v2 = *uvPtr++;
+    prim->u3 = *uvPtr++;
+    prim->v3 = *uvPtr++;
+    if (!(++prim->b1 & 1)) {
+        prim->b0++;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_013", EntityWeaponAttack);
 

--- a/src/weapon/w_050.c
+++ b/src/weapon/w_050.c
@@ -5,7 +5,55 @@
 
 INCLUDE_ASM("weapon/nonmatchings/w_050", EntityWeaponAttack);
 
-INCLUDE_ASM("weapon/nonmatchings/w_050", func_162000_8017B784);
+extern u8 D_162000_8017B000[6][8];
+
+s32 func_162000_8017B784(Primitive* prim, s32 x, s32 y) {
+    s32 size;
+    s32 left;
+    s32 right;
+    s32 top;
+    s32 bottom;
+    u8* uvPtr;
+
+    // Should be able to do this as an array access but nope
+    uvPtr = &D_162000_8017B000;
+    uvPtr += prim->b0 * 8;
+
+    if (prim->b0 >= 3) {
+        size = 4;
+    } else {
+        size = 6;
+    }
+    if (prim->b0 == 6) {
+        return -1;
+    }
+    left = x - size;
+    top = y - size;
+    right = x + size;
+    bottom = y + size;
+
+    prim->x0 = left;
+    prim->y0 = top;
+    prim->x1 = right;
+    prim->y1 = top;
+    prim->x2 = left;
+    prim->y2 = bottom;
+    prim->x3 = right;
+    prim->y3 = bottom;
+
+    prim->u0 = *uvPtr++;
+    prim->v0 = *uvPtr++;
+    prim->u1 = *uvPtr++;
+    prim->v1 = *uvPtr++;
+    prim->u2 = *uvPtr++;
+    prim->v2 = *uvPtr++;
+    prim->u3 = *uvPtr++;
+    prim->v3 = *uvPtr++;
+    if (!(++prim->b1 & 1)) {
+        prim->b0++;
+    }
+    return 0;
+}
 
 extern s16 D_162000_8017B030[];
 


### PR DESCRIPTION
`func_107000_8017ADF8` is already in the repo and decompiled. I found that there are several duplicates of this function, so this PR decompiles all of them.

The only difference between the copies is 1. The address of the data array, obviously and 2. the assignment to the `size` variable. Some duplicates use 4 and 6, others use 2 and 3. Otherwise they're exactly the same.

This is the only heavily-duplicated weapon helper function remaining. I have decompiled all of the helper functions (the ones that are unique to the weapon they're part of, rather than being in the standard structure like `func_ptr_801700XX`) and will be doing PRs for each of them in sequence.