### PR TITLE
Decompile MAD BottomCornerText

### DIFF
--- a/config/symbols.stmad.txt
+++ b/config/symbols.stmad.txt
@@ -69,6 +69,7 @@ EntityIntenseExplosion = 0x801964E4;
 EntitySoulStealOrb = 0x801982BC;
 EntityEnemyBlood = 0x80198650;
 EntityRoomForeground = 0x80198B00;
+BottomCornerText = 0x80198BC8;
 GetSideToPlayer = 0x801920AC;
 UNK_Invincibility0 = 0x801806B4;
 g_ItemIconSlots = 0x80199E54;

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -560,4 +560,164 @@ void EntityRoomForeground(Entity* entity) {
     AnimateEntity(obj->unk10, entity);
 }
 
-INCLUDE_ASM("asm/us/st/mad/nonmatchings/15520", func_80198BC8);
+// Different from other overlays, but identical to the one in Weapon 21.
+void BottomCornerText(u8* str, u8 lowerLeft) {
+    u8 toPrint[64];
+    Primitive* prim;
+    s32 i;
+    u32 ch;
+    u32 ch2;
+    u8* chIdx = &toPrint;
+
+    s16 textWidth = 0;
+    s32 widthTemp;
+    // serves two purposes, use #define for dual names
+    u16 dualVar = 0;
+#define charcount dualVar
+    for (i = 0; i < 64; i++) {
+        *chIdx++ = 0;
+    }
+
+    chIdx = &toPrint;
+    while (1) {
+        ch = *str++;
+        if (ch == 0xFF) {
+            ch = *str++;
+            if (ch == 0) {
+                break;
+            }
+        }
+        *chIdx = ch;
+        chIdx++;
+        textWidth += 1;
+        if (ch != 0) {
+            charcount += 1;
+        }
+        if (*str == 0xFF) {
+            str++;
+            ch = *str++;
+            ch2 = ch & 0xFF;
+            if (ch2 == 0) {
+                break;
+            }
+            if (ch2 != 0xFF) {
+                *chIdx = ch;
+                charcount += 1;
+            } else {
+                str -= 2;
+            }
+        }
+        chIdx++;
+    }
+
+    g_unkGraphicsStruct.BottomCornerTextPrims =
+        g_api.AllocPrimitives(PRIM_SPRT, charcount + 4);
+    if (g_unkGraphicsStruct.BottomCornerTextPrims == -1) {
+        return;
+    }
+#undef charcount
+
+    prim = &g_PrimBuf[g_unkGraphicsStruct.BottomCornerTextPrims];
+    prim->type = 3;
+    prim->b0 = prim->b1 = prim->b2 = prim->b3 = prim->g0 = prim->g1 = prim->g2 =
+        prim->g3 = prim->r0 = prim->r1 = prim->r2 = prim->r3 = 0;
+    if (lowerLeft) {
+        prim->b0 = prim->b1 = 0xAF;
+    } else {
+        prim->g0 = prim->g1 = 0x5F;
+    }
+#define xpos dualVar
+
+    textWidth <<= 3;
+    if (lowerLeft) {
+        textWidth |= 4;
+        xpos = 7;
+    } else {
+        xpos = 0xD4 - textWidth;
+    }
+    prim->x0 = prim->x2 = xpos;
+    prim->x1 = prim->x3 = xpos + textWidth + 0x20;
+    prim->y0 = prim->y1 = 0xD0;
+    prim->y2 = prim->y3 = 0xDF;
+    prim->priority = 0x1EE;
+    prim->drawMode = 0x11;
+    prim = prim->next;
+
+    prim->tpage = 0x1F;
+    prim->clut = 0x197;
+    prim->x0 = xpos - 6;
+    prim->y0 = 0xCB;
+    prim->u0 = 0x80;
+    prim->v0 = 0;
+    prim->u1 = 0x10;
+    prim->v1 = 0x18;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_DEFAULT;
+    prim = prim->next;
+
+    prim->tpage = 0x1F;
+    prim->clut = 0x197;
+    prim->x0 = xpos + textWidth + 0x16;
+    prim->y0 = 0xCB;
+    prim->u0 = 0xA8;
+    prim->v0 = 0;
+    prim->u1 = 0x10;
+    prim->v1 = 0x18;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_DEFAULT;
+    prim = prim->next;
+
+    prim->type = 4;
+    prim->y0 = prim->y1 = 0xCD;
+    prim->tpage = 0x1F;
+    prim->clut = 0x197;
+    prim->y2 = prim->y3 = 0xE1;
+    prim->u0 = prim->u2 = 0x98;
+    prim->u1 = prim->u3 = 0x9C;
+    prim->v0 = prim->v1 = 2;
+    prim->x0 = prim->x2 = xpos + 0xA;
+    prim->x1 = prim->x3 = xpos + textWidth + 0x18;
+    prim->v2 = prim->v3 = 0x16;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_DEFAULT;
+
+    xpos += 0x10;
+
+    chIdx = &toPrint;
+    for (prim = prim->next; prim != NULL;) {
+        ch = *chIdx++;
+        if (ch != 0) {
+            prim->u0 = (ch & 0xF) * 8;
+            prim->v0 = (ch & 0xF0) >> 1;
+            prim->tpage = 0x1E;
+            prim->clut = 0x196;
+            prim->v1 = 8;
+            prim->u1 = 8;
+            prim->priority = 0x1F0;
+            prim->drawMode = 0;
+            prim->x0 = xpos;
+            prim->y0 = 0xD4;
+            prim = prim->next;
+        }
+        ch = *chIdx++;
+        if (ch != 0) {
+            prim->u0 = (ch & 0xF) * 8;
+            prim->v0 = (ch & 0xF0) >> 1;
+            prim->tpage = 0x1E;
+            prim->clut = 0x196;
+            prim->v1 = 8;
+            prim->u1 = 8;
+            prim->priority = 0x1F0;
+            prim->drawMode = 0;
+            prim->x0 = xpos;
+            prim->y0 = 0xCC;
+            prim = prim->next;
+        }
+        if ((u32)((ch + 0x10) & 0xFF) < 0xDU) {
+            xpos += 0xC;
+        } else {
+            xpos += 8;
+        }
+    }
+    g_unkGraphicsStruct.BottomCornerTextTimer = 0x130;
+}

