### PR TITLE
Decompile heaven sword func_ptr_80170008

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -211,6 +211,27 @@ typedef struct {
 } ET_Weapon;
 
 typedef struct {
+    s16 angle;
+    s16 unk7E;
+    s16 unk80;
+    s16 unk82;
+    s32 unk84;
+    s16 xPos;
+    s16 unk8A;
+    struct Entity* parent;
+    s32 unk90;
+    s32 unk94;
+    s32 unk98;
+    s32 accelerationX;
+    s32 accelerationY;
+    s32 unkA4;
+    s32 unkA8;
+    u8 anim;
+    u8 unkAD;
+    s16 equipId;
+} ET_HeavenSword;
+
+typedef struct {
     /* 0x7C */ u8 unk7C;
     /* 0x7D */ u8 unk7D;
     /* 0x7E */ s16 unk7E;
@@ -1136,6 +1157,7 @@ typedef union { // offset=0x7C
     ET_MessageBox messageBox;
     ET_Weapon weapon;
     ET_Shield shield;
+    ET_HeavenSword heavenSword;
     ET_MedusaShieldLaser medshieldlaser;
     ET_ShamanShieldStar shamanshieldstar;
     ET_Food food;

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -3,7 +3,9 @@
 #include "weapon_private.h"
 #include "shared.h"
 
+extern SpriteParts D_5F000_8017A040[];
 extern u8 D_5F000_8017A5B0[6][8];
+extern s16 D_5F000_8017A5E0[];
 
 s32 func_5F000_8017A9CC(Primitive* prim, s32 x, s32 y) {
     s32 size;
@@ -80,7 +82,182 @@ s32 func_ptr_80170004(Entity* self) {
     DestroyEntity(self);
 }
 
-INCLUDE_ASM("weapon/nonmatchings/w_013", func_ptr_80170008);
+void func_ptr_80170008(Entity* self) {
+    Entity* ents2;
+    Primitive* prim;
+    s16 angle;
+
+    FntPrint("x:%02x,y:%02x\n", self->posX.i.hi, self->posY.i.hi);
+
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_5F000_8017A040);
+        self->animSet = ANIMSET_OVL(0x10);
+        self->unk5A = 0x64;
+        self->palette = 0x110;
+        if (g_HandId != 0) {
+            self->animSet += 2;
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        }
+        self->animCurFrame = 6;
+        self->facingLeft = PLAYER.facingLeft;
+        self->zPriority = PLAYER.zPriority + 2;
+        self->flags = FLAG_UNK_04000000;
+        self->drawFlags = FLAG_DRAW_ROTZ;
+        self->posY.i.hi = PLAYER.posY.i.hi + PLAYER.hitboxOffY - 8;
+        if (PLAYER.step != Player_Crouch) {
+            self->posY.i.hi -= 8;
+        }
+        if (self->facingLeft) {
+            self->posX.i.hi = PLAYER.posX.i.hi - PLAYER.hitboxOffX;
+        } else {
+            self->posX.i.hi = PLAYER.posX.i.hi + PLAYER.hitboxOffX;
+        }
+        self->ext.heavenSword.unk90 = self->posX.i.hi << 0x10;
+        self->ext.heavenSword.unk94 = self->posY.i.hi << 0x10;
+        self->ext.heavenSword.angle = -0x200;
+        self->ext.heavenSword.unk84 = 0x100;
+
+        if (self->facingLeft) {
+            self->ext.heavenSword.xPos = self->posX.i.hi - 0x78;
+        } else {
+            self->ext.heavenSword.xPos = self->posX.i.hi + 0x78;
+        }
+        self->ext.heavenSword.unk8A = self->posY.i.hi;
+        SetWeaponProperties(self, 0);
+        DestroyEntityWeapon(1);
+        self->hitboxWidth = self->hitboxHeight = 14;
+        self->ext.heavenSword.unk98 = 0x60;
+        g_Player.D_80072F00[10] = 4;
+        self->step++;
+        return;
+    case 1:
+        self->rotZ += 0x100;
+        angle = self->ext.heavenSword.angle;
+        self->ext.heavenSword.angle += -0x20;
+        self->ext.heavenSword.unk84 += 0x10;
+        if (self->facingLeft) {
+            self->posX.val = (rcos(angle) * -self->ext.heavenSword.unk84) +
+                             self->ext.heavenSword.unk90;
+        } else {
+            self->posX.val = (rcos(angle) * self->ext.heavenSword.unk84) +
+                             self->ext.heavenSword.unk90;
+        }
+        self->posY.val = (-self->ext.heavenSword.unk84 * rsin(angle)) +
+                         self->ext.heavenSword.unk94;
+        if (!(g_GameTimer & 1) && (self->ext.heavenSword.angle < -0x400)) {
+            // what the hell
+            ents2 = g_api.CreateEntFactoryFromEntity(
+                self,
+                (((g_HandId + 1) << 0xE) + 0x46 +
+                 (D_5F000_8017A5E0[(self->ext.heavenSword.unk80 >> 1) % 14]
+                  << 16)),
+                0);
+            self->ext.heavenSword.unk80++;
+        }
+        if (g_GameTimer % 6 == 0) {
+            g_api.func_80134714(0x60A, self->ext.heavenSword.unk98, 0);
+            self->ext.heavenSword.unk98 -= 4;
+            if (self->ext.heavenSword.unk98 < 0) {
+                self->ext.heavenSword.unk98 = 0;
+            }
+        }
+        if (self->ext.heavenSword.angle >= -0xB00) {
+            return;
+        }
+        self->ext.heavenSword.unk82 = 8;
+        self->step++;
+        break;
+    case 2:
+        if (--self->ext.heavenSword.unk82 == 0) {
+            self->drawFlags = FLAG_DRAW_UNK80;
+            self->step++;
+        }
+        break;
+    case 3:
+        self->ext.heavenSword.unk82++;
+        if ((self->ext.heavenSword.unk82 < 0x20) &&
+            !(self->ext.heavenSword.unk82 & 3)) {
+            g_api.PlaySfx(0x60B);
+        }
+        if (self->ext.heavenSword.unk82 > 0x10) {
+            self->posX.i.hi = self->ext.heavenSword.xPos;
+            self->posY.i.hi = self->ext.heavenSword.unk8A;
+            self->hitboxWidth = 0x12;
+            self->hitboxHeight = 4;
+        }
+        if (self->ext.heavenSword.unk82 > 0x30) {
+            self->drawFlags = 0;
+        }
+        if (self->ext.heavenSword.unk82 == 0x34) {
+            g_api.PlaySfx(0x66A);
+            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
+            self->rotX = self->rotY = 0x100;
+            self->palette = 0x815F;
+            self->primIndex = g_api.AllocPrimitives(PRIM_LINE_G2, 1);
+            if (self->primIndex != -1) {
+                self->flags |= FLAG_HAS_PRIMS;
+                prim = &g_PrimBuf[self->primIndex];
+                prim->r0 = prim->b0 = prim->r1 = prim->b1 = 0xF0;
+                prim->g0 = 0x80;
+                prim->g1 = 0x80;
+                prim->x0 = prim->x1 = self->posX.i.hi;
+                prim->y0 = prim->y1 = self->posY.i.hi;
+                prim->priority = self->zPriority;
+                prim->drawMode = DRAW_TPAGE2 | DRAW_TPAGE | DRAW_TRANSP;
+            } else {
+                DestroyEntity(self);
+                return;
+            }
+            self->step++;
+            return;
+        }
+        break;
+    case 4:
+        if (self->primIndex != -1) {
+            prim = &g_PrimBuf[self->primIndex];
+            if (prim->x0 > -0x110) {
+                prim->x0 -= 0x10;
+            }
+            if (prim->x1 < 0x110) {
+                prim->x1 += 0x10;
+            }
+            if ((prim->x0 < 0) && (prim->x1 > 0x100)) {
+                if (prim->b1 > 8) {
+                    prim->b1 -= 8;
+                }
+                if (prim->g1 > 8) {
+                    prim->g1 -= 4;
+                } else {
+                    DestroyEntity(self);
+                    return;
+                }
+
+                prim->r0 = prim->b0 = prim->r1 = prim->b1;
+                prim->g0 = prim->g1;
+            }
+        }
+        self->rotX += 0x80;
+        self->rotY = 0x20;
+        if (self->rotX >= 0x700) {
+            self->animCurFrame = 0;
+        }
+        if (self->posX.i.hi >= 0x101) {
+            self->hitboxOffX = 0x100 - self->posX.i.hi;
+        }
+        if (self->posX.i.hi < 0) {
+            self->hitboxOffX = -self->posX.i.hi;
+        }
+        if (self->facingLeft != 0) {
+            self->hitboxOffX = -self->hitboxOffX;
+        }
+        self->hitboxWidth = 0xFE;
+        self->hitboxHeight = 2;
+
+        break;
+    }
+}
 
 // Pay attention to unk80, unk8A, and childPalette. These all seem to be
 // special for Heaven Sword and we should probably have it as a special weapon.

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -211,7 +211,6 @@ void func_ptr_80170008(Entity* self) {
                 return;
             }
             self->step++;
-            return;
         }
         break;
     case 4:


### PR DESCRIPTION
This one is kind of ugly in places.

It uses offset 0x84 as an s32, while Weapon uses it to hold an entity, so this forced the creation of a new ext for the heaven sword.

There is only one more function left in this file (EntityWeaponAttack), so once that one is done, I will move the whole file over to use the Heaven Sword extension.