### PR TITLE
Fix zero-related bug in decompile.py

### DIFF
--- a/tools/decompile.py
+++ b/tools/decompile.py
@@ -272,7 +272,7 @@ def decompile(func_name: str, number_occurrence: int = None, force: bool = False
 
     if force:
         funcs = funcs[:1]
-    elif number_occurrence and number_occurrence < len(funcs):
+    elif number_occurrence is not None and number_occurrence < len(funcs):
         funcs = [funcs[number_occurrence]]
     else:
         if len(funcs) > 1:


### PR DESCRIPTION
When using the `dec` script, it is possible to select a function where there are multiple functions sharing a name. The test case I had for this was `EntityEquipItemDrop`. If you run `dec EntityEquipItemDrop`, it will tell you that there are 4 occurrences of functions with that name, and list the four, telling you to re-run with -n or -f to specify which.

If you choose to specify option #0, with `dec EntityEquipItemDrop -n 0`, then the number_occurence variable will be set to zero. But the if-statement `if number_occurrence` fails, because the value is zero, which is parsed as False. Decompilation therefore fails, as if you had not passed `-n`.

This change explicitly tests for None, so that zero is a valid selection.