### PR TITLE
Defake NP3 func_801CD78C

### DIFF
--- a/src/st/np3/4B018.c
+++ b/src/st/np3/4B018.c
@@ -62,16 +62,14 @@ void func_801CD734() {
         func_801CD658();
 }
 
-void func_801CD78C(Entity* src, s32 speed, s16 angle, Entity* dst) {
-    if (g_CurrentEntity->facingLeft != 0) {
+void func_801CD78C(Point32* src, s32 speed, s16 angle, Point32* dst) {
+    if (g_CurrentEntity->facingLeft) {
         angle = -angle;
     }
+    *dst = *src;
 
-    //! FAKE:
-    (*(Point32*)dst) = (*(Point32*)src);
-
-    (*(Point32*)dst).x -= speed * rsin(angle) * 16;
-    (*(Point32*)dst).y += speed * rcos(angle) * 16;
+    dst->x -= speed * rsin(angle) * 16;
+    dst->y += speed * rcos(angle) * 16;
 }
 
 void func_801CD83C(Entity* self) {


### PR DESCRIPTION
This function is part of a small network of functions that pass around Entities and Point32s, so it ends up being a little weird. I guess the first two elements of an Entity are equivalent to a Point32, but still weird.

Within this function though, there is nothing to indicate that the args are Entity, and a PSP function seems to allocate the right stack size to call this with Point32, so I think we should do that, and have the callers cast their entities to Point32 if needed.