### PR TITLE
Asset manager next

### DIFF
--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -374,12 +374,18 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 		} else {
 			less = func(i, j int) bool {
 				if (toSort[i].Y < toSort[j].Y) {
-					return true;
+					return true
 				}
 				if (toSort[i].Y > toSort[j].Y) {
-					return false;
+					return false
 				}
-				return toSort[i].X < toSort[j].X;
+				if (toSort[i].SpawnID < toSort[j].SpawnID) {
+					return true
+				}
+				if (toSort[i].SpawnID > toSort[j].SpawnID) {
+					return false
+				}
+				return int8(toSort[i].Slot) < int8(toSort[j].Slot)
 			}
 		}
 		sorting := make([][]layoutEntry, len(banks))

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -355,13 +355,13 @@ func buildSprites(fileName string, outputDir string) error {
 
 func buildEntityLayouts(fileName string, outputDir string) error {
 	writeLayoutEntries := func(sb *strings.Builder, banks [][]layoutEntry) {
-		for _, entries := range banks {
-			sb.WriteString(fmt.Sprintf("    0xFFFE, 0xFFFE, 0, 0, 0,\n"))
+		for i, entries := range banks {
+			sb.WriteString(fmt.Sprintf("    0xFFFE, 0xFFFE, 0, 0, 0, // Bank %d start\n", i))
 			for _, e := range entries {
 				sb.WriteString(fmt.Sprintf("    0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X,\n",
 					e.X, e.Y, int(e.ID)|(int(e.Flags)<<8), int(e.Slot)|(int(e.SpawnID)<<8), e.Params))
 			}
-			sb.WriteString(fmt.Sprintf("    0xFFFF, 0xFFFF, 0, 0, 0,\n"))
+			sb.WriteString(fmt.Sprintf("    0xFFFF, 0xFFFF, 0, 0, 0, // Bank %d end\n\n", i))
 		}
 	}
 	makeSortedBanks := func(banks [][]layoutEntry, sortByX bool) [][]layoutEntry {
@@ -373,7 +373,13 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 			}
 		} else {
 			less = func(i, j int) bool {
-				return toSort[i].Y <= toSort[j].Y
+				if (toSort[i].Y < toSort[j].Y) {
+					return true;
+				}
+				if (toSort[i].Y > toSort[j].Y) {
+					return false;
+				}
+				return toSort[i].X < toSort[j].X;
 			}
 		}
 		sorting := make([][]layoutEntry, len(banks))

--- a/tools/sotn-assets/main.go
+++ b/tools/sotn-assets/main.go
@@ -130,7 +130,7 @@ func extractOvlAssets(o ovl, outputDir string) error {
 		return err
 	}
 	if err := os.WriteFile(path.Join(outputDir, "layers.json"), content, 0644); err != nil {
-		return fmt.Errorf("unable to create rooms file: %w", err)
+		return fmt.Errorf("unable to create layers file: %w", err)
 	}
 
 	content, err = json.MarshalIndent(o.layouts, "", "  ")
@@ -138,7 +138,7 @@ func extractOvlAssets(o ovl, outputDir string) error {
 		return err
 	}
 	if err := os.WriteFile(path.Join(outputDir, "entity_layouts.json"), content, 0644); err != nil {
-		return fmt.Errorf("unable to create rooms file: %w", err)
+		return fmt.Errorf("unable to create entity layouts file: %w", err)
 	}
 
 	for offset, bytes := range o.tileMaps {


### PR DESCRIPTION
Attempt to fix the vertical entity layout sort in https://github.com/Xeeynamo/sotn-decomp/pull/1343. There isn't nearly enough data yet to say with certainty that this is how it was done. For example I see this run of equivalent y values in no3 that seems to break any conceivable pattern:

```
xxd -c10 -s0x4536 -l1960 disks/us/ST/NO3/NO3.BIN

...
00004ba8: 8000 d000 4d00 9000 0000  ....M.....
00004bb2: 0001 d000 1b00 7100 0000  ......q...
00004bbc: 7f05 d000 1900 7300 0000  ......s...
00004bc6: bf03 d000 1900 7200 0000  ......r...
00004bd0: 0006 d000 1b00 7100 0100  ......q...
00004bda: 8006 d000 4d00 9000 0000  ....M.....
...
```