### PR TITLE
Rewrite DRA and ST0 gpubuffer function to remove NON_MATCHING

### DIFF
--- a/src/dra/42398.c
+++ b/src/dra/42398.c
@@ -649,19 +649,16 @@ void func_800E34DC(s32 arg0) {
 
     g_GpuBuffers[0].draw.clip.y = 0x0014;
     g_GpuBuffers[0].draw.clip.h = 0x00CF;
-#ifndef NON_MATCHING
-    g_GpuBuffers_1_buf_draw_clip_y = arg0 == 0 ? 0x0014 : 0x0114;
-#else
-    g_GpuBuffers[1].draw.clip.y = 0x0014;
-#endif
+    if (!arg0) {
+        g_GpuBuffers[1].draw.clip.y = 0x0014;
+    } else {
+        g_GpuBuffers[1].draw.clip.y = 0x0114;
+    }
     g_GpuBuffers[1].draw.clip.h = 0x00CF;
-    g_GpuBuffers[1].draw.isbg = 1;
-    g_GpuBuffers[0].draw.isbg = 1;
+    g_GpuBuffers[0].draw.isbg = g_GpuBuffers[1].draw.isbg = 1;
     func_800E346C();
-    g_GpuBuffers[1].draw.dtd = 0;
-    g_GpuBuffers[0].draw.dtd = 0;
-    g_GpuBuffers[1].disp.isrgb24 = 0;
-    g_GpuBuffers[0].disp.isrgb24 = 0;
+    g_GpuBuffers[0].draw.dtd = g_GpuBuffers[1].draw.dtd = 0;
+    g_GpuBuffers[0].disp.isrgb24 = g_GpuBuffers[1].disp.isrgb24 = 0;
 }
 
 void SetStageDisplayBuffer(void) {

--- a/src/st/st0/30030.c
+++ b/src/st/st0/30030.c
@@ -53,17 +53,15 @@ void func_801B01C0(void) {
 void func_801B01F8(s32 arg0) {
     g_GpuBuffers[0].draw.clip.y = 0x0014;
     g_GpuBuffers[0].draw.clip.h = 0x00CF;
-#ifndef NON_MATCHING
-    g_GpuBuffers_1_buf_draw_clip_y = arg0 == 0 ? 0x0014 : 0x0114;
-#else
-    g_GpuBuffers[1].draw.clip.y = 0x0014;
-#endif
+    if (!arg0) {
+        g_GpuBuffers[1].draw.clip.y = 0x0014;
+    } else {
+        g_GpuBuffers[1].draw.clip.y = 0x0114;
+    }
     g_GpuBuffers[1].draw.clip.h = 0x00CF;
-    g_GpuBuffers[1].draw.isbg = 1;
-    g_GpuBuffers[0].draw.isbg = 1;
+    g_GpuBuffers[0].draw.isbg = g_GpuBuffers[1].draw.isbg = 1;
     func_801B01C0();
-    g_GpuBuffers[1].disp.isrgb24 = 0;
-    g_GpuBuffers[0].disp.isrgb24 = 0;
+    g_GpuBuffers[0].disp.isrgb24 = g_GpuBuffers[1].disp.isrgb24 = 0;
 }
 
 // Set stage display buffer


### PR DESCRIPTION
Found this function which had a NON_MATCHING.

I'm getting pretty good at finding PSP functions now, so finding the PSP told me that this was an if-block, not a ternary operator.

PSP also indicated that some of the other lines were using multiple-assignment, rather than a sequence of individual assignments, so I made those changes too.

As usual, I don't really know what these do, but it's nice to have pure matches now.

Now the only functions left with NON_MATCHING are RenderEntities and RenderPrimitives.