### PR TITLE
Refactor entity.h Functions

### DIFF
--- a/config/symbols.us.stcen.txt
+++ b/config/symbols.us.stcen.txt
@@ -36,6 +36,7 @@ CreateEntityFromEntity = 0x80193538;
 EntityRedDoor = 0x8019362C;
 DestroyEntity = 0x80194264;
 PreventEntityFromRespawning = 0x8019434C;
+AnimateEntity = 0x80194394;
 GetSideToPlayer = 0x801945D4;
 MoveEntity = 0x80194618;
 FallEntity = 0x80194648;

--- a/config/symbols.us.strwrp.txt
+++ b/config/symbols.us.strwrp.txt
@@ -21,6 +21,7 @@ CreateEntityFromEntity = 0x8018C854;
 EntityIsNearPlayer = 0x8018C8D0;
 DestroyEntity = 0x8018D580;
 PreventEntityFromRespawning = 0x8018D668;
+AnimateEntity = 0x8018D6B0;
 GetDistanceToPlayerX = 0x8018D880;
 GetSideToPlayer = 0x8018D8F0;
 MoveEntity = 0x8018D934;

--- a/src/st/cen/11280.c
+++ b/src/st/cen/11280.c
@@ -7,20 +7,7 @@ INCLUDE_ASM("st/cen/nonmatchings/11280", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-INCLUDE_ASM("st/cen/nonmatchings/11280", func_80194394);
+#include "../entity.h"
 
 u8 func_8019444C(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/cen/1B274.c
+++ b/src/st/cen/1B274.c
@@ -67,7 +67,7 @@ void EntitySoulStealOrb(Entity* self) {
                        self->ext.soulStealOrb.unk80);
         MoveEntity(self); // argument pass necessary to match
         prim = &g_PrimBuf[self->primIndex];
-        func_80194394(&D_80181238, self);
+        AnimateEntity(&D_80181238, self);
         angle = (float)(u32)self; // !FAKE
         prim->tpage = 0x18;
         prim->clut = 0x194;
@@ -107,7 +107,7 @@ void EntityUnkId08(Entity* entity) {
             entity->drawFlags = (u8)(entity->drawFlags | FLAG_DRAW_ROTZ);
         }
     }
-    func_80194394(objInit->unk10, entity);
+    AnimateEntity(objInit->unk10, entity);
 }
 
 void BottomCornerText(u8* str, u8 lower_left) {

--- a/src/st/cen/D600.c
+++ b/src/st/cen/D600.c
@@ -29,7 +29,7 @@ void EntityBackgroundBlock(Entity* self) {
             self->rotX = 0x200;
         }
     }
-    func_80194394(obj->unk10, self);
+    AnimateEntity(obj->unk10, self);
 }
 
 INCLUDE_ASM("st/cen/nonmatchings/D600", EntityUnkId12);
@@ -58,7 +58,7 @@ void EntityUnkId01(Entity* self) {
         newEntity->params = 1;
     }
 
