### PR TITLE
Decompile pair of duplicated weapon helper functions

### DIFF
--- a/src/weapon/w_026.c
+++ b/src/weapon/w_026.c
@@ -17,7 +17,36 @@ s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 26; }
 
-INCLUDE_ASM("weapon/nonmatchings/w_026", func_BA000_8017B37C);
+extern s16 D_BA000_8017AA98;
+extern s16 D_BA000_8017AA9A;
+
+void func_BA000_8017B37C(void) {
+    RECT rect;
+    s16 temp;
+
+    if (D_BA000_8017AA9A & 1) {
+        if (++D_BA000_8017AA98 >= 0x20) {
+            D_BA000_8017AA9A++;
+            D_BA000_8017AA98 = 0x1F;
+        }
+    } else {
+        if (--D_BA000_8017AA98 < 0) {
+            D_BA000_8017AA9A++;
+            D_BA000_8017AA98 = 0;
+        }
+    }
+
+    temp = g_Clut[0x112D + g_HandId * 0x180];
+    temp &= 0xFC1F;
+    temp += D_BA000_8017AA98 << 5;
+    g_Clut[0x112D + g_HandId * 0x180] = temp;
+
+    rect.x = 0;
+    rect.y = 0xF1;
+    rect.w = 0x100;
+    rect.h = 3;
+    LoadImage(&rect, &g_Clut[0x1100]);
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_026", EntityWeaponShieldSpell);
 

--- a/src/weapon/w_028.c
+++ b/src/weapon/w_028.c
@@ -17,7 +17,36 @@ s32 func_ptr_80170014(Entity* self) {}
 
 int GetWeaponId(void) { return 28; }
 
-INCLUDE_ASM("weapon/nonmatchings/w_028", func_C8000_8017B3D4);
+extern s16 D_C8000_8017AB18;
+extern s16 D_C8000_8017AB1A;
+
+void func_C8000_8017B3D4(void) {
+    RECT rect;
+    s16 temp;
+
+    if (D_C8000_8017AB1A & 1) {
+        if (++D_C8000_8017AB18 >= 0x20) {
+            D_C8000_8017AB1A++;
+            D_C8000_8017AB18 = 0x1F;
+        }
+    } else {
+        if (--D_C8000_8017AB18 < 0) {
+            D_C8000_8017AB1A++;
+            D_C8000_8017AB18 = 0;
+        }
+    }
+
+    temp = g_Clut[0x113B + g_HandId * 0x180];
+    temp &= 0xFFE0;
+    temp += D_C8000_8017AB18;
+    g_Clut[0x113B + g_HandId * 0x180] = temp;
+
+    rect.x = 0;
+    rect.y = 0xF1;
+    rect.w = 0x100;
+    rect.h = 3;
+    LoadImage(&rect, &g_Clut[0x1100]);
+}
 
 INCLUDE_ASM("weapon/nonmatchings/w_028", EntityWeaponShieldSpell);
 


### PR DESCRIPTION
These two functions are extremely similar so I am doing them in one PR.

Not sure what they actually do, the call to LoadImage is a bit surprising. This is used for the Skull Shield and Shaman Shield; I don't know what they have in common.