### PR TITLE
Conditionally compile libsnd

### DIFF
--- a/.github/workflows/picci.yaml
+++ b/.github/workflows/picci.yaml
@@ -62,3 +62,18 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/pc -DCMAKE_BUILD_TYPE=Release -DSDL2_PATH=C:\temp-sdl2\SDL2-2.28.5
         cmake --build ${{github.workspace}}/pc --config Release
+
+  build-linux-lle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install requirements
+        run: sudo apt-get update && sudo apt-get install build-essential libsdl2-dev
+      - name: Clone repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          submodules: false
+      - name: Build
+        run: |
+          cmake -B ${{github.workspace}}/pc -DWANT_LIBSND_LLE=1
+          cmake --build ${{github.workspace}}/pc --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,97 @@ set(SOURCE_FILES_PSX_SDK
     src/main/psxsdk/libgpu/prim.c
 )
 
+set(WANT_LIBSND_LLE FALSE CACHE BOOL "Whether to append use LLE for libsnd")
+
+if(WANT_LIBSND_LLE)
+set(SOURCE_FILES_LIBSND_LLE
+    # libsnd
+    src/main/psxsdk/libsnd/adsr.c
+    src/main/psxsdk/libsnd/cres.c
+    src/main/psxsdk/libsnd/decre.c
+    src/main/psxsdk/libsnd/libsnd_i.h
+    src/main/psxsdk/libsnd/next.c
+    src/main/psxsdk/libsnd/pause.c
+    src/main/psxsdk/libsnd/play.c
+    src/main/psxsdk/libsnd/replay.c
+    src/main/psxsdk/libsnd/scsmvol.c
+    src/main/psxsdk/libsnd/scssattr.c
+    src/main/psxsdk/libsnd/scssvol.c
+    src/main/psxsdk/libsnd/seqinit.c
+    src/main/psxsdk/libsnd/seqread.c
+    src/main/psxsdk/libsnd/seskoff.c
+    src/main/psxsdk/libsnd/seskon.c
+    src/main/psxsdk/libsnd/sscall.c
+    src/main/psxsdk/libsnd/ssclose.c
+    src/main/psxsdk/libsnd/ssend.c
+    src/main/psxsdk/libsnd/ssinit.c
+    src/main/psxsdk/libsnd/ssinit_h.c
+    src/main/psxsdk/libsnd/ssplay.c
+    src/main/psxsdk/libsnd/ssquit.c
+    src/main/psxsdk/libsnd/ssstart.c
+    src/main/psxsdk/libsnd/sstable.c
+    src/main/psxsdk/libsnd/sstick.c
+    src/main/psxsdk/libsnd/ssvol.c
+    src/main/psxsdk/libsnd/stop.c
+    src/main/psxsdk/libsnd/tempo.c
+    src/main/psxsdk/libsnd/ut_gpa.c
+    src/main/psxsdk/libsnd/ut_gva.c
+    src/main/psxsdk/libsnd/ut_rdel.c
+    src/main/psxsdk/libsnd/ut_rdep.c
+    src/main/psxsdk/libsnd/ut_rev.c
+    src/main/psxsdk/libsnd/ut_rfb.c
+    src/main/psxsdk/libsnd/ut_roff.c
+    src/main/psxsdk/libsnd/ut_ron.c
+    src/main/psxsdk/libsnd/ut_sva.c
+    src/main/psxsdk/libsnd/vm_doff.c
+    src/main/psxsdk/libsnd/vm_don.c
+    src/main/psxsdk/libsnd/vm_vsu.c
+    src/main/psxsdk/libsnd/vmanager.c
+    src/main/psxsdk/libsnd/vs_mono.c
+    src/main/psxsdk/libsnd/vs_srv.c
+    src/main/psxsdk/libsnd/vs_vab.c
+    src/main/psxsdk/libsnd/vs_vfb.c
+    src/main/psxsdk/libsnd/vs_vh.c
+    src/main/psxsdk/libsnd/vs_vtb.c
+    src/main/psxsdk/libsnd/vs_vtbp.c
+    src/main/psxsdk/libsnd/vs_vtc.c
+    
+    # libspu
+    src/main/psxsdk/libspu/s_cb.c
+    src/main/psxsdk/libspu/s_crwa.c
+    src/main/psxsdk/libspu/s_dcb.c
+    src/main/psxsdk/libspu/s_gva.c
+    src/main/psxsdk/libspu/s_i.c
+    src/main/psxsdk/libspu/s_ini.c
+    src/main/psxsdk/libspu/s_it.c
+    src/main/psxsdk/libspu/s_itc.c
+    src/main/psxsdk/libspu/s_m_f.c
+    src/main/psxsdk/libspu/s_m_init.c
+    src/main/psxsdk/libspu/s_m_m.c
+    src/main/psxsdk/libspu/s_m_util.c
+    src/main/psxsdk/libspu/s_m_wsa.c
+    src/main/psxsdk/libspu/s_n2p.c
+    src/main/psxsdk/libspu/s_q.c
+    src/main/psxsdk/libspu/s_r.c
+    src/main/psxsdk/libspu/s_sav.c
+    src/main/psxsdk/libspu/s_sca.c
+    src/main/psxsdk/libspu/s_si.c
+    src/main/psxsdk/libspu/s_sic.c
+    src/main/psxsdk/libspu/s_sk.c
+    src/main/psxsdk/libspu/s_snv.c
+    src/main/psxsdk/libspu/s_sr.c
+    src/main/psxsdk/libspu/s_srmp.c
+    src/main/psxsdk/libspu/s_stm.c
+    src/main/psxsdk/libspu/s_stsa.c
+    src/main/psxsdk/libspu/s_sva.c
+    src/main/psxsdk/libspu/s_w.c
+    src/main/psxsdk/libspu/s_wp.c
+    src/main/psxsdk/libspu/spu.c
+    src/main/psxsdk/libspu/sr_gaks.c
+)
+list(APPEND SOURCE_FILES_PSX_SDK ${SOURCE_FILES_LIBSND_LLE})
+endif()
+
 set(SOURCE_FILES_MOCK_SDK
     src/pc/psxsdk/libapi.c
     src/pc/psxsdk/libetc.c
@@ -204,6 +295,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ${SDL2_LIBRARIES} core m)
 endif()
 
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     _USE_MATH_DEFINES # needed for msvc
     VERSION_PC
