### PR TITLE
Nicer logs

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -11,7 +11,7 @@ typedef enum {
 } LOG_LEVEL;
 
 #define NAMEOF(var) #var
-#define NOT_IMPLEMENTED DEBUGF("not implemented")
+#define NOT_IMPLEMENTED WARNF("not implemented")
 
 #ifndef NO_LOGS
 

--- a/src/pc/log.c
+++ b/src/pc/log.c
@@ -1,6 +1,10 @@
 #include <log.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
+
+// uncomment to disable the logs grouping feature
+// #define FORCE_LINEAR_LOGS
 
 #ifdef NDEBUG
 LOG_LEVEL g_MinLogLevel = LOG_LEVEL_I;
@@ -10,22 +14,103 @@ LOG_LEVEL g_MinLogLevel = LOG_LEVEL_D;
 
 void SetMinLogLevel(LOG_LEVEL level) { g_MinLogLevel = level; }
 
+typedef unsigned int hash;
+
+typedef struct {
+    unsigned short level;
+    unsigned short count;
+    size_t ttyLine;
+    hash hash;
+} LogEntry;
+
+#define MAX_LOGS 65536
+#define MASTER_SEED 5381
+
+static LogEntry logHistory[MAX_LOGS] = {0};
+static size_t ttyLineCount = 1;
+
+hash djb2_hash(hash hash, const char* str) {
+    int c;
+    while ((c = *str++))
+        hash += (hash << 5) + c;
+    return hash;
+}
+
+static const char levels[] = "DIWE";
+static const char* coloured_levels[] = {
+    "\033[1;90;m",
+    "\033[1;37;m",
+    "\033[1;33;m",
+    "\033[1;31;m",
+};
+
+// WARNING: the whole function is thread-unsafe
 void _log(unsigned int level, const char* file, unsigned int line,
           const char* func, const char* fmt, ...) {
-    static const char levels[] = "DIWE";
     va_list args;
 
     va_start(args, fmt);
-    if (level >= g_MinLogLevel && level < LEN(levels)) {
+    if (level >= g_MinLogLevel && level < sizeof(levels) - 1) {
         char buf[1024];
 
         int n = vsnprintf(buf, sizeof(buf), fmt, args);
         if (n >= sizeof(buf)) {
             WARNF("cannot write '%d' characters in '%s'", n, NAMEOF(buf));
+            buf[sizeof(buf) - 1] = '\0';
         }
 
-        fprintf(stderr, "[%c][%s:%d][%s] %s\n", levels[level], file, line, func,
-                buf);
+#ifdef FORCE_LINEAR_LOGS
+        if (false) {
+#else
+        if (isatty(fileno(stderr))) {
+#endif
+            hash altHash = djb2_hash(MASTER_SEED, buf);
+            hash logHash = altHash;
+            logHash = djb2_hash(logHash, file);
+            logHash += (logHash << 5) + line;
+            logHash = djb2_hash(logHash, func);
+
+            LogEntry* entry = &logHistory[logHash % MAX_LOGS];
+            if (entry->hash) {
+                // check if the collision is real or caused by a small dict
+                if (entry->hash == altHash) {
+                    // duplicate log
+                    if (++entry->count > 9999) {
+                        // adjust the count to show the log keeps being
+                        // triggered
+                        entry->count = 9000;
+                    }
+
+                    // go back N amount of lines to modify the existing log
+                    size_t nLinesBack = ttyLineCount - entry->ttyLine;
+                    while (nLinesBack-- > 0) {
+                        fputs("\033[F", stderr);
+                    }
+
+                    // now update the log line, in a very cheap way
+                    fprintf(stderr, "(%d) ", entry->count);
+
+                    // go immediately back to the last line
+                    nLinesBack = ttyLineCount - entry->ttyLine;
+                    while (nLinesBack-- > 0) {
+                        fputs("\033[E", stderr);
+                    }
+                    va_end(args);
+                    return;
+                }
+            }
+
+            entry->level = level;
+            entry->count = 1;
+            entry->ttyLine = ttyLineCount;
+            entry->hash = altHash;
+            ttyLineCount++;
+            fprintf(stderr, "%s%s:%d ┃ %s ┃ %s\033[m\n", coloured_levels[level],
+                    file, line, func, buf);
+        } else {
+            fprintf(stderr, "[%c][%s:%d][%s] %s\n", levels[level], file, line,
+                    func, buf);
+        }
     }
     va_end(args);
 }

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -88,8 +88,11 @@ void DebugInputWait(const char* msg);
 
 int g_Frame = 0;
 void MyDrawSyncCallback(int mode) {
-    DEBUGF("-------------------- frame %d --------------------", g_Frame);
     DEBUGF("state: %d, game step: %d", g_GameState, g_GameStep);
+    DEBUGF("*** HEEY, I AM A DEBUG LOG");
+    INFOF("*** YOYO, I AM AN INFO LOG");
+    WARNF("*** 'SUP, I AM A WARN LOG");
+    ERRORF("*** HALT, I AM A WARN LOG");
 
     // force loaded map to always be visible
     if (g_Tilemap.tileDef) {

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -89,10 +89,6 @@ void DebugInputWait(const char* msg);
 int g_Frame = 0;
 void MyDrawSyncCallback(int mode) {
     DEBUGF("state: %d, game step: %d", g_GameState, g_GameStep);
-    DEBUGF("*** HEEY, I AM A DEBUG LOG");
-    INFOF("*** YOYO, I AM AN INFO LOG");
-    WARNF("*** 'SUP, I AM A WARN LOG");
-    ERRORF("*** HALT, I AM A WARN LOG");
 
     // force loaded map to always be visible
     if (g_Tilemap.tileDef) {


### PR DESCRIPTION
![image](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/81e07623-f2d5-4b00-9624-7aa678593aa8)

Add colours to the various logs to make sense out of all the produced noise. Also gets rid of the square brackets and use a nicer column separator. Don't mind the error log being mis-labeled. My hunger for copy&pasting code consistently betrays me.

![image](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/1873521f-cb41-4a80-aa0c-7e6b6a752ffa)

but most importantly groups the logs to avoid spamming the same one for every frame. The log count keeps getting updated on the left-hand side of the log, replacing the beginning of the path (almost never relevant). If the log is old, the logging function will go back, update the line and go back down.

It is a tad bit slower than the original implementation, but logs are never meant to be seen anyway, especially debug logs. I used a relatively fast hashing function paired with a dictionary to avoid unnecessary loops. There are two hashes. `logHash` simply works as an index to the massive 65K entry dictionary to pick an index. If an entry is found then check the other hash `altHash` to check if the dictionary collided with an actually different log, effectively replacing it. Since `entry->hash` is `0` at the beginning, that also works for new elements.

I believe the slowest part of the code are the two `while (nLinesBack-- > 0)`. I am thinking to maybe unroll the loop in a similar way `memcpy` works internally to save `fputs` calls. But I have little clue on how to measure improvements. If you know better on how to take advantage of moving the cursor through the TTY, please let me know.

You can disable this entire functionality with `#define FORCE_LINEAR_LOGS` and it gets disabled if `stderr` is not printing on a terminal.