### PR TITLE
patchgte to asm

### DIFF
--- a/config/splat.us.main.yaml
+++ b/config/splat.us.main.yaml
@@ -154,7 +154,7 @@ segments:
       - [0x956C, c, psxsdk/libgte/fgo_05]
       - [0x970C, c, psxsdk/libgte/fgo_06]
       - [0x98AC, c, psxsdk/libgte/ratan]
-      - [0x9A2C, c, psxsdk/libgte/patchgte]
+      - [0x9A2C, asm, psxsdk/libgte/patchgte]
       - [0x9ACC, c, psxsdk/libapi/c68]
       - [0x9ADC, c, psxsdk/libcd/cdrom]
       - [0x9B0C, c, psxsdk/libcd/event]

--- a/src/main/psxsdk/libgte/patchgte.c
+++ b/src/main/psxsdk/libgte/patchgte.c
@@ -1,5 +1,0 @@
-#include "common.h"
-
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/patchgte", patch_gte);
-
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/patchgte", func_8001929C);


### PR DESCRIPTION
I think this file is all handwritten asm

patch_gte
https://gist.github.com/sozud/f25a15fe190fc8fa77b59b2278de4d85

func_8001929C
https://gist.github.com/sozud/27df133a0207fa732991b0786ee2f34c

func_8001929C is the code used to patch the bios. The sequence
```
/* 9A3C 8001923C B0000A24 */  addiu      $t2, $zero, 0xB0
/* 9A40 80019240 09F84001 */  jalr       $t2
/* 9A44 80019244 56000924 */   addiu     $t1, $zero, 0x56
```
looks like a bios call to me and I'm not sure this can be generated by a compiler? Scratch here
https://decomp.me/scratch/TlFnw