--- a/src/st/mad/EDB8.c
+++ b/src/st/mad/EDB8.c
@@ -216,7 +216,8 @@ void TestCollisions(void) {
                             g_unkGraphicsStruct.BottomCornerTextPrims);
                         g_unkGraphicsStruct.BottomCornerTextTimer = 0;
                     }
-                    func_80198BC8(g_api.enemyDefs[entFrom5C->enemyId].name, 0);
+                    BottomCornerText(
+                        g_api.enemyDefs[entFrom5C->enemyId].name, 0);
                     entFrom5C->flags |= FLAG_UNK_01000000;
                 }
                 miscVar2 = 0;
@@ -1052,7 +1053,7 @@ void CollectGold(u16 goldSize) { // CollectGold
         *unk = 0;
     }
 
-    func_80198BC8(D_80180D60[goldSizeIndex], 1);
+    BottomCornerText(D_80180D60[goldSizeIndex], 1);
     DestroyEntity(g_CurrentEntity);
 }
 

--- a/src/st/mad/mad.h
+++ b/src/st/mad/mad.h
@@ -39,7 +39,7 @@ void CreateEntityFromCurrentEntity(u16, Entity*);
 u8 func_80192914(s16 arg0, s16 arg1);
 void ReplaceBreakableWithItemDrop(Entity*);
 void CreateEntityFromEntity(u16 entityId, Entity* ent1, Entity* ent2);
-void func_80198BC8(void* const, s32);
+void BottomCornerText(u8* str, u8 lowerLeft);
 void func_8019344C(void);
 void EntityUnkId15(Entity* entity);
 


### PR DESCRIPTION
When decompiling MAD TestCollisions in my last PR, I noticed that the call to BottomCornerText was going to func_80198BC8 in MAD, which was not yet decompiled.

The duplicates report indicated that func_80198BC8 was a duplicate of func_97000_8017AB54, a weapon function that I decompiled a few weeks ago.

I copied the code for that function into here, and renamed it to BottomCornerText to match the other overlays, even though it's not the exact same code as is used in other overlays.