### PR TITLE
Update func_8011A4D0 to match on PSP

### DIFF
--- a/config/symbols.us.weapon.txt
+++ b/config/symbols.us.weapon.txt
@@ -1,2 +1,2 @@
-g_Weapon = 0x80170000;
+g_Weapon = 0x8017A000;
 BottomCornerText = 0x8017AB54;

--- a/src/dra/7A4D0.c
+++ b/src/dra/7A4D0.c
@@ -78,10 +78,7 @@ void func_8011A4D0(void) {
     s32 temp_s2;
     s32 i;
     s32 i2;
-    s32 i3;
-    u16 entityId;
     s32 enemy;
-    s32 enemy2;
 
     temp_s2 = *D_80097420;
     entity = g_CurrentEntity = &g_Entities[4];
@@ -93,26 +90,26 @@ void func_8011A4D0(void) {
             continue;
         }
         if (entity->step == 0) {
-            entityId = entity->entityId;
-            if (entityId < 0xD0) {
+            if (entity->entityId < 0xD0) {
                 // Objects 00-CF
-                entity->pfnUpdate = g_DraEntityTbl[entityId];
-            } else if (entityId < 0xE0) {
+                entity->pfnUpdate = g_DraEntityTbl[entity->entityId];
+            } else if (entity->entityId < 0xE0) {
                 // Objects D0-DF
-                entity->pfnUpdate = D_8016FCC0[entityId];
-            } else if (entityId == 0xEF || entityId == 0xFF ||
-                       entityId == 0xED || entityId == 0xFD) {
+                entity->pfnUpdate =
+                    ((PfnEntityUpdate*)FAMILIAR_PTR)[entity->entityId - 0xD0];
+            } else if (entity->entityId == 0xEF || entity->entityId == 0xFF ||
+                       entity->entityId == 0xED || entity->entityId == 0xFD) {
                 entity->pfnUpdate = g_DraEntityTbl[1];
-            } else if (entityId == 0xEE || entityId == 0xFE) {
+            } else if (entity->entityId == 0xEE || entity->entityId == 0xFE) {
                 entity->pfnUpdate = g_DraEntityTbl[15];
-            } else if (entityId >= 0xF0) {
+            } else if (entity->entityId >= 0xF0) {
                 // Objects F0-FC
                 entity->pfnUpdate =
-                    ((PfnEntityUpdate*)(&D_8017D000))[entityId - 0xF0];
+                    ((PfnEntityUpdate*)WEAPON1_PTR)[entity->entityId - 0xF0];
             } else {
                 // Objects E0-EC
                 entity->pfnUpdate =
-                    ((PfnEntityUpdate*)(&D_8017A000))[entityId - 0xE0];
+                    ((PfnEntityUpdate*)WEAPON0_PTR)[entity->entityId - 0xE0];
             }
         }
         if ((temp_s2 == 0) || (entity->flags & FLAG_UNK_10000)) {
@@ -120,9 +117,9 @@ void func_8011A4D0(void) {
             entity = g_CurrentEntity;
             if (entity->entityId != 0) {
                 if (!(entity->flags & FLAG_UNK_04000000) &&
-                    ((u16)(entity->posX.i.hi + 32) > 320 ||
-                     (u16)(entity->posY.i.hi + 16) > 272)) {
-                    DestroyEntity(entity);
+                    (entity->posX.i.hi > 288 || entity->posX.i.hi < -32 ||
+                     entity->posY.i.hi > 256 || entity->posY.i.hi < -16)) {
+                    DestroyEntity(g_CurrentEntity);
                 } else {
                     if (entity->flags & 0x100000) {
                         UpdateAnim(NULL, D_800ACFB4);
@@ -131,31 +128,31 @@ void func_8011A4D0(void) {
             }
         }
     }
-    if (D_8013803C != 0) {
-        if (--D_8013803C & 1) {
+    if (D_8013803C) {
+        D_8013803C--;
+        if (D_8013803C & 1) {
             func_800EA5AC(1U, D_80138040, D_80138044, D_80138048);
         }
     }
     D_8013800C[1] = D_8013800C[2] = 0;
-    enemy = g_Entities[16].enemyId;
-    if (enemy == 1) {
+    if (g_Entities[16].enemyId == 1) {
         D_8013800C[1] = 1;
-    } else if (enemy == 2) {
+    } else if (g_Entities[16].enemyId == 2) {
         D_8013800C[2] = 1;
     }
     for (i2 = 3; i2 < 11; i2++) {
         D_8013800C[i2] = 0;
     }
     entity = &g_Entities[17];
-    for (i3 = 17; i3 < 48; entity++, i3++) {
-        enemy2 = entity->enemyId;
-        if (enemy2 >= 3) {
-            D_8013800C[enemy2]++;
+    for (i2 = 17; i2 < 48; entity++, i2++) {
+        enemy = entity->enemyId;
+        if (2 < enemy) {
+            D_8013800C[enemy]++;
         }
     }
     // Appears to be a temporary debugging block that was left in.
     if ((g_Player.unk0C & 0xC0000) ||
-        (PLAYER.step == 0x12 && PLAYER.step_s == 0)) {
+        (PLAYER.step == Player_Teleport && PLAYER.step_s == 0)) {
 #if defined(VERSION_US)
         // Japanese for "without hit".
         FntPrint("atari nuki\n");
@@ -183,7 +180,8 @@ void func_8011A870(void) {
 
         if (entity->step == 0) {
             if (entity->entityId >= 0xD0 && entity->entityId < 0xE0) {
-                entity->pfnUpdate = D_8016FCC0[entity->entityId];
+                entity->pfnUpdate =
+                    ((PfnEntityUpdate*)FAMILIAR_PTR)[entity->entityId - 0xD0];
             } else {
                 continue;
             }

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -3,6 +3,7 @@
 
 #include "game.h"
 #include "weapon.h"
+#include "servant.h"
 #include "items.h"
 
 #define DAMAGE_FLAG_NORMAL 0x0000
@@ -778,10 +779,9 @@ extern u8 g_CdSoundCommand16;
 extern s8 D_8013B690;
 extern s32 D_8013B694;
 extern s32 D_8013B69C;
-extern PfnEntityUpdate D_8016FCC0[];
+extern ServantDesc D_80170000;
 extern Weapon D_8017A000;
 extern Weapon D_8017D000;
-extern void (*D_80170000)(s32 arg0);
 extern ImgSrc* g_imgUnk8013C200;
 extern ImgSrc* g_imgUnk8013C270;
 extern u8 D_801EC000[];

--- a/src/dra/loading.c
+++ b/src/dra/loading.c
@@ -124,7 +124,7 @@ void AnimateNowLoading(NowLoadingModel* self, s16 x, s16 y, s32 isDone) {
 
 void func_800E6218(s32 arg0) {
     if (g_Servant != 0) {
-        D_80170000(arg0);
+        D_80170000.Init(arg0);
     }
 }
 

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -9,9 +9,10 @@
 
 u16 g_RawVram[VRAM_W * VRAM_H];
 GameApi g_ApiInit = {0};
-void (*D_80170000)(s32 arg0); // ServantDesc D_80170000 = {0};
 u8 g_DemoRecordingBuffer[DEMO_MAX_LEN];
 extern bool g_IsQuitRequested;
+
+ServantDesc D_80170000;
 
 void EntityWeaponAttack(Entity* self);
 void func_ptr_80170004(Entity* self);


### PR DESCRIPTION
Based on Sozud's scratch (https://decomp.me/scratch/zVBXP), I got the function to match, and then confirmed that it also matches on PSX.

I also discovered a few improvements, especially in changing `D_8016FCC0[entityId];` to instead be `((PfnEntityUpdate*)FAMILIAR_PTR)[entity->entityId - 0xD0];`

While I was at it, I also updated the D_80170000 variable from a void* to be g_ServantDesc, just like we have in the servant overlay. The ServantDesc struct only exists in servant.h, so we update that as well.

Finally, we move g_Weapon to not be at 80170000, since it doesn't belong there.