@@ -213,6 +305,10 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     DEMO_KEY_PTR=0
     _internal_version_us
     )
+
+if(WANT_LIBSND_LLE)
+target_compile_definitions(core PRIVATE WANT_LIBSND_LLE=1)
+endif()
 
 # null target
 

--- a/src/main/psxsdk/libsnd/libsnd_i.h
+++ b/src/main/psxsdk/libsnd/libsnd_i.h
@@ -31,7 +31,7 @@ void SpuInit();
 void _SsInit();
 void Snd_SetPlayMode(s16, s16, u8, s16);
 void SpuQuit();
-void _SsStart(s32);
+static void _SsStart(s32);
 extern void (*D_80032EF8)();
 extern void (*D_80032EFC)();
 extern s32 D_80032F04;
@@ -50,8 +50,7 @@ extern s32 _svm_vab_total[];
 extern s32 _svm_vab_start[];
 extern u8 _svm_vab_used[];
 
-s16 SsVabOpenHeadWithMode(u8* addr, s16 vabid, s32 arg2, u32 sbaddr);
-
+int SsVabOpenHeadWithMode(unsigned char *pAddr, int vabId, s32 pFn, long mode);
 void SpuFree(s32);
 extern u16 _svm_vab_count;
 

--- a/src/main/psxsdk/libsnd/libsnd_i.h
+++ b/src/main/psxsdk/libsnd/libsnd_i.h
@@ -50,7 +50,7 @@ extern s32 _svm_vab_total[];
 extern s32 _svm_vab_start[];
 extern u8 _svm_vab_used[];
 
