### PR TITLE
Fix AnsiToSotnMenuString to not spam logs

### DIFF
--- a/src/pc/str.c
+++ b/src/pc/str.c
@@ -196,13 +196,13 @@ const char* AnsiToSotnMenuString(const char* str) {
         ERRORF("buffer full for '%s' (%d/%d)", str, end, LEN(str_buffer));
         return dummy_string;
     }
+    DEBUGF("%s", str);
 
     char* start = str_buffer + str_buffer_index;
     char* dst = start;
     const unsigned char* src = str;
     struct SotnMenuPair* pair;
     while (*src != '\0') {
-        DEBUGF("%s", src);
         SotnMenuPair* pair = ReadCharacterInfo(&src);
         if (pair) {
             *dst++ = pair->value;


### PR DESCRIPTION
Now with a much faster start-up