### PR TITLE
Use built-in abs function

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -114,13 +114,11 @@ If a function returns only `0` or `1`, and is used as a boolean (i.e. in conditi
   Become familiar with the various defines and enums we have available.
 
 - Those in `macros.h`
-  - `ABS`, `ABS_ALT`,
   - `CLAMP` and friends.
 
 ## Arrays
 
 - It's better to not hardcode array sizes (easier to mod)
-- Use `sizeof` or `ARRAY_COUNT`/`ARRAY_COUNTU` where it makes sense, e.g. in loops that are using an array.
 - clang-format sometimes does weird things to array formatting. Experiment with and without a comma after the last element and see which looks better.
 
 ## Documentation and Comments

--- a/include/common.h
+++ b/include/common.h
@@ -20,14 +20,15 @@
 #endif
 
 #include "include_asm.h"
-#include "macros.h"
 #include "settings.h"
 #include "types.h"
 
 #define LEN(x) ((s32)(sizeof(x) / sizeof(*(x))))
-#define LENU(x) ((u32)(sizeof(x) / sizeof(*(x))))
 #define OFF(type, field) ((size_t)(&((type*)0)->field))
 #define STRCPY(dst, src) __builtin_memcpy(dst, src, sizeof(src))
+#define SQ(x) ((x) * (x))
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
+#define MAX(a, b) ((a) > (b) ? (b) : (a))
 
 #ifdef _MSC_VER
 #define __builtin_memcpy memcpy

--- a/include/game.h
+++ b/include/game.h
@@ -2,6 +2,7 @@
 #define GAME_H
 #include "common.h"
 #include "log.h"
+#include "macros.h"
 #include <psxsdk/kernel.h>
 
 // lseek etc. conflicts

--- a/include/macros.h
+++ b/include/macros.h
@@ -18,20 +18,3 @@ typedef enum {
 } EntityTypes;
 
 #define PLAYER g_Entities[PLAYER_CHARACTER]
-
-#define SQ(x) ((x) * (x))
-#ifndef VERSION_PSP
-#define ABS(x) ((x) < 0 ? -(x) : (x))
-#else
-#define ABS abs
-#endif
-#define ABS_ALT(x) ((x) >= 0 ? (x) : -(x))
-#define MIN(a, b) (a > b ? b : a)
-#define DECR(x) ((x) == 0 ? 0 : --(x))
-
-#define CLAMP(x, min, max) ((x) < (min) ? (min) : (x) > (max) ? (max) : (x))
-#define CLAMP_MAX(x, max) ((x) > (max) ? (max) : (x))
-#define CLAMP_MIN(x, min) ((x) < (min) ? (min) : (x))
-
-#define ARRAY_COUNT(arr) (s32)(sizeof(arr) / sizeof(arr[0]))
-#define ARRAY_COUNTU(arr) (u32)(sizeof(arr) / sizeof(arr[0]))

--- a/src/dra/4A538.c
+++ b/src/dra/4A538.c
@@ -535,7 +535,7 @@ void ResetEntityArray(void) {
     u32 j;
 
     entity = &g_Entities[0];
-    for (i = 0; i < ARRAY_COUNT(g_Entities); i++) {
+    for (i = 0; i < LEN(g_Entities); i++) {
         ch = (s8*)entity;
         for (j = 0; j < sizeof(Entity); j++) {
             *ch++ = 0;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -262,11 +262,6 @@ void func_8010A3F0(void) {
 }
 
 TeleportCheck GetTeleportToOtherCastle(void) {
-    s32 xCheckTop;
-    s32 yCheckTop;
-    s32 xCheckRTop;
-    s32 yCheckRTop;
-
     // Is player in the pose when pressing UP?
     if (PLAYER.step != 0 || PLAYER.step_s != 1) {
         return TELEPORT_CHECK_NONE;
@@ -274,30 +269,21 @@ TeleportCheck GetTeleportToOtherCastle(void) {
 
     // Check for X/Y boundaries in TOP
     if (g_StageId == STAGE_TOP) {
-        xCheckTop = g_Tilemap.left * 256 + playerX - 8000;
-        if (ABS(xCheckTop) < 4) {
-            yCheckTop = g_Tilemap.top * 256 + playerY - 2127;
-            if (ABS(yCheckTop) < 4) {
-                return TELEPORT_CHECK_TO_RTOP;
-            }
+        if (abs(g_Tilemap.left * 256 + playerX - 8000) < 4 &&
+            abs(g_Tilemap.top * 256 + playerY - 2127) < 4) {
+            return TELEPORT_CHECK_TO_RTOP;
         }
     }
 
     // Check for X/Y boundaries in RTOP
     if (g_StageId == STAGE_RTOP) {
-        xCheckRTop = g_Tilemap.left * 256 + playerX - 8384;
-        if (ABS(xCheckRTop) < 4) {
+        if (abs(g_Tilemap.left * 256 + playerX - 8384) < 4 &&
 #if defined(VERSION_US)
-            yCheckRTop = g_Tilemap.top * 256 + playerY - 14407;
-            if (ABS(yCheckRTop) < 4) {
-                return TELEPORT_CHECK_TO_TOP;
-            }
+            abs(g_Tilemap.top * 256 + playerY - 14407) < 4) {
 #elif defined(VERSION_HD)
-            yCheckRTop = g_Tilemap.top * 256 + playerY;
-            if (ABS(yCheckRTop) - 14407 < 4) {
-                return TELEPORT_CHECK_TO_TOP;
-            }
+            abs(g_Tilemap.top * 256 + playerY) - 14407 < 4) {
 #endif
+            return TELEPORT_CHECK_TO_TOP;
         }
     }
 
@@ -907,7 +893,7 @@ block_160:
         break;
     case 24: /* switch 5 */
         D_8009741C[0] |= 2;
-        if (ABS(PLAYER.velocityX) > FIX(3)) {
+        if (abs(PLAYER.velocityX) > FIX(3)) {
             func_8010E168(1, 4);
         }
         var_s0 = 0x2C100204;
@@ -997,7 +983,7 @@ block_160:
         }
         temp_s1 = g_Player.pl_vram_flag;
         if (!(g_Player.unk0C & (0x40400000 | 5))) {
-            if ((ABS(PLAYER.velocityX) >= FIX(2)) || (PLAYER.step == 8)) {
+            if ((abs(PLAYER.velocityX) >= FIX(2)) || (PLAYER.step == 8)) {
                 goto block_293;
             } else {
                 goto oddblock;

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -536,7 +536,7 @@ void func_8010E570(s32 arg0) {
     case 3:
     case 4:
         var_a0 = 6;
-        if (ABS(PLAYER.velocityX) > FIX(2.5)) {
+        if (abs(PLAYER.velocityX) > FIX(2.5)) {
             var_a0 = 4;
         }
         break;
@@ -1391,7 +1391,7 @@ bool func_8010FDF8(s32 branchFlags) {
                 goto label;
             }
 
-            if (ABS(PLAYER.velocityX) > 0x20000) {
+            if (abs(PLAYER.velocityX) > 0x20000) {
                 PlaySfx(0x647);
                 CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0, 0), 0);
                 func_8010E570(PLAYER.velocityX);

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -603,7 +603,7 @@ void func_80113F7C(void) {
 
     posX = var_a0 + PLAYER.posX.i.hi - entity->posX.i.hi - var_a2;
 
-    if (ABS(posX) < 16) {
+    if (abs(posX) < 16) {
         if (entity->velocityX != 0) {
             if (entity->velocityX >= 0) {
                 PLAYER.entityRoomIndex = 1;
@@ -1187,36 +1187,23 @@ void func_80115BB0(void) {
 
 // same as RIC/func_8015BB80
 void func_80115C50(void) {
-    s32 dist;
-
     if (g_StageId == STAGE_TOP) {
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8000 > 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8000 > 0) {
             PLAYER.posX.i.hi--;
         }
 
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8000 < 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8000 < 0) {
             PLAYER.posX.i.hi++;
         }
     }
 
     if (g_StageId == (STAGE_TOP | STAGE_INVERTEDCASTLE_FLAG)) {
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
 
-        if (dist - 8384 > 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8384 > 0) {
             PLAYER.posX.i.hi--;
         }
 
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8384 < 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8384 < 0) {
             PLAYER.posX.i.hi++;
         }
     }

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -466,7 +466,7 @@ void ControlBatForm(void) {
             }
             DecelerateX(0x480);
             DecelerateY(0x480);
-            if (ABS(PLAYER.velocityY) > FIX(1.25)) {
+            if (abs(PLAYER.velocityY) > FIX(1.25)) {
                 if (PLAYER.velocityY > 0) {
                     PLAYER.velocityY = FIX(1.25);
                 } else {

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -972,7 +972,7 @@ void UnknownEntId49(Entity* self) {
     self->drawFlags = PLAYER.drawFlags & FLAG_DRAW_UNK8;
     self->unk6C = PLAYER.unk6C;
 
-    if (ABS(PLAYER.rotZ) == 0x200) {
+    if (abs(PLAYER.rotZ) == 0x200) {
         x_offset = PLAYER.entityRoomIndex != 0 ? 0x10 : -0x10;
         self->posX.i.hi = x_offset + PLAYER.posX.i.hi;
         self->posY.i.hi = PLAYER.posY.i.hi + 9 + ((g_GameTimer >> 1) & 1);

--- a/src/dra/843B0.c
+++ b/src/dra/843B0.c
@@ -1890,12 +1890,12 @@ void EntityAguneaHitEnemy(Entity* self) {
             somethingX = temp_s6->posX.i.hi - prim->x2;
             somethingY = temp_s6->posY.i.hi - prim->y2;
             var_s3 = 0;
-            if ((ABS(somethingX) < 8) && (ABS(somethingY) < 8)) {
+            if ((abs(somethingX) < 8) && (abs(somethingY) < 8)) {
                 self->step++;
                 break;
             }
-            if (ABS(somethingX) < 0x40) {
-                var_s3 = ABS(somethingY) < 0x40;
+            if (abs(somethingX) < 0x40) {
+                var_s3 = abs(somethingY) < 0x40;
             }
             if (self->ext.et_801291C4.unk88 == 0) {
                 self->ext.et_801291C4.unk88 = 4;
@@ -2226,7 +2226,7 @@ void EntitySubwpnBible(Entity* self) {
         self->ext.et_BibleSubwpn.unk80 += (self->facingLeft ? 0x80 : -0x80);
         self->ext.et_BibleSubwpn.unk80 &= 0xFFF;
         self->ext.et_BibleSubwpn.unk82 += self->ext.et_BibleSubwpn.unk84;
-        if (ABS(self->ext.et_BibleSubwpn.unk82) >= 0x200) {
+        if (abs(self->ext.et_BibleSubwpn.unk82) >= 0x200) {
             // temp_v0 needed because otherwise unk84 gets loaded with lhu
             // instead of lh
             temp_v0 = -self->ext.et_BibleSubwpn.unk84;
@@ -2401,14 +2401,14 @@ void func_8012CCE4(void) {
         // some clever && and ||
         if (PLAYER.facingLeft) {
             if ((g_Player.pl_vram_flag & 0xF000) == 0xC000) {
-                PLAYER.velocityY = -(ABS(PLAYER.velocityX) + FIX(3.5));
+                PLAYER.velocityY = -(abs(PLAYER.velocityX) + FIX(3.5));
             }
             if ((g_Player.pl_vram_flag & 0xF000) == 0x8000) {
                 PLAYER.velocityY = FIX(-0.5);
             }
         } else {
             if ((g_Player.pl_vram_flag & 0xF000) == 0x8000) {
-                PLAYER.velocityY = -(ABS(PLAYER.velocityX) + FIX(3.5));
+                PLAYER.velocityY = -(abs(PLAYER.velocityX) + FIX(3.5));
             }
             if ((g_Player.pl_vram_flag & 0xF000) == 0xC000) {
                 PLAYER.velocityY = FIX(-0.5);
@@ -2469,7 +2469,6 @@ void func_8012CFF0(void) {
 }
 
 void func_8012D024(void) {
-    s32 separation;
     DecelerateX(0x2000);
     if (g_Player.padTapped & PAD_CROSS) {
         func_8012CCE4();
@@ -2494,8 +2493,8 @@ void func_8012D024(void) {
     if (D_800B0914 != 0) {
         return;
     }
-    separation = (PLAYER.posY.i.hi - g_Entities[17].posY.i.hi);
-    if (ABS(separation) < 4 && --D_800B0918 == 0) {
+    if (abs(PLAYER.posY.i.hi - g_Entities[17].posY.i.hi) < 4 &&
+        --D_800B0918 == 0) {
         D_800B0914 = 1;
         func_8010DA48(0xE9);
         return;

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -63,7 +63,7 @@ void func_8012D3E8(void) {
         return;
     case 2:
         if ((g_Player.padTapped & PAD_SQUARE) &&
-            (ABS(PLAYER.velocityX) < FIX(3))) {
+            (abs(PLAYER.velocityX) < FIX(3))) {
             func_8012CC30(0);
             return;
         }
@@ -143,11 +143,11 @@ void func_8012D3E8(void) {
         return;
     case 3:
         if ((g_Player.padTapped & PAD_SQUARE) &&
-            (ABS(PLAYER.velocityX) < FIX(3))) {
+            (abs(PLAYER.velocityX) < FIX(3))) {
             func_8012CC30(0);
             return;
         }
-        if (ABS(PLAYER.velocityX) > FIX(1)) {
+        if (abs(PLAYER.velocityX) > FIX(1)) {
             DecelerateX(0x2000);
         }
         if ((PLAYER.facingLeft && (directionsPressed & PAD_RIGHT)) ||
@@ -173,7 +173,7 @@ void func_8012D3E8(void) {
             ((g_Player.padPressed & PAD_LEFT) && PLAYER.facingLeft)) {
             func_8010DA48(0xE2);
             D_800B0914 = 2;
-            if (ABS(PLAYER.velocityX) < FIX(2)) {
+            if (abs(PLAYER.velocityX) < FIX(2)) {
                 SetSpeedX(FIX(2));
                 return;
             }
@@ -345,7 +345,7 @@ void func_8012E040(void) {
     case 0:
         func_8010E27C();
         if (var_s0 != 0) {
-            if (ABS(PLAYER.velocityX) < FIX(1)) {
+            if (abs(PLAYER.velocityX) < FIX(1)) {
                 SetSpeedX(FIX(1));
             }
         }
@@ -353,7 +353,7 @@ void func_8012E040(void) {
     case 1:
         func_8010E27C();
         if (var_s0 != 0) {
-            if (ABS(PLAYER.velocityX) >= FIX(1)) {
+            if (abs(PLAYER.velocityX) >= FIX(1)) {
                 DecelerateX(FIX(16.0 / 128));
             } else {
                 SetSpeedX(FIX(1));
@@ -374,7 +374,7 @@ void func_8012E040(void) {
         if (g_Player.pl_vram_flag & 8 && PLAYER.velocityX != 0) {
             D_800B0914 = 1;
         }
-        if (ABS(PLAYER.velocityX) < FIX(1)) {
+        if (abs(PLAYER.velocityX) < FIX(1)) {
             D_800B0914 = 1;
         }
         if ((PLAYER.facingLeft != 0 && (g_Player.padPressed & PAD_RIGHT)) ||
@@ -737,13 +737,13 @@ void func_8012EF2C(void) {
     D_80138438 = g_Player.unk04;
     for (i = 0; i < 8; i++) {
         var_v1 = 4;
-        if (ABS(PLAYER.velocityX) >= FIX(4)) {
+        if (abs(PLAYER.velocityX) >= FIX(4)) {
             var_v1 = 3;
         }
-        if (ABS(PLAYER.velocityX) >= FIX(5)) {
+        if (abs(PLAYER.velocityX) >= FIX(5)) {
             var_v1--;
         }
-        if (ABS(PLAYER.velocityX) >= FIX(6)) {
+        if (abs(PLAYER.velocityX) >= FIX(6)) {
             var_v1--;
         }
         // Might be misusing D_800AFFB8 here

--- a/src/dra/90264.c
+++ b/src/dra/90264.c
@@ -101,7 +101,7 @@ void func_80130264(Entity* self) {
     }
     self->palette = PLAYER.palette;
     self->hitboxState = 0;
-    if (ABS(PLAYER.velocityX) > FIX(3) &&
+    if (abs(PLAYER.velocityX) > FIX(3) &&
         (PLAYER.step_s != 2 || D_800B0914 != 4)) {
         func_8011A328(self, 13);
         self->enemyId = 3;
@@ -219,10 +219,10 @@ void func_80130618(Entity* self) {
     self->palette = PLAYER.palette;
     self->drawMode = 0;
     self->drawFlags &= ~DRAW_HIDE;
-    if (ABS(PLAYER.velocityX) > FIX(3)) {
+    if (abs(PLAYER.velocityX) > FIX(3)) {
         self->drawFlags |= DRAW_HIDE;
         self->drawMode = FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40;
-        self->unk6C = ~MIN((ABS(PLAYER.velocityX) - FIX(3)) >> 12, 160);
+        self->unk6C = ~MIN((abs(PLAYER.velocityX) - FIX(3)) >> 12, 160);
     }
 }
 static const u32 rodata_func_80130618_padding = 0;
@@ -465,7 +465,7 @@ void func_80130E94(Entity* self) {
                 var_s2 = 0x40;
                 D_8013844C += 0x100;
                 var_s1 =
-                    MIN((ABS(PLAYER.velocityX) + -FIX(3)) >> 10, 0x100) - 0x100;
+                    MIN((abs(PLAYER.velocityX) + -FIX(3)) >> 10, 0x100) - 0x100;
                 break;
             }
             break;
@@ -522,10 +522,10 @@ void func_80130E94(Entity* self) {
     self->palette = PLAYER.palette;
     self->drawMode = 0;
     self->drawFlags &= ~DRAW_HIDE;
-    if (ABS(PLAYER.velocityX) > FIX(3)) {
+    if (abs(PLAYER.velocityX) > FIX(3)) {
         self->drawFlags |= DRAW_HIDE;
         self->drawMode = FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40;
-        self->unk6C = ~MIN((ABS(PLAYER.velocityX) - FIX(3)) >> 12, 128);
+        self->unk6C = ~MIN((abs(PLAYER.velocityX) - FIX(3)) >> 12, 128);
     }
 }
 static const u32 rodata_func_80130E94_padding = 0;

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -10,11 +10,6 @@
 #include "../destroy_entity.h"
 
 TeleportCheck GetTeleportToOtherCastle(void) {
-    s32 xCheckTop;
-    s32 yCheckTop;
-    s32 xCheckRTop;
-    s32 yCheckRTop;
-
     // Is player in the pose when pressing UP?
     if (PLAYER.step != 0 || PLAYER.step_s != 1) {
         return TELEPORT_CHECK_NONE;
@@ -22,23 +17,17 @@ TeleportCheck GetTeleportToOtherCastle(void) {
 
     // Check for X/Y boundaries in TOP
     if (g_StageId == STAGE_TOP) {
-        xCheckTop = (g_Tilemap.left << 8) + playerX - 8000;
-        if (ABS(xCheckTop) < 4) {
-            yCheckTop = (g_Tilemap.top << 8) + playerY - 2127;
-            if (ABS(yCheckTop) < 4) {
-                return TELEPORT_CHECK_TO_RTOP;
-            }
+        if (abs((g_Tilemap.left << 8) + playerX - 8000) < 4 &&
+            abs((g_Tilemap.top << 8) + playerY - 2127) < 4) {
+            return TELEPORT_CHECK_TO_RTOP;
         }
     }
 
     // Check for X/Y boundaries in RTOP
     if (g_StageId == STAGE_RTOP) {
-        xCheckRTop = (g_Tilemap.left << 8) + playerX - 8384;
-        if (ABS(xCheckRTop) < 4) {
-            yCheckRTop = (g_Tilemap.top << 8) + playerY;
-            if (ABS(yCheckRTop) - 14407 < 4) {
-                return TELEPORT_CHECK_TO_TOP;
-            }
+        if (abs((g_Tilemap.left << 8) + playerX - 8384) < 4 &&
+            abs((g_Tilemap.top << 8) + playerY) - 14407 < 4) {
+            return TELEPORT_CHECK_TO_TOP;
         }
     }
 
@@ -676,7 +665,7 @@ block_48:
     }
     playerY = &g_Entities[PLAYER_CHARACTER].posY.i;
     temp_s0 = g_Player.pl_vram_flag;
-    if ((ABS(PLAYER.velocityY) > FIX(2)) || (ABS(PLAYER.velocityX) > FIX(2))) {
+    if ((abs(PLAYER.velocityY) > FIX(2)) || (abs(PLAYER.velocityX) > FIX(2))) {
         PLAYER.velocityY = PLAYER.velocityY >> 2;
         PLAYER.velocityX = PLAYER.velocityX >> 2;
         if ((playerY->i.hi < 0) || (func_801572A8(1), (playerY->i.hi < 0)) ||

--- a/src/ric/1CB04.c
+++ b/src/ric/1CB04.c
@@ -452,7 +452,7 @@ void func_80159C04(void) {
 
     temp_v0 = var_a0 + PLAYER.posX.i.hi - entity->posX.i.hi - var_a2;
 
-    if (ABS(temp_v0) < 16) {
+    if (abs(temp_v0) < 16) {
         if (entity->velocityX != 0) {
             if (entity->velocityX < 0) {
                 PLAYER.entityRoomIndex = 0;
@@ -1130,36 +1130,23 @@ void func_8015B898(void) {
 
 // same as DRA/func_80115C50
 void func_8015BB80(void) {
-    s32 dist;
-
     if (g_StageId == STAGE_TOP) {
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8000 > 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8000 > 0) {
             PLAYER.posX.i.hi--;
         }
 
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8000 < 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8000 < 0) {
             PLAYER.posX.i.hi++;
         }
     }
 
     if (g_StageId == (STAGE_TOP | STAGE_INVERTEDCASTLE_FLAG)) {
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
 
-        if (dist - 8384 > 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8384 > 0) {
             PLAYER.posX.i.hi--;
         }
 
-        dist = g_Tilemap.left * 256 + playerX;
-        dist = ABS(dist);
-
-        if (dist - 8384 < 0) {
+        if (abs(g_Tilemap.left * 256 + playerX) - 8384 < 0) {
             PLAYER.posX.i.hi++;
         }
     }

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -497,8 +497,6 @@ void EntityRichterRevivalColumn(Entity* self) {
 
 void EntityCrossBoomerang(Entity* self) {
     s32 xAccel;
-    s32 xDist;
-    s32 yDist;
     Point16* temp_a0;
     s16 playerHitboxX;
     s16 playerHitboxY;
@@ -540,7 +538,7 @@ void EntityCrossBoomerang(Entity* self) {
         self->posX.val += self->velocityX;
         xAccel = self->facingLeft ? FIX(-1.0 / 16) : FIX(1.0 / 16);
         self->velocityX -= xAccel;
-        if (ABS(self->velocityX) < FIX(0.75)) {
+        if (abs(self->velocityX) < FIX(0.75)) {
             self->step++;
         }
         break;
@@ -551,7 +549,7 @@ void EntityCrossBoomerang(Entity* self) {
         self->posX.val += self->velocityX;
         xAccel = self->facingLeft ? FIX(-1.0 / 16) : FIX(1.0 / 16);
         self->velocityX -= xAccel;
-        if (ABS(self->velocityX) > FIX(0.75)) {
+        if (abs(self->velocityX) > FIX(0.75)) {
             self->step++;
         }
         break;
@@ -560,7 +558,7 @@ void EntityCrossBoomerang(Entity* self) {
         // Increase speed until a terminal velocity of 2.5.
         xAccel = self->facingLeft ? FIX(-1.0 / 16) : FIX(1.0 / 16);
         self->velocityX -= xAccel;
-        if (ABS(self->velocityX) > FIX(2.5)) {
+        if (abs(self->velocityX) > FIX(2.5)) {
             self->step++;
         }
         /* fallthrough */
@@ -570,15 +568,14 @@ void EntityCrossBoomerang(Entity* self) {
         // Now we check 2 conditions. If we're within the player's hitbox...
         playerHitboxX = (PLAYER.posX.i.hi + PLAYER.hitboxOffX);
         playerHitboxY = (PLAYER.posY.i.hi + PLAYER.hitboxOffY);
-        xDist = tempX.i.hi - playerHitboxX;
-        if (ABS(xDist) < (PLAYER.hitboxWidth + self->hitboxWidth)) {
-            yDist = self->posY.i.hi - playerHitboxY;
-            if (ABS(yDist) < (PLAYER.hitboxHeight + self->hitboxHeight)) {
-                // ... Then we go to step 7 to be destroyed.
-                self->step = 7;
-                self->ext.crossBoomerang.timer = 0x20;
-                return;
-            }
+        if (abs(tempX.i.hi - playerHitboxX) <
+                PLAYER.hitboxWidth + self->hitboxWidth &&
+            abs(self->posY.i.hi - playerHitboxY) <
+                PLAYER.hitboxHeight + self->hitboxHeight) {
+            // ... Then we go to step 7 to be destroyed.
+            self->step = 7;
+            self->ext.crossBoomerang.timer = 0x20;
+            return;
         }
         // Alternatively, if we're offscreen, we will also be destroyed.
         if ((self->facingLeft == 0 && self->posX.i.hi < -0x20) ||
@@ -1961,12 +1958,12 @@ void EntityAguneaHitEnemy(Entity* self) {
             somethingX = temp_s6->posX.i.hi - prim->x2;
             somethingY = temp_s6->posY.i.hi - prim->y2;
             var_s3 = 0;
-            if ((ABS(somethingX) < 8) && (ABS(somethingY) < 8)) {
+            if ((abs(somethingX) < 8) && (abs(somethingY) < 8)) {
                 self->step++;
                 break;
             }
-            if (ABS(somethingX) < 0x40) {
-                var_s3 = ABS(somethingY) < 0x40;
+            if (abs(somethingX) < 0x40) {
+                var_s3 = abs(somethingY) < 0x40;
             }
             if (self->ext.et_801291C4.unk88 == 0) {
                 self->ext.et_801291C4.unk88 = 4;

--- a/src/ric/319C4.c
+++ b/src/ric/319C4.c
@@ -120,7 +120,7 @@ void func_8016D9C4(Entity* self) {
                 primLine->angle - (ratan2(primLine->preciseY.val,
                                           FIX(128) - primLine->preciseX.val) &
                                    0xFFF);
-            if (ABS(angleChange) > 0x800) {
+            if (abs(angleChange) > 0x800) {
                 if (angleChange < 0) {
                     angleChange += 0x1000;
                 } else {
@@ -369,33 +369,33 @@ void func_8016E46C(Entity* self) {
         if (var_s3 >= 6) {
             var_s3 = i - 4;
         }
-        temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 20) + (i << 8)) * 96;
-        prim->r0 = prim->r1 = ABS(temp_v1 >> 0xc);
+        temp_v1 = (rsin((self->ext.et_8016E46C.unk80 * 20) + (i << 8)) * 96);
+        prim->r0 = prim->r1 = abs(temp_v1 >> 0xc);
         temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 15) + (i << 8)) * 96;
-        prim->g0 = prim->g1 = ABS(temp_v1 >> 0xc);
+        prim->g0 = prim->g1 = abs(temp_v1 >> 0xc);
         temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 10) + (i << 8)) * 96;
-        prim->b0 = prim->b1 = ABS(temp_v1 >> 0xc);
+        prim->b0 = prim->b1 = abs(temp_v1 >> 0xc);
         temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 15) + (var_s3 << 8)) * 96;
-        prim->r2 = prim->r3 = ABS(temp_v1 >> 0xc);
+        prim->r2 = prim->r3 = abs(temp_v1 >> 0xc);
         temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 10) + (var_s3 << 8)) * 96;
-        prim->g2 = prim->g3 = ABS(temp_v1 >> 0xc);
+        prim->g2 = prim->g3 = abs(temp_v1 >> 0xc);
         temp_v1 = rsin((self->ext.et_8016E46C.unk80 * 20) + (var_s3 << 8)) * 96;
-        prim->b2 = prim->b3 = ABS(temp_v1 >> 0xc);
+        prim->b2 = prim->b3 = abs(temp_v1 >> 0xc);
         prim->x1 = D_80175894[i].unk0;
         prim->y0 = prim->y1 = D_80175894[i].unk2;
         prim->x3 = D_80175894[var_s3].unk0;
         prim->y2 = prim->y3 = D_80175894[var_s3].unk2;
         prim->x0 = D_80175894[i].unk0 + self->ext.et_8016E46C.unk7E;
         prim->x2 = D_80175894[var_s3].unk0 + self->ext.et_8016E46C.unk7E;
-        if (var_s7 < ABS(D_80175894[i].unk2)) {
-            var_s7 = ABS(D_80175894[i].unk2);
+        if (var_s7 < abs(D_80175894[i].unk2)) {
+            var_s7 = abs(D_80175894[i].unk2);
         }
         prim = prim->next;
     }
     halfwidth = self->ext.et_8016E46C.unk7E / 2;
     hitboxOffX = self->facingLeft == 0 ? halfwidth : -halfwidth;
     self->hitboxOffX = hitboxOffX;
-    self->hitboxWidth = ABS(hitboxOffX);
+    self->hitboxWidth = abs(hitboxOffX);
     self->hitboxHeight = var_s7 - self->posY.i.hi;
 }
 
@@ -983,7 +983,7 @@ void StopwatchCrashDoneSparkle(Entity* self) {
                     }
                     var_v1 = self->ext.et_stopWatchSparkle.unk86 -
                              self->ext.et_stopWatchSparkle.unk94;
-                    if (ABS(var_v1) >= 0x801) {
+                    if (abs(var_v1) >= 0x801) {
                         if (var_v1 < 0) {
                             var_v1 += 0x1000;
                         } else {
@@ -1500,7 +1500,6 @@ void func_801719A4(Entity* self) {
     s32 cosine;
     s32 var_s4;
     s32 var_s6;
-    s32 xDiff;
     s32 ySub;
     s16 temp_v0;
 
@@ -1701,8 +1700,7 @@ void func_801719A4(Entity* self) {
         self->posY.val += (var_s6 - self->posY.val) / 4;
         if (self->ext.et_801719A4.unk94 < 2) {
             if (PLAYER.facingLeft != self->facingLeft) {
-                xDiff = var_s4 - self->posX.val;
-                if (ABS(xDiff) < FIX(1)) {
+                if (abs(var_s4 - self->posX.val) < FIX(1)) {
                     self->facingLeft = PLAYER.facingLeft;
                 } else if (!self->facingLeft) {
                     if (var_s4 < self->posX.val) {
@@ -1717,8 +1715,7 @@ void func_801719A4(Entity* self) {
         } else if (D_801758CC[self->ext.et_801719A4.unk94] != 0) {
             parent = self->ext.et_801719A4.unk98;
             if (parent->facingLeft != self->facingLeft) {
-                xDiff = var_s4 - self->posX.val;
-                if (ABS(xDiff) >= FIX(1)) {
+                if (abs(var_s4 - self->posX.val) >= FIX(1)) {
                     if (!self->facingLeft) {
                         if (var_s4 < self->posX.val) {
                             self->facingLeft = parent->facingLeft;
@@ -2074,7 +2071,7 @@ void EntitySubwpnBible(Entity* self) {
         self->ext.et_BibleSubwpn.unk80 += (self->facingLeft ? 0x80 : -0x80);
         self->ext.et_BibleSubwpn.unk80 &= 0xFFF;
         self->ext.et_BibleSubwpn.unk82 += self->ext.et_BibleSubwpn.unk84;
-        if (ABS(self->ext.et_BibleSubwpn.unk82) >= 0x200) {
+        if (abs(self->ext.et_BibleSubwpn.unk82) >= 0x200) {
             // temp_v0 needed because otherwise unk84 gets loaded with lhu
             // instead of lh
             temp_v0 = -self->ext.et_BibleSubwpn.unk84;

--- a/src/servant/tt_000/10E8.c
+++ b/src/servant/tt_000/10E8.c
@@ -1147,10 +1147,10 @@ s16 func_80173F30(Entity* entity, s16 x, s16 y) {
 
 s16 func_80173F74(s16 x1, s16 x2, s16 minDistance) {
 #ifdef VERSION_PSP
-    s16 diff = ABS(x2 - x1);
+    s16 diff = abs(x2 - x1);
 #else
     s32 diffTmp = x2 - x1;
-    s16 diff = ABS(diffTmp);
+    s16 diff = abs(diffTmp);
 #endif
     if (minDistance > diff) {
         minDistance = diff;
@@ -1305,7 +1305,7 @@ void ProcessEvent(Entity* self, bool resetEvent) {
             if (evt->roomX >= 0 ||
                 (g_StageId >= STAGE_RNO0 && g_StageId < STAGE_RNZ1_DEMO)) {
 #endif
-                if (ABS(evt->roomX) != g_CurrentRoomX ||
+                if (abs(evt->roomX) != g_CurrentRoomX ||
                     evt->roomY != g_CurrentRoomY) {
                     continue;
                 }

--- a/src/st/cen/18084.c
+++ b/src/st/cen/18084.c
@@ -291,7 +291,7 @@ void func_8019A328(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -300,9 +300,9 @@ void func_8019A328(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -884,7 +884,7 @@ void EntityElevatorStationary(Entity* self) {
         if (*(u8*)&self[-1].ext.stub[0x4]) {
             posX = self->posX.i.hi - player->posX.i.hi;
             if (g_pads[0].pressed & PAD_UP) {
-                if (ABS(posX) < 8) {
+                if (abs(posX) < 8) {
                     g_Entities[1].ext.stub[0x00] = 1;
                     g_Player.D_80072EFC = 2;
                     g_Player.D_80072EF4 = 0;
@@ -983,7 +983,7 @@ void EntityElevatorStationary(Entity* self) {
         prim = prim->next;
     }
 
-    if (ABS(self->posY.i.hi) > 384) {
+    if (abs(self->posY.i.hi) > 384) {
         DestroyEntity(self);
     }
 }
@@ -1108,7 +1108,7 @@ void EntityMovingElevator(Entity* self) {
         prim = prim->next;
     }
 
-    if (ABS(self->posY.i.hi) > 384) {
+    if (abs(self->posY.i.hi) > 384) {
         DestroyEntity(self);
     }
 }

--- a/src/st/dre/1E1C8.c
+++ b/src/st/dre/1E1C8.c
@@ -418,7 +418,7 @@ void func_801A046C(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -427,9 +427,9 @@ void func_801A046C(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/entity_is_near_player.h
+++ b/src/st/entity_is_near_player.h
@@ -2,11 +2,11 @@ bool EntityIsNearPlayer(Entity* self) {
     s16 posX = PLAYER.posX.i.hi - self->posX.i.hi;
     s16 posY;
 
-    posX = ABS(posX);
+    posX = abs(posX);
 
     if (posX < 17) {
         posY = PLAYER.posY.i.hi - self->posY.i.hi;
-        posY = ABS(posY);
+        posY = abs(posY);
         return posY < 33;
     }
     return 0;

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -425,7 +425,7 @@ void func_80197A9C(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -434,9 +434,9 @@ void func_80197A9C(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/no3/48A84.c
+++ b/src/st/no3/48A84.c
@@ -433,7 +433,7 @@ void func_801CAD28(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -442,9 +442,9 @@ void func_801CAD28(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/np3/36990.c
+++ b/src/st/np3/36990.c
@@ -602,8 +602,8 @@ void EntityGaibon(Entity* self) {
             if (self->hitPoints < (hitPoints / 2)) {
                 self->ext.GS_Props.nearDeath = 1;
                 temp_s3 = self->posX.i.hi - 128;
-                if (ABS(temp_s3) < 0x60) {
-                    self->unk3C = 0;
+                if (abs(temp_s3) < 0x60) {
+                    self->hitboxState = 0;
                     SetStep(GAIBON_NEAR_DEATH);
                 }
             }
@@ -614,7 +614,7 @@ void EntityGaibon(Entity* self) {
             SetStep(GAIBON_PICKUP_SLOGRA);
         }
         if (D_801812CC != 0) {
-            self->unk3C = 0;
+            self->hitboxState = 0;
             if (self->step != GAIBON_RETREAT) {
                 SetStep(GAIBON_RETREAT);
             }
@@ -752,10 +752,10 @@ void EntityGaibon(Entity* self) {
                     func_801C2598(NA_SE_EN_GAIBON_SMALL_FIREBALL);
                     newEntity->posY.i.hi -= 2;
                     if (self->facingLeft != 0) {
-                        newEntity->unk1E = 0x220;
+                        newEntity->rotZ = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
-                        newEntity->unk1E = 0x5E0;
+                        newEntity->rotZ = 0x5E0;
                         newEntity->posX.i.hi -= 12;
                     }
                     newEntity->zPriority = self->zPriority + 1;
@@ -773,7 +773,7 @@ void EntityGaibon(Entity* self) {
             self->velocityY -= self->velocityY / 32;
             if (AnimateEntity(&D_801814D8, self) == 0) {
                 temp_s3 = self->posX.i.hi - 128;
-                if (ABS(temp_s3) < 0x60) {
+                if (abs(temp_s3) < 0x60) {
                     SetStep(GAIBON_LANDING_AFTER_SHOOTING);
                 } else {
                     SetStep(GAIBON_FLY_SHOOT_BIG_FIREBALL);
@@ -857,10 +857,10 @@ void EntityGaibon(Entity* self) {
 
                     newEntity->posY.i.hi -= 6;
                     if (self->facingLeft != 0) {
-                        newEntity->unk1E = 0;
+                        newEntity->rotZ = 0;
                         newEntity->posX.i.hi += 16;
                     } else {
-                        newEntity->unk1E = 0x800;
+                        newEntity->rotZ = 0x800;
                         newEntity->posX.i.hi -= 16;
                     }
                     newEntity->zPriority = self->zPriority + 1;
@@ -891,10 +891,10 @@ void EntityGaibon(Entity* self) {
                         E_GAIBON_BIG_FIREBALL, self, newEntity);
                     newEntity->posY.i.hi -= 2;
                     if (self->facingLeft != 0) {
-                        newEntity->unk1E = 0x220;
+                        newEntity->rotZ = 0x220;
                         newEntity->posX.i.hi += 12;
                     } else {
-                        newEntity->unk1E = 0x5E0;
+                        newEntity->rotZ = 0x5E0;
                         newEntity->posX.i.hi -= 12;
                     }
                     newEntity->zPriority = self->zPriority + 1;
@@ -916,7 +916,7 @@ void EntityGaibon(Entity* self) {
             self->ext.GS_Props.timer--;
             if (self->ext.GS_Props.timer == 0) {
                 temp_s3 = self->posX.i.hi - 128;
-                if (ABS(temp_s3) < 96) {
+                if (abs(temp_s3) < 96) {
                     SetStep(GAIBON_LANDING_AFTER_SHOOTING);
                 } else {
                     SetStep(GAIBON_FLY_TOWARDS_PLAYER);
@@ -951,8 +951,8 @@ void EntityGaibon(Entity* self) {
             self->velocityY = (speed * rsin(angle)) >> 0xC;
             MoveEntity();
 
-            if (ABS(slograGaibonDistX) < 8) {
-                if (ABS(slograGaibonDistY) < 8) {
+            if (abs(slograGaibonDistX) < 8) {
+                if (abs(slograGaibonDistY) < 8) {
                     self->ext.GS_Props.grabedAscending = 1;
                     self->velocityX = 0;
                     self->velocityY = 0;
@@ -1080,8 +1080,8 @@ void EntityGaibon(Entity* self) {
             self->velocityX = (speed * rcos(angle)) >> 0xC;
             self->velocityY = (speed * rsin(angle)) >> 0xC;
             MoveEntity();
-            if (ABS(slograGaibonDistX) < 8) {
-                if (ABS(slograGaibonDistY) < 8) {
+            if (abs(slograGaibonDistX) < 8) {
+                if (abs(slograGaibonDistY) < 8) {
                     self->velocityX = 0;
                     self->velocityY = 0;
                     self->step_s++;
@@ -1165,8 +1165,8 @@ void EntityGaibon(Entity* self) {
     hitbox = &D_801815B4[self->animCurFrame][D_80181584];
     hitbox--;
     hitbox++;
-    self->unk10 = *hitbox++;
-    self->unk12 = *hitbox++;
+    self->hitboxOffX = *hitbox++;
+    self->hitboxOffY = *hitbox++;
     self->hitboxWidth = hitbox[0];
     self->hitboxHeight = hitbox[1];
 }

--- a/src/st/np3/402F4.c
+++ b/src/st/np3/402F4.c
@@ -554,7 +554,7 @@ void func_801C2598(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -563,9 +563,9 @@ void func_801C2598(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/np3/44DCC.c
+++ b/src/st/np3/44DCC.c
@@ -849,7 +849,7 @@ void EntityMerman2(Entity* self) {
                 }
 
                 colorOffset =
-                    (u32)(((ABS(self->velocityY) >> 0xC) - 10) & 0xFF) >> 1;
+                    (u32)(((abs(self->velocityY) >> 0xC) - 10) & 0xFF) >> 1;
 
                 setRGB0(prim, 128 - colorOffset, 128 - colorOffset,
                         colorOffset + 192);

--- a/src/st/np3/4B018.c
+++ b/src/st/np3/4B018.c
@@ -135,10 +135,7 @@ void func_801CDA6C(Entity* self, s32 arg1) {
 INCLUDE_ASM("st/np3/nonmatchings/4B018", func_801CDAC8);
 
 bool func_801CDC80(s16* arg0, s16 arg1, s16 arg2) {
-    s32 var_v1 = *arg0 - arg1;
-    s32 ret;
-
-    if (ABS(var_v1) < arg2) {
+    if (abs(*arg0 - arg1) < arg2) {
         *arg0 = arg1;
         return true;
     }

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -286,7 +286,7 @@ void EntityGurkhaSword(Entity* self) {
             func_801C2598(0x625);
         }
 
-        if (ABS(self->velocityX) == 0x80000) {
+        if (abs(self->velocityX) == 0x80000) {
             self->ext.gurkhaSword.unk8C = 0;
             self->step = 1;
         }

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -27,10 +27,10 @@ void func_801B0958(Entity* self) {
 bool func_801B0A20(Entity* self) {
     s16 diffX = PLAYER.posX.i.hi - self->posX.i.hi;
 
-    diffX = ABS(diffX);
+    diffX = abs(diffX);
     if (self->hitboxWidth >= diffX) {
         diffX = PLAYER.posY.i.hi - self->posY.i.hi;
-        diffX = ABS(diffX);
+        diffX = abs(diffX);
         return (self->hitboxHeight >= diffX);
     } else {
         return false;
@@ -568,8 +568,6 @@ void EntityMoveableBox(Entity* self) {
     s32 var_s1 = temp_s1;
     s16 primIndex;
     s32 temp_v0_2;
-    s32 var_v0;
-    s32 var_v1;
     s32 new_var;
 
     switch (self->step) {
@@ -620,12 +618,12 @@ void EntityMoveableBox(Entity* self) {
 
         if (self->params == 0) {
             temp_v0_2 = self->posX.i.hi + g_Tilemap.scrollX.i.hi;
-            var_v1 = temp_v0_2 - 192;
-            var_v1 = ABS(var_v1);
-            var_v0 = temp_v0_2 - 256;
-            var_v0 = ABS(var_v0);
-            var_s1 = 24 > var_v1;
-            if (var_v0 < 24) {
+            if (abs(temp_v0_2 - 192) < 24) {
+                var_s1 = 1;
+            } else {
+                var_s1 = 0;
+            }
+            if (abs(temp_v0_2 - 256) < 24) {
                 var_s1 = 2;
             }
             if ((self->ext.generic.unk84.unk == 0) &&
@@ -891,7 +889,6 @@ void EntityCannonWall(Entity* self) {
 void func_801B2AD8(Entity* self) {
     POLY_GT4* poly;
     s16 primIndex;
-    s32 var_v0;
     s32 var_a0;
     s32 temp;
 
@@ -926,13 +923,12 @@ void func_801B2AD8(Entity* self) {
 
     case 1:
         var_a0 = self->hitFlags;
-        var_v0 = self->posX.i.hi - self[-1].posX.i.hi;
 
-        if (ABS(var_v0) < 8) {
+        if (abs(self->posX.i.hi - self[-1].posX.i.hi) < 8) {
             var_a0 |= 0x8000;
         }
 
-        if (var_a0 != 0) {
+        if (var_a0) {
             self->posY.val += FIX(1.0);
             temp = g_Tilemap.scrollY.i.hi + self->posY.i.hi;
             if (temp > 376) {

--- a/src/st/nz0/33FCC.c
+++ b/src/st/nz0/33FCC.c
@@ -1028,8 +1028,8 @@ void EntityGaibon(Entity* self) {
             self->velocityX = (speed * rcos(angle)) >> 0xC;
             self->velocityY = (speed * rsin(angle)) >> 0xC;
             MoveEntity();
-            if (ABS(slograGaibonDistX) < 8) {
-                if (ABS(slograGaibonDistY) < 8) {
+            if (abs(slograGaibonDistX) < 8) {
+                if (abs(slograGaibonDistY) < 8) {
                     self->ext.GS_Props.grabedAscending = 1;
                     self->velocityX = 0;
                     self->velocityY = 0;

--- a/src/st/nz0/4070C.c
+++ b/src/st/nz0/4070C.c
@@ -589,7 +589,7 @@ void func_801C29B0(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -598,9 +598,9 @@ void func_801C29B0(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/nz0/45F2C.c
+++ b/src/st/nz0/45F2C.c
@@ -221,7 +221,7 @@ void func_801C6574(Entity* entity) { // Bone Projectile from Skeleton
         entity->posY.val -= FIX(0.0625);
         xDistanceToPlayer = GetDistanceToPlayerX();
         xDistanceToPlayer /= 32;
-        xDistanceToPlayer = CLAMP_MAX(xDistanceToPlayer, 7);
+        xDistanceToPlayer = MAX(xDistanceToPlayer, 7);
         velocityX = D_80182488[xDistanceToPlayer];
         xDistanceToPlayer = entity->facingLeft;
 

--- a/src/st/nz0/47048.c
+++ b/src/st/nz0/47048.c
@@ -61,7 +61,7 @@ void EntitySubWeaponContainer(Entity* self) {
                 newEntity->posY.i.hi -= 30;
                 newEntity->params = Random() & 3;
                 if (newEntity->params == 0) {
-                    absRnd = ABS(rnd);
+                    absRnd = abs(rnd);
                     if (absRnd >= 9) {
                         newEntity->params = 1;
                     }

--- a/src/st/nz0/47CF0.c
+++ b/src/st/nz0/47CF0.c
@@ -9,14 +9,18 @@
 s32 EntityIsNearPlayer2(Entity* e) {
     s16 diff = PLAYER.posX.i.hi - e->posX.i.hi;
 
-    diff = ABS(diff);
+    diff = abs(diff);
 
     if (diff >= 25) {
-        diff = 0;
+        return 0;
     } else {
         diff = PLAYER.posY.i.hi - e->posY.i.hi;
-        diff = ABS(diff);
-        diff = diff < 33;
+        diff = abs(diff);
+        if (diff < 33) {
+            return 1;
+        } else {
+            return 0;
+        }
     }
     return diff;
 }

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -22,10 +22,10 @@ void func_801A7D64(Entity* self) {
 bool func_801A7E2C(Entity* self) {
     s16 diffX = PLAYER.posX.i.hi - self->posX.i.hi;
 
-    diffX = ABS(diffX);
+    diffX = abs(diffX);
     if (self->hitboxWidth >= diffX) {
         diffX = PLAYER.posY.i.hi - self->posY.i.hi;
-        diffX = ABS(diffX);
+        diffX = abs(diffX);
         return (self->hitboxHeight >= diffX);
     } else {
         return false;
@@ -274,7 +274,7 @@ void func_801A8620(Entity* entity) {
 
     case 1:
         dist = entity->posY.i.hi - PLAYER.posY.i.hi;
-        dist = ABS(dist);
+        dist = abs(dist);
 
         if (dist < 0x20) {
             switch (params) {

--- a/src/st/st0/36358.c
+++ b/src/st/st0/36358.c
@@ -743,7 +743,7 @@ void func_801B9DB0(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -752,9 +752,9 @@ void func_801B9DB0(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/st/wrp/F420.c
+++ b/src/st/wrp/F420.c
@@ -641,7 +641,7 @@ void func_801916C4(s16 sfxId) {
     s16 var_v1;
 
     var_a3 = g_CurrentEntity->posX.i.hi - 128;
-    var_a2 = (ABS(var_a3) - 32) >> 5;
+    var_a2 = (abs(var_a3) - 32) >> 5;
     if (var_a2 > 8) {
         var_a2 = 8;
     } else if (var_a2 < 0) {
@@ -650,9 +650,9 @@ void func_801916C4(s16 sfxId) {
     if (var_a3 < 0) {
         var_a2 = -var_a2;
     }
-    var_a3 = ABS(var_a3) - 96;
+    var_a3 = abs(var_a3) - 96;
     y = g_CurrentEntity->posY.i.hi - 128;
-    temp_v0_2 = ABS(y) - 112;
+    temp_v0_2 = abs(y) - 112;
     var_v1 = var_a3;
     if (temp_v0_2 > 0) {
         var_v1 += temp_v0_2;

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -72,7 +72,7 @@ void EntityWeaponAttack(Entity* self) {
             self->ext.weapon.unk7E += 8;
         }
         fakePrim = (FakePrim*)&g_PrimBuf[self->primIndex];
-        self->rotZ += ABS(self->ext.weapon.unk82);
+        self->rotZ += abs(self->ext.weapon.unk82);
         self->ext.weapon.unk80 += self->ext.weapon.unk82;
         fakePrim->posX.i.hi = fakePrim->x0;
         fakePrim->posY.i.hi = fakePrim->y0;
@@ -312,7 +312,7 @@ s32 func_ptr_80170014(Entity* self) {
             self->hitboxWidth = 4;
         }
         self->posX.val += self->velocityX;
-        if (ABS(self->velocityX) >= FIX(0.5)) {
+        if (abs(self->velocityX) >= FIX(0.5)) {
             self->hitboxWidth = 8;
             return;
         }

--- a/src/weapon/w_021.c
+++ b/src/weapon/w_021.c
@@ -195,8 +195,8 @@ s32 func_97000_8017AF2C(Entity* self, s32 arg1) {
         return 1;
     }
     // All other foods use this logic to tell if you've grabbed it
-    xDist = ABS(self->posX.i.hi - PLAYER.posX.i.hi + PLAYER.hitboxOffX);
-    yDist = ABS(self->posY.i.hi - PLAYER.posY.i.hi + PLAYER.hitboxOffY);
+    xDist = abs(self->posX.i.hi - PLAYER.posX.i.hi + PLAYER.hitboxOffX);
+    yDist = abs(self->posY.i.hi - PLAYER.posY.i.hi + PLAYER.hitboxOffY);
     if (xDist > (self->hitboxWidth + PLAYER.hitboxWidth)) {
         return 0;
     }


### PR DESCRIPTION
Given the recent discovery (thanks @Mc-muffin) I deleted the `ABS` macro (together with a few other unused ones) and started using `abs` instead. 

This is not a simple Find & Replace. I also checked every single code change and removed previously necessary temporary variables.