-int SsVabOpenHeadWithMode(unsigned char *pAddr, int vabId, s32 pFn, long mode);
+int SsVabOpenHeadWithMode(unsigned char* pAddr, int vabId, s32 pFn, long mode);
 void SpuFree(s32);
 extern u16 _svm_vab_count;
 

--- a/src/main/psxsdk/libsnd/ssstart.c
+++ b/src/main/psxsdk/libsnd/ssstart.c
@@ -1,8 +1,8 @@
 #include "common.h"
 #include "libsnd_i.h"
 
-void _SsSeqCalledTbyT_1per2();
-void _SsTrapIntrVSync();
+static void _SsSeqCalledTbyT_1per2();
+static void _SsTrapIntrVSync();
 
 static void _SsStart(s32 arg0) {
     u16 rcnt_target;

--- a/src/pc/psxsdk/libsnd.c
+++ b/src/pc/psxsdk/libsnd.c
@@ -1,3 +1,4 @@
+#ifndef WANT_LIBSND_LLE
 #include <common.h>
 #include <psxsdk/libspu.h>
 #include <psxsdk/libsnd.h>
@@ -73,9 +74,284 @@ s32 SsVabOpenHeadSticky(u_char* addr, u_long vabid, u_long sbaddr) {
     return 0;
 }
 
-s32 SsVabTransBodyPartly(u_char* addr, u_long bufsize, u_long vabid) {
+short SsVabTransBodyPartly(
+    unsigned char* addr, unsigned long bufsize, short vabid) {
     NOT_IMPLEMENTED;
     return 0;
 }
 
 void SsVabClose(short vab_id) { NOT_IMPLEMENTED; }
+
+#else
+#include <common.h>
+#include <psxsdk/libspu.h>
+#include <log.h>
+#include <assert.h>
+#include "../../main/psxsdk/libsnd/libsnd_i.h"
+
+u16* D_80032F10;
+
+struct SpuVoice _svm_voice[NUM_SPU_CHANNELS];
+
+void WaitEvent(s32) {}
+
+union RegBuf _svm_sreg_buf;
+
+unsigned char _svm_sreg_dirty[NUM_SPU_CHANNELS];
+
+unsigned short _svm_okon1;
+unsigned short _svm_okon2;
+unsigned short _svm_okof1;
+unsigned short _svm_okof2;
+
+s32 _svm_brr_start_addr[16]; /* number: 10 */
+s16 _svm_stereo_mono;        /* number: 11 */
+SpuReverbAttr _svm_rattr;    /* number: 12 */
+u8 _svm_vab_used[16] = {0};  /* number: 13 */
+u8 spuVmMaxVoice;            /* number: 14 */
+u16 _svm_vab_count;          /* number: 15 */
+s16 kMaxPrograms;            /* number: 16 */
+struct struct_svm _svm_cur;  /* number: 17 */
+s16 _svm_damper;             /* number: 18 */
+s16 _svm_vcf;                /* number: 19 */
+u8 _svm_auto_kof_mode;       /* number: 20 */
+VabHdr* _svm_vab_vh[16];     /* number: 21 */
+ProgAtr* _svm_vab_pg[16];    /* number: 22 */
+VagAtr* _svm_vab_tn[16];     /* number: 23 */
+s32 _svm_vab_start[16];      /* number: 24 */
+s32 _svm_vab_total[16];      /* number: 25 */
+VabHdr* _svm_vh;             /* number: 26 */
+ProgAtr* _svm_pg;            /* number: 27 */
+VagAtr* _svm_tn;             /* number: 28 */
+void* _svm_vg;               /* number: 29 */
+
+void ResetCallback() {}
+
+typedef void (*SndSsMarkCallbackProc)(short seq_no, short sep_no, short data);
+
+SndSsMarkCallbackProc _SsMarkCallback[32][16]; /* #11 */
+struct SeqStruct* _ss_score[32];               /* #12 */
+s32 VBLANK_MINUS;                              /* #13 */
+s32 _snd_openflag;                             /* #14 */
+s16 _snd_seq_s_max;                            /* #15 */
+s16 _snd_seq_t_max;                            /* #16 */
+s32 _snd_ev_flag;                              /* #17 */
+
+long _spu_transMode;
+
+void* DMACallback(int dma, void (*func)()) { return NULL; }
+
+s32 _spu_rev_startaddr[4];
+s32 D_80033098;
+
+// s_ini.c
+s32 _spu_fd = 0;
+long _spu_trans_mode = 0;
+s32 _spu_rev_flag = 0;
+s32 _spu_rev_reserve_wa = 0;
+s32 _spu_rev_offsetaddr = 0;
+
+SpuReverbAttr _spu_rev_attr = {0, 0, 0, 0, 0, 0};
+
+u16 _spu_voice_centerNote[24] = {
+    0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000,
+    0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000,
+    0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000, 0xc000};
+
+s32 _spu_EVdma = 0;
+
+s32 _spu_keystat = 0;
+
+s8 _spu_zerobuf[1024] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+s32 _spu_isCalled = 0;
+
+u16 D_80032F14[1];
+s32 _spu_AllocBlockNum;
+s32 D_80033560;
+s8* D_80033564;
+s32 _spu_mem_mode_plus = 3;
+
+typedef struct tagSpuMalloc {
+    u32 addr;
+    u32 size;
+} SPU_MALLOC;
+
+SPU_MALLOC* _spu_memList = NULL;
+
+s32 _spu_inTransfer;
+struct _ss_spu_vm_rec_struct {
+    u32 pad[2];
+    SPU_MALLOC D_8003BD50[364];
+};
+
+short D_80032EC0[] = {0x0000, 0x0000, 0x1000, 0x3000,
+                      0x00BF, 0x0000, 0x0000, 0x0000};
+union SpuUnion* _spu_RXX;
+
+u16 D_80032ED0[] = {0x3FFF, 0x3FFF, 0x0000, 0x0000, 0x0000, 0x0000,
+                    0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+                    0x0000, 0x0000, 0x0000, 0x0000};
+
+struct _ss_spu_vm_rec_struct _ss_spu_vm_rec;
+
+s16 _svm_orev1;
+s16 _svm_orev2;
+
+void SpuVmKeyOn(s16, s16, u8, s32, s32, s32) { assert(0); }
+
+s32 _svm_envx_hist[32];
+s32 D_8003BD08 = 0;
+
+void SpuVmFlush(void) {}
+
+void SpuVmKeyOnNow(short vagCount, short pitch) { assert(0); }
+
+void vmNoiseOn(s32 arg0) { assert(0); }
+
+void SpuVmDoAllocate(void) { assert(0); }
+
+struct rev_param_entry {
+    u32 flags;
+    u16 dAPF1;
+    u16 dAPF2;
+    u16 vIIR;
+    u16 vCOMB1;
+    u16 vCOMB2;
+    u16 vCOMB3;
+    u16 vCOMB4;
+    u16 vWALL;
+    u16 vAPF1;
+    u16 vAPF2;
+    u16 mLSAME;
+    u16 mRSAME;
+    u16 mLCOMB1;
+    u16 mRCOMB1;
+    u16 mLCOMB2;
+    u16 mRCOMB2;
+    u16 dLSAME;
+    u16 dRSAME;
+    u16 mLDIFF;
+    u16 mRDIFF;
+    u16 mLCOMB3;
+    u16 mRCOMB3;
+    u16 mLCOMB4;
+    u16 mRCOMB4;
+    u16 dLDIFF;
+    u16 dRDIFF;
+    u16 mLAPF1;
+    u16 mRAPF1;
+    u16 mLAPF2;
+    u16 mRAPF2;
+    u16 vLIN;
+    u16 vRIN;
+};
+
+struct rev_param_entry _spu_rev_param[1];
+
+long SpuSetReverbModeParam(SpuReverbAttr* attr) { return 0; }
+
+long ResetRCnt(long spec) { return 1; }
+
+void* InterruptCallback(u8, void (*)()) { return 0; }
+
+long GetVideoMode(void) { return 0; }
+
+struct SndSeqTickEnv _snd_seq_tick_env;
+
+s32 D_8003355C;
+
+void SpuSetCommonAttr(SpuCommonAttr* attr) {}
+
+s32 _spu_AllocBlockNum;
+s32 _spu_AllocLastNum;
+s32 _spu_mem_mode_unitM;
+s32 _spu_rev_offsetaddr;
+s32 _spu_rev_reserve_wa;
+
+long SpuMalloc(long size) { return 0; }
+
+int SsVabOpenHeadWithMode(unsigned char* pAddr, int vabId, s32 pFn, long mode) {
+    return 0;
+}
+
+void func_800286E0(void) {}
+
+u16 _spu_tsa;
+void (* volatile _spu_transferCallback)();
+
+s32 _spu_mem_mode;
+s32 _spu_mem_mode_unit;
+s32 _spu_mem_mode_unitM;
+
+s32* D_80033508;
+s32* D_8003350C;
+s32* D_80033510;
+s32* D_80033518;
+s32 D_80033550;
+s32 D_800334FC;
+s32* D_80033514;
+u16 D_80033540[] = {
+    0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707,
+};
+s32 _spu_addrMode;
+
+void (* volatile _spu_IRQCallback)();
+
+void DeliverEvent(unsigned long, unsigned long) {}
+
+s32 D_800330F8[128];
+s32 D_80033558;
+volatile u32* D_80033554;
+
+int _spu_t(int count, ...) { return 0; }
+
+void _SsSndCrescendo(s16, s16) {}
+void _SsSndDecrescendo(s16, s16) {}
+
+void SpuVmSetVol(
+    short seq_sep_no, short vabId, short program, short voll, short volr) {}
+
+void _SsContDataEntry(s16, s16, u8) {}
+
+#endif

--- a/src/pc/psxsdk/libsnd.c
+++ b/src/pc/psxsdk/libsnd.c
@@ -74,8 +74,7 @@ s32 SsVabOpenHeadSticky(u_char* addr, u_long vabid, u_long sbaddr) {
     return 0;
 }
 
-short SsVabTransBodyPartly(
-    unsigned char* addr, unsigned long bufsize, short vabid) {
+s32 SsVabTransBodyPartly(u_char* addr, u_long bufsize, u_long vabid) {
     NOT_IMPLEMENTED;
     return 0;
 }

--- a/src/pc/psxsdk/libspu.c
+++ b/src/pc/psxsdk/libspu.c
@@ -2,6 +2,7 @@
 #include <psxsdk/libspu.h>
 #include <log.h>
 
+#ifndef WANT_LIBSND_LLE
 void SpuSetVoiceAttr(SpuVoiceAttr* arg) { DEBUGF("SpuSetVoiceAttr"); }
 
 long SpuMallocWithStartAddr(unsigned long addr, long size) {
@@ -27,3 +28,12 @@ long SpuClearReverbWorkArea(long rev_mode) {
 void SpuSetKey(long on_off, unsigned long voice_bit) {
     DEBUGF("on_off %d voice_bit %08X", on_off, voice_bit);
 }
+
+#else
+long SpuMallocWithStartAddr(unsigned long addr, long size) {
+    NOT_IMPLEMENTED;
+    return -1;
+}
+
+void _SpuSetVoiceAttr(SpuVoiceAttr* arg, s32, s32, s32) {}
+#endif


### PR DESCRIPTION
This makes changes to allow libsnd/libspu to compile when WANT_LIBSND_LLE is set. If turned on it will immediately crash due to trying to write to the SPU. A build is added to make sure it's compiling.