-    func_80194394(D_80180574[params], self);
+    AnimateEntity(D_80180574[params], self);
 
     if (self->unk44 != 0) {
         g_api.PlaySfx(NA_SE_BREAK_CANDLE);
@@ -913,7 +913,7 @@ void EntityElevatorStationary(Entity* self) {
             break;
 
         case 1:
-            if (func_80194394(D_80180780, self) == 0) {
+            if (AnimateEntity(D_80180780, self) == 0) {
                 self->animFrameIdx = 0;
                 self->animFrameDuration = 0;
                 g_Entities[1].ext.stub[0x00] = 0;
@@ -932,7 +932,7 @@ void EntityElevatorStationary(Entity* self) {
 
         switch (self->step_s) {
         case 0:
-            if (func_80194394(D_80180768, self) == 0) {
+            if (AnimateEntity(D_80180768, self) == 0) {
                 self->animFrameIdx = 0;
                 self->animFrameDuration = 0;
                 self->step_s++;
@@ -950,7 +950,7 @@ void EntityElevatorStationary(Entity* self) {
             break;
 
         case 2:
-            if (func_80194394(&D_80180780, self) == 0) {
+            if (AnimateEntity(&D_80180780, self) == 0) {
                 self->animFrameIdx = 0;
                 self->animFrameDuration = 0;
                 g_Entities[1].ext.stub[0x00] = 0;

--- a/src/st/dre/173C4.c
+++ b/src/st/dre/173C4.c
@@ -7,51 +7,7 @@ INCLUDE_ASM("st/dre/nonmatchings/173C4", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-s32 AnimateEntity(const u8 frames[], Entity* entity) {
-    s32 flag = 0;
-    u16 currentFrameIndex = entity->animFrameIdx * 2;
-    u8* currentFrame = frames + currentFrameIndex;
-
-    if (entity->animFrameDuration == 0) {
-        if (currentFrame[0] > 0) {
-            flag = 0x80;
-            if (currentFrame[0] == 0xFF) {
-                return false;
-            }
-
-            entity->animFrameDuration = *currentFrame++;
-            entity->animCurFrame = *currentFrame++;
-            entity->animFrameIdx++;
-        } else {
-            currentFrame = frames;
-            entity->animFrameIdx = 0;
-            entity->animFrameDuration = 0;
-            entity->animFrameDuration = *currentFrame++;
-            entity->animCurFrame = *currentFrame++;
-            entity->animFrameIdx++;
-            return false;
-        }
-    }
-
-    entity->animFrameDuration = entity->animFrameDuration - 1;
-    entity->animCurFrame = currentFrame[-1];
-    flag |= true;
-
-    return (u8)flag;
-}
+#include "../entity.h"
 
 u8 func_8019A590(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/entity.h
+++ b/src/st/entity.h
@@ -1,0 +1,14 @@
+// an implementation of entity.c
+#include "../destroy_entity.h"
+#include "../destroy_entities_from_index.h"
+
+void PreventEntityFromRespawning(Entity* entity) {
+    if (entity->entityRoomIndex) {
+        u32 value = (entity->entityRoomIndex - 1);
+        u16 index = value / 32;
+        u16 bit = value % 32;
+        g_entityDestroyed[index] |= 1 << bit;
+    }
+}
+
+#include "animate_entity.h"

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -51,20 +51,7 @@ void CreateEntitiesToTheLeft(s16 posX) {
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex != 0) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_80191F24(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/no3/41C80.c
+++ b/src/st/no3/41C80.c
@@ -7,20 +7,7 @@ INCLUDE_ASM("st/no3/nonmatchings/41C80", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_801C4E4C(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/np3/394F0.c
+++ b/src/st/np3/394F0.c
@@ -7,20 +7,7 @@ INCLUDE_ASM("st/np3/nonmatchings/394F0", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_801BC6BC(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/nz0/39908.c
+++ b/src/st/nz0/39908.c
@@ -6,20 +6,7 @@ INCLUDE_ASM("st/nz0/nonmatchings/39908", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_801BCAD4(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/rwrp/14590.c
+++ b/src/st/rwrp/14590.c
@@ -67,7 +67,7 @@ void EntitySoulStealOrb(Entity* self) {
                        self->ext.soulStealOrb.unk80);
         MoveEntity(self); // argument pass necessary to match
         prim = &g_PrimBuf[self->primIndex];
-        func_8018D6B0(&D_80181110, self);
+        AnimateEntity(&D_80181110, self);
         angle = (float)(u32)self; // !FAKE
         prim->tpage = 0x18;
         prim->clut = 0x194;
@@ -107,7 +107,7 @@ void func_80194DD4(Entity* entity) {
             entity->drawFlags = (u8)(entity->drawFlags | FLAG_DRAW_ROTZ);
         }
     }
-    func_8018D6B0(objInit->unk10, entity);
+    AnimateEntity(objInit->unk10, entity);
 }
 
 INCLUDE_ASM("st/rwrp/nonmatchings/14590", BottomCornerText);

--- a/src/st/rwrp/8DF0.c
+++ b/src/st/rwrp/8DF0.c
@@ -23,7 +23,7 @@ void EntityBreakable(Entity* entity) {
     u16 temp_s0 = entity->params >> 0xC;
 
     if (entity->step != 0) {
-        func_8018D6B0(D_801805B8[temp_s0], entity);
+        AnimateEntity(D_801805B8[temp_s0], entity);
         if (entity->unk44 != 0) {
             g_api.PlaySfx(NA_SE_BREAK_CANDLE);
             temp_v0 = AllocEntity(&D_8007D858, &D_8007D858 + 32);

--- a/src/st/rwrp/A59C.c
+++ b/src/st/rwrp/A59C.c
@@ -7,20 +7,7 @@ INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018B6B4);
 
 INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018C948);
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-INCLUDE_ASM("st/rwrp/nonmatchings/A59C", func_8018D6B0);
+#include "../entity.h"
 
 u8 func_8018D768(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/sel/3410C.c
+++ b/src/st/sel/3410C.c
@@ -295,38 +295,7 @@ void func_801B4B9C(Entity* entity, s16 step) {
     entity->animFrameDuration = 0;
 }
 
-s32 AnimateEntity(const u8 frames[], Entity* entity) {
-    s32 flag = 0;
-    u16 currentFrameIndex = entity->animFrameIdx * 2;
-    u8* currentFrame = frames + currentFrameIndex;
-
-    if (entity->animFrameDuration == 0) {
-        if (currentFrame[0] > 0) {
-            flag = 0x80;
-            if (currentFrame[0] == 0xFF) {
-                return false;
-            }
-
-            entity->animFrameDuration = *currentFrame++;
-            entity->animCurFrame = *currentFrame++;
-            entity->animFrameIdx++;
-        } else {
-            currentFrame = frames;
-            entity->animFrameIdx = 0;
-            entity->animFrameDuration = 0;
-            entity->animFrameDuration = *currentFrame++;
-            entity->animCurFrame = *currentFrame++;
-            entity->animFrameIdx++;
-            return false;
-        }
-    }
-
-    entity->animFrameDuration = entity->animFrameDuration - 1;
-    entity->animCurFrame = currentFrame[-1];
-    flag |= true;
-
-    return (u8)flag;
-}
+#include "../animate_entity.h"
 
 void func_801B4C68(void) {
     Entity* player;

--- a/src/st/st0/31CA0.c
+++ b/src/st/st0/31CA0.c
@@ -7,20 +7,7 @@ INCLUDE_ASM("st/st0/nonmatchings/31CA0", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_801B4AF0(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;

--- a/src/st/wrp/861C.c
+++ b/src/st/wrp/861C.c
@@ -19,20 +19,7 @@ INCLUDE_ASM("st/wrp/nonmatchings/861C", TestCollisions);
 
 #include "../entity_red_door.h"
 
-#include "../../destroy_entity.h"
-
-#include "../../destroy_entities_from_index.h"
-
-void PreventEntityFromRespawning(Entity* entity) {
-    if (entity->entityRoomIndex) {
-        u32 value = (entity->entityRoomIndex - 1);
-        u16 index = value / 32;
-        u16 bit = value % 32;
-        g_entityDestroyed[index] |= 1 << bit;
-    }
-}
-
-#include "../animate_entity.h"
+#include "../entity.h"
 
 u8 func_8018B7E8(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;


### PR DESCRIPTION
This organizes funcitons believed to be originally found in `entity.c` into an equivalent `entity.h` based on the research of @Xeeynamo:

* `DestroyEntity`
* `DestroyEntitiesFromIndex`
* `AnimateEntity`
* `PreventEntityFromRespawning`

 Includes `entity.h` in place of stage implementations or ASM.