### PR TITLE
Speed Up `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ clean:
 	git clean -fdx sotn_calltree.txt
 
 format: format-src format-tools format-symbols
+
 format-src: bin/clang-format
 	@# find explainer:
 	@#    find $(SRC_DIR) $(INCLUDE_DIR)                      : look in src and include
@@ -159,6 +160,11 @@ format-symbols:
 	./tools/symbols.py remove-orphans config/splat.us.strwrp.yaml
 	./tools/symbols.py remove-orphans config/splat.us.tt_000.yaml
 	./tools/symbols.py remove-orphans config/splat.us.stmad.yaml
+
+# fast-format
+ff: MAKEFLAGS += --jobs
+ff:
+	$(MAKE) format
 
 patch:
 	$(DIRT_PATCHER) config/dirt.$(VERSION).json
@@ -493,7 +499,7 @@ SHELL = /bin/bash -e -o pipefail
 include tools/tools.mk
 
 .PHONY: all, clean, patch, check, build, expected
-.PHONY: format, format-src, format-tools, format-symbols
+.PHONY: format, ff, format-src, format-tools, format-symbols
 .PHONY: main, dra, ric, cen, dre, mad, no3, np3, nz0, st0, wrp, rwrp, tt_000
 .PHONY: %_dirs
 .PHONY: extract, extract_%


### PR DESCRIPTION
After building for all supported architectures `make format` was taking around 30s. This commit includes various changes which get that down to around 3½s on the same machine.

This changes the `format` target in a few ways:

  * filters out files generated by CMake
  * runs `clang-format` in parallel
  * breaks `format` into 3 separate targets which can be run in parallel

When building the PC version cmake creates a file to test compiler features. This file is picked up by the pattern which matches files for `clang-format`. This file took around 20s, filtering it out brought total format time to around 10s.

Instead of passing a list created by a `find` command directly as the args to `clang-format` the list is now passed to `xargs` which runs several processes in parallel, each looking at 10 files (determined by experimentation). This has the added advantage of ensuring as the source list grows `ARG_MAX` won't be a concern. This brought total format time to around 6s.

`format` was broken up into three targets `-src`, `-tools`, and `-symbols`. These targets can be run in parallel, bringing the total time down to 3½s.