### PR TITLE
Add blueprint support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ set(SOURCE_FILES_PC
     src/pc/str.c
     src/pc/sim_pc.c
     src/pc/pl_ric.c
-    src/pc/stage_dummy.c
+    src/pc/stages/stage_loader.c
+    src/pc/stages/stage_dummy.c
 )
 
 if(WIN32)
@@ -112,7 +113,7 @@ set(SOURCE_FILES_DRA
 )
 
 set(SOURCE_FILES_STAGE_SEL
-    src/pc/stage_sel.c
+    src/pc/stages/stage_sel.c
     src/st/sel/banks.c
     src/st/sel/CD54.c
     src/st/sel/2C048.c

--- a/src/pc/pc.h
+++ b/src/pc/pc.h
@@ -24,8 +24,16 @@ typedef struct {
     size_t length;
 } FileLoad;
 
+typedef struct {
+    const char* path;
+    const char* content;
+    size_t length;
+    void* param;
+} FileStringified;
+
 bool FileRead(bool (*cb)(FILE* file), const char* path);
-bool FileStringify(bool (*cb)(const char* content), const char* path);
+bool FileStringify(
+    bool (*cb)(FileStringified* file), const char* path, void* param);
 bool FileUseContent(
     bool (*cb)(FileLoad* file, void* param), const char* path, void* param);
 

--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -112,8 +112,8 @@ void InitSubwpnDefs(void);
 void InitGfxEquipIcons(FILE* f);
 void InitPalEquipIcons(FILE* f);
 void InitVbVh(void);
-bool InitSfxData(const char* content);
-bool InitXaData(const char* content);
+static bool InitSfxData(FileStringified* file);
+static bool InitXaData(FileStringified* file);
 
 bool InitGame(void) {
     if (!InitPlatform()) {
@@ -216,11 +216,11 @@ bool InitGame(void) {
     FileRead(InitPalEquipIcons, "assets/dra/g_PalEquipIcon.bin");
     InitVbVh();
 
-    if (!FileStringify(InitSfxData, "assets/dra/sfx.json")) {
+    if (!FileStringify(InitSfxData, "assets/dra/sfx.json", NULL)) {
         WARNF("failed to init sfx");
     }
 
-    if (!FileStringify(InitXaData, "assets/dra/music_xa.json")) {
+    if (!FileStringify(InitXaData, "assets/dra/music_xa.json", NULL)) {
         WARNF("failed to init xa data");
     }
 
@@ -242,7 +242,8 @@ bool FileRead(bool (*cb)(FILE* file), const char* path) {
     fclose(f);
     return r;
 }
-bool FileStringify(bool (*cb)(const char* content), const char* path) {
+bool FileStringify(
+    bool (*cb)(FileStringified* file), const char* path, void* param) {
     INFOF("open '%s'", path);
     FILE* f = fopen(path, "rb");
     if (f == NULL) {
@@ -271,7 +272,12 @@ bool FileStringify(bool (*cb)(const char* content), const char* path) {
 
     ((char*)content)[len] = '\0';
 
-    bool r = cb(content);
+    FileStringified file;
+    file.path = path;
+    file.content = content;
+    file.length = len;
+    file.param = param;
+    bool r = cb(&file);
     free(content);
     fclose(f);
     return r;
@@ -470,8 +476,8 @@ void InitVbVh() {
         }                                                                      \
     }
 
-bool InitSfxData(const char* content) {
-    cJSON* json = cJSON_Parse(content);
+static bool InitSfxData(FileStringified* file) {
+    cJSON* json = cJSON_Parse(file->content);
     cJSON* array = cJSON_GetObjectItemCaseSensitive(json, "asset_data");
     if (cJSON_IsArray(array)) {
         int len = cJSON_GetArraySize(array);
@@ -494,8 +500,8 @@ bool InitSfxData(const char* content) {
     return true;
 }
 
-bool InitXaData(const char* content) {
-    cJSON* json = cJSON_Parse(content);
+static bool InitXaData(FileStringified* file) {
+    cJSON* json = cJSON_Parse(file->content);
     cJSON* array = cJSON_GetObjectItemCaseSensitive(json, "asset_data");
     if (cJSON_IsArray(array)) {
         int len = cJSON_GetArraySize(array);

--- a/src/pc/stages/stage_dummy.c
+++ b/src/pc/stages/stage_dummy.c
@@ -1,0 +1,97 @@
+#include <game.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cJSON/cJSON.h>
+#include "stage_loader.h"
+#include "sfx.h"
+
+static void Update(void);
+static void TestCollisions(void);
+static void func_8018A7AC(void);
+static void InitRoomEntities(s32 objLayoutId);
+
+static RoomHeader g_Rooms[1];
+static s16** g_SpriteBanks[1];
+static u16* g_Cluts[1];
+static void* g_EntityGfxs[17];
+static void UpdateStageEntities(void);
+
+static Overlay g_StageDesc = {
+    Update,
+    TestCollisions,
+    func_8018A7AC,
+    InitRoomEntities,
+    g_Rooms,
+    g_SpriteBanks,
+    g_Cluts,
+    NULL,
+    NULL,
+    g_EntityGfxs,
+    UpdateStageEntities,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+static RoomHeader g_Rooms[1] = {0};
+static s16** g_SpriteBanks[1] = {0};
+
+static u32* D_801801B8[] = {
+    (u32*)0x00000000, (u32*)0x00000000, (u32*)0x00000000,
+    (u32*)0x00000000, (u32*)0xFFFFFFFF,
+};
+static void* g_EntityGfxs[] = {
+    D_801801B8, D_801801B8, D_801801B8, D_801801B8, D_801801B8, D_801801B8,
+    D_801801B8, D_801801B8, D_801801B8, D_801801B8, D_801801B8, D_801801B8,
+    D_801801B8, D_801801B8, D_801801B8, D_801801B8, NULL,
+};
+
+static u8 D_80181D08[0x2000];
+static u32* D_801800A0[] = {
+    (u32*)0x00000005, (u32*)0x00002000, (u32*)0x00000010,
+    (u32*)D_80181D08, (u32*)0xFFFFFFFF,
+};
+static u16* g_Cluts[] = {
+    D_801800A0,
+};
+
+void InitStageDummy(Overlay* o) {
+    FILE* f;
+
+    f = fopen("assets/st/wrp/D_80181D08.dec", "rb");
+    if (f) {
+        fseek(f, 0, SEEK_END);
+        size_t len = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        fread(D_80181D08, len, 1, f);
+        fclose(f);
+    }
+
+    g_StageDesc.tileLayers = LoadRooms("assets/st/wrp/rooms.layers.json");
+    memcpy(o, &g_StageDesc, sizeof(Overlay));
+}
+
+static void Update(void) { NOT_IMPLEMENTED; }
+
+static void TestCollisions(void) { NOT_IMPLEMENTED; }
+
+static void func_8018A7AC(void) { NOT_IMPLEMENTED; }
+
+void SetGameState(GameState gameState);
+void PlaySfx(s32 sfxId);
+static void InitRoomEntities(s32 objLayoutId) {
+    if (g_StageId == STAGE_SEL) {
+        SetGameState(Game_NowLoading);
+        g_GameStep = NowLoading_2;
+        g_StageId = STAGE_WRP;
+        return;
+    }
+
+    INFOF("Stage ID: %02X", g_StageId);
+    PlaySfx(MU_REQUIEM_FOR_THE_GODS);
+}
+
+static void UpdateStageEntities(void) { NOT_IMPLEMENTED; }

--- a/src/pc/stages/stage_loader.h
+++ b/src/pc/stages/stage_loader.h
@@ -1,0 +1,10 @@
+#ifndef STAGE_LOADER_H
+#define STAGE_LOADER_H
+
+#include "../pc.h"
+
+// load a rooms.layers.json file and all its dependencies to the returned
+// pre-allocated RoomDef array. Returns NULL in case of a failure.
+RoomDef* LoadRooms(const char* filePath);
+
+#endif

--- a/src/pc/stages/stage_sel.c
+++ b/src/pc/stages/stage_sel.c
@@ -1,6 +1,6 @@
 #include <game.h>
-#include "../st/sel/sel.h"
-#include "pc.h"
+#include "../../st/sel/sel.h"
+#include "../pc.h"
 #include "sfx.h"
 
 // stubs

--- a/src/pc/stubs.c
+++ b/src/pc/stubs.c
@@ -204,7 +204,6 @@ SVECTOR* D_800B0CB4[][4] = {
     &stubbbbbbbb, &stubbbbbbbb, &stubbbbbbbb,
 };
 unk_800B08CC D_800B08CC[6] = {0};
-FactoryBlueprint g_FactoryBlueprints[400] = {0}; // TODO load from JSON file
 s32 D_800B07C8 = 0x12345678;
 Unkstruct_80138094 D_80138094[100]; // unknown size
 s32 D_8013808C;

--- a/tools/splat_ext/assets.py
+++ b/tools/splat_ext/assets.py
@@ -99,9 +99,9 @@ def serialize_asset(content: str, asset_config: str) -> bytearray:
                     field_bitsize = field_def[field_name]
                     # If the field is a bit flag
                     if field_bitsize == 1:
-                        if subvalue == "TRUE":
+                        if subvalue == True:
                             packed_bitstring += "1"
-                        elif subvalue == "FALSE":
+                        elif subvalue == False:
                             packed_bitstring += "0"
                         else:
                             print("Problem serializing asset")
@@ -206,7 +206,7 @@ class PSXSegAssets(N64Segment):
                             # If the field is a bit flag
                             if field_bitcount == 1:
                                 bit_state = (
-                                    "TRUE" if value_bits[bit_index] == "1" else "FALSE"
+                                    True if value_bits[bit_index] == "1" else False
                                 )
                                 parsed_fields[field_name] = bit_state
                                 bit_index += 1


### PR DESCRIPTION
I had to cherry-pick some existing changes from another branch, but that part is tested and working.

For the blueprint stuff, I changed the fields from the strings `"TRUE"` and `"FALSE"` to native JSON boolean values `true` and `false`. That made things much easier to parse.

The parsing mechanic is straightforward. I'd like to have @bismurphy review on the blueprint parser and asset changes specifically.

One of the blueprints in action:

![image](https://github.com/Xeeynamo/sotn-decomp/assets/6128729/68bcc339-fd54-4eaf-9f07-e314450c7755)
