### PR TITLE
Decompile NP3 func_801B3D24

### DIFF
--- a/src/st/np3/3246C.c
+++ b/src/st/np3/3246C.c
@@ -702,7 +702,48 @@ void EntityTransparentWater(Entity* self) {
     }
 }
 
-INCLUDE_ASM("st/np3/nonmatchings/3246C", func_801B3D24);
+void func_801B3D24(Primitive* prim) {
+    s32 xVar;
+    s32 yVar;
+
+    switch (prim->p3) {
+    case 1:
+        xVar = (Random() & 0xF) - 8;
+        prim->x0 = g_CurrentEntity->posX.i.hi + xVar;
+        prim->y0 = 0x9C;
+        prim->x1 = 0;
+        prim->y1 = 0;
+        if (xVar > 0) {
+            LOW(prim->x3) = Random() << 6;
+        } else {
+            LOW(prim->x3) = -Random() * 0x40;
+        }
+        LOW(prim->x2) = (Random() << 8) + FIX(-4);
+        prim->blendMode = 2;
+        prim->p3++;
+        /* fallthrough */
+    case 2:
+        xVar = (prim->x0 << 0x10) + (u16)prim->x1;
+        yVar = (prim->y0 << 0x10) + (u16)prim->y1;
+        xVar += LOW(prim->x3);
+        yVar += LOW(prim->x2);
+        prim->x0 = (xVar >> 0x10);
+        prim->x1 = xVar & 0xFFFF;
+        prim->y0 = (yVar >> 0x10);
+        prim->y1 = yVar & 0xFFFF;
+
+        LOW(prim->x2) += 0x4000;
+        if (LOW(prim->x2) <= 0x60000) {
+            return;
+        }
+        prim->p3++;
+        return;
+    case 3:
+        prim->blendMode = 8;
+        prim->p3 = 0;
+        break;
+    }
+}
 
 void EntityCavernDoorLever(Entity* entity) {
     s32 posX;


### PR DESCRIPTION
A simple function, but a weird one.

Does a lot of odd stuff with LOW on the x coordinate (and therefore also y coordinate) of a Primitive.

It's possible that these are weird compiler optimizations (kind of like the one that does the thing with animation frames on Entities, where it loads both animation values to compare them), but hard to say for now. Hopefully with it decompiled, the research to identify what this is actually doing can come in the future.