### PR TITLE
Decompile CRN func_80193184

### DIFF
--- a/config/symbols.us.stcen.txt
+++ b/config/symbols.us.stcen.txt
@@ -24,6 +24,7 @@ UpdateStageEntities = 0x80191178;
 TestCollisions = 0x80191280;
 EntityNumericDamage = 0x80192398;
 CreateEntityWhenInHorizontalRange = 0x80192C18;
+CreateEntitiesToTheLeft = 0x80193184;
 InitRoomEntities = 0x80193298;
 CreateEntityFromEntity = 0x80193538;
 EntityIsNearPlayer = 0x801935B4;

--- a/include/stage.h
+++ b/include/stage.h
@@ -8,6 +8,9 @@
 #include "objects.h"
 #include "sfx.h"
 
+#define LAYOUT_OBJ_START 0xffff
+#define LAYOUT_OBJ_END 0xfffe
+
 typedef struct {
     /* 0x0 */ u16 posX;
     /* 0x2 */ u16 posY;

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -201,7 +201,33 @@ void func_80193088(s16 arg0) {
     }
 }
 
-INCLUDE_ASM("st/cen/nonmatchings/11280", func_80193184);
+void CreateEntitiesToTheLeft(s16 posY) {
+    u8 flag;
+    s32 expected;
+
+    if (posY < 0) {
+        posY = 0;
+    }
+
+    if (D_8019C770 == 0) {
+        func_80193030(posY - D_8009790C);
+        D_8019C770 = 1;
+    }
+
+    while (true) {
+        if (g_LayoutObjEnd->posY == LAYOUT_OBJ_END ||
+            posY > g_LayoutObjEnd->posY) {
+            return;
+        }
+        expected = 0;
+        flag = (g_LayoutObjEnd->entityRoomIndex >> 8) + 0xFF;
+        if ((flag == 0xFF) ||
+            (g_entityDestroyed[flag >> 5] & (1 << (flag & 0x1F))) == expected) {
+            CreateEntityWhenInHorizontalRange(g_LayoutObjEnd);
+        }
+        g_LayoutObjEnd--;
+    }
+}
 
 void InitRoomEntities(s32 objLayoutId) {
     u16* pObjLayoutStart = D_801801EC[objLayoutId];

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -85,6 +85,7 @@ extern ObjInit2 D_8018125C[];
 
 extern LayoutEntity* D_8019C764;
 extern u16* D_8019C768;
+#define g_LayoutObjEnd ((LayoutEntity*)D_8019C768)
 extern u8 D_8019C76C;
 extern s16 D_8019D37E;
 extern u16 D_8019D380;


### PR DESCRIPTION
This function appears to create all entities to the left of the provided horizontal position. It's implementation is shared across several stages but requires some refactoring to make it shareable.