### PR TITLE
Fix args for func_80118B18

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1345,7 +1345,7 @@ typedef struct {
     /* 8003C804 */ void (*func_80118894)(Entity*);
     /* 8003C808 */ EnemyDef* enemyDefs;
     /* 8003C80C */ Entity* (*func_80118970)(void);
-    /* 8003C810 */ s32 (*func_80118B18)(Entity* ent1, Entity* ent2, s32 arg2);
+    /* 8003C810 */ s32 (*func_80118B18)(Entity* ent1, Entity* ent2, s16 facingLeft);
     /* 8003C814 */ s32 (*UpdateUnarmedAnim)(s8* frameProps, u16** frames);
     /* 8003C818 */ void (*func_8010DBFC)(s8*, s32*);
     /* 8003C81C */ void (*func_80118C28)(s32 arg0);

--- a/include/game.h
+++ b/include/game.h
@@ -1345,7 +1345,8 @@ typedef struct {
     /* 8003C804 */ void (*func_80118894)(Entity*);
     /* 8003C808 */ EnemyDef* enemyDefs;
     /* 8003C80C */ Entity* (*func_80118970)(void);
-    /* 8003C810 */ s32 (*func_80118B18)(Entity* ent1, Entity* ent2, s16 facingLeft);
+    /* 8003C810 */ s32 (*func_80118B18)(
+        Entity* ent1, Entity* ent2, s16 facingLeft);
     /* 8003C814 */ s32 (*UpdateUnarmedAnim)(s8* frameProps, u16** frames);
     /* 8003C818 */ void (*func_8010DBFC)(s8*, s32*);
     /* 8003C81C */ void (*func_80118C28)(s32 arg0);

--- a/src/dra/75F54.c
+++ b/src/dra/75F54.c
@@ -1340,7 +1340,7 @@ Entity* func_80118970(void) {
     return NULL;
 }
 
-s32 func_80118B18(Entity* ent1, Entity* ent2, s32 arg2) {
+s32 func_80118B18(Entity* ent1, Entity* ent2, s16 facingLeft) {
     s16 var_a1;
     s16 posX;
     s16 posY;
@@ -1351,7 +1351,7 @@ s32 func_80118B18(Entity* ent1, Entity* ent2, s32 arg2) {
         posY = ent2->posY.i.hi;
     } else {
         posY = 112;
-        if ((arg2 << 0x10) != 0) {
+        if (facingLeft != 0) {
             posX = -32;
         } else {
             posX = 288;

--- a/src/dra/dra_header.c
+++ b/src/dra/dra_header.c
@@ -31,7 +31,7 @@ DR_ENV* func_800EDB08(POLY_GT4* poly);
 u16* func_80106A28(u32 arg0, u16 kind);
 void func_80118894(Entity* self);
 Entity* func_80118970(void);
-s32 func_80118B18(Entity* ent1, Entity* ent2, s32 arg2);
+s32 func_80118B18(Entity* ent1, Entity* ent2, s16 facingLeft);
 u32 UpdateUnarmedAnim(s8* frameProps, u16** frames);
 void func_8010DBFC(s32*, s32*);
 void func_80118C28(s32 arg0);


### PR DESCRIPTION
The Medusa Shield's laser-beams use this function for finding enemies to target (I think).

I was reviewing this function and noticed the awkward line `if ((arg2 << 0x10) != 0) {`, and realized that means `arg2` should be `s16`. It matches, so I think this is right.

Named it facingLeft since that's what is used in the call that I have so far. The function graphs indicate that there are 3 functions that use this one (none decompiled yet), so we will see if this shifts as we discover more. For now, I think this change makes the most sense.