### PR TITLE
Decompile DRA RenderPrimitives

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -100,8 +100,15 @@ typedef struct Prim {
 #define COLOR_LEN ((COLOR_BPP) / 8)
 #define PALETTE_LEN ((COLORS_PER_PAL) * ((COLOR_BPP) / 8))
 #define COLOR16(r, g, b, a) (r) + ((g) << 5) + ((b) << 10) + ((a) << 15)
+// PS1 and PSP use different values for these two
+#ifndef VERSION_PSP
 #define OTSIZE 0x200
 #define MAXSPRT16 0x280
+#endif
+#ifdef VERSION_PSP
+#define OTSIZE 0x600
+#define MAXSPRT16 0x320
+#endif
 #define MAX_DRAW_MODES 0x400
 #define MAX_TILE_COUNT 0x100
 #define MAX_LINE_G2_COUNT 0x100

--- a/src/dra/4A538.c
+++ b/src/dra/4A538.c
@@ -1806,7 +1806,7 @@ void RenderPrimitives(void) {
     #define RECT_LOC 0x128
     #endif
     RECT* rect = (RECT*)SP(RECT_LOC);
-    PrimitivesRenderer* r = (PrimitivesRenderer*)SP(0x000); //a0
+    PrimitivesRenderer* r = (PrimitivesRenderer*)SP(0x000);
     PrimBuf* primbuf = (PrimBuf*)SP(0x024);
     
     s32 var_s1;

--- a/src/dra/4A538.c
+++ b/src/dra/4A538.c
@@ -1768,22 +1768,8 @@ void FreePrimitives(s32 primitiveIndex) {
     }
 }
 
-#ifndef NON_MATCHING
-INCLUDE_ASM("dra/nonmatchings/4A538", RenderPrimitives);
-#else
-typedef struct {
-    /* 0x1F800000 */ OT_TYPE* ot;
-    /* 0x1F800004 */ POLY_GT4* gt4;
-    /* 0x1F800008 */ POLY_G4* g4;
-    /* 0x1F80000C */ POLY_GT3* gt3;
-    /* 0x1F800010 */ LINE_G2* g2;
-    /* 0x1F800014 */ TILE* tile;
-    /* 0x1F800018 */ DR_MODE* dr;
-    /* 0x1F80001C */ SPRT* sprt;
-    /* 0x1F800020 */ DR_ENV* env;
-} PrimitivesRenderer;
-
-typedef union {
+typedef union
+{
     TILE tile;
     LINE_G2 g2;
     POLY_G4 g4;
@@ -1792,37 +1778,48 @@ typedef union {
     SPRT sprt;
 } PrimBuf;
 
-void RenderPrimitives(void) {
-#ifdef VERSION_PC
-    RECT _rect;
-    RECT* rect = &_rect;
-    PrimitivesRenderer _r;
-    PrimitivesRenderer* r = &_r;
-    PrimBuf _primbuf;
-    PrimBuf* primbuf = &_primbuf;
-#else
-    RECT* rect = (RECT*)0x1F800128;
-    PrimitivesRenderer* r = (PrimitivesRenderer*)0x1F800000;
-    PrimBuf* primbuf = (PrimBuf*)0x1F800024;
+typedef struct 
+{
+  u_long *ot;
+  POLY_GT4 *gt4;
+  POLY_G4 *g4;
+  POLY_GT3 *gt3;
+  LINE_G2 *g2;
+  TILE *tile;
+  DR_MODE *dr;
+  SPRT *sprt;
+  DR_ENV *env;
+} PrimitivesRenderer;
+
+#ifndef VERSION_PSP
+#define OT_MULT 1
+#endif
+#ifdef VERSION_PSP
+#define OT_MULT 3
 #endif
 
-    DRAWENV sp18;
-    s32 i;
-    s16 sp80;
-    Primitive* prim;
-    DR_ENV* env;
-    s32 useShadeTex;
-    s32 var_a1;
-    s32 tpage;
-    s32 dtd;
-    u16 var_v0;
-    u16 drawMode;
-    u8 primType;
+void RenderPrimitives(void) {
+    #ifdef VERSION_PSP
+    #define RECT_LOC 0x12C
+    #endif
+    #ifndef VERSION_PSP
+    #define RECT_LOC 0x128
+    #endif
+    RECT* rect = (RECT*)SP(RECT_LOC);
+    PrimitivesRenderer* r = (PrimitivesRenderer*)SP(0x000); //a0
+    PrimBuf* primbuf = (PrimBuf*)SP(0x024);
+    
+    s32 var_s1;
+    Primitive* var_s0;
+    u8 var_s2;
+    s32 var_s4;
+    s32 var_s3;
+    s32 var_a2;
 
-    rect->x = 0;
-    rect->y = 0;
-    rect->w = 255;
-    rect->h = 255;
+    DRAWENV sp18;
+    s16 sp80;
+    DR_ENV* env;
+
     r->ot = g_CurrentBuffer->ot;
     r->gt4 = &g_CurrentBuffer->polyGT4[g_GpuUsage.gt4];
     r->g4 = &g_CurrentBuffer->polyG4[g_GpuUsage.g4];
@@ -1832,6 +1829,10 @@ void RenderPrimitives(void) {
     r->dr = &g_CurrentBuffer->drawModes[g_GpuUsage.drawModes];
     r->sprt = &g_CurrentBuffer->sprite[g_GpuUsage.sp];
     r->env = &g_CurrentBuffer->env[g_GpuUsage.env];
+    rect->x = 0;
+    rect->y = 0;
+    rect->w = 255;
+    rect->h = 255;
     if (D_8003C0EC[3]) {
         if (g_GpuUsage.tile < MAX_TILE_COUNT) {
             setSemiTrans(r->tile, false);
@@ -1847,69 +1848,83 @@ void RenderPrimitives(void) {
             D_8003C0EC[3]--;
         }
     } else {
-        var_a1 = 0;
-        i = 0;
-        prim = g_PrimBuf + i;
-        for (; i < MAX_PRIM_COUNT; prim++, i++) {
-            primType = prim->type;
-            if (!primType) {
+        var_a2 = 0;
+        var_s1 = 0;
+        for (var_s0 = &g_PrimBuf[0]; var_s1 < MAX_PRIM_COUNT; var_s0++, var_s1++) {
+            var_s2 = var_s0->type;
+            if (!var_s2) {
                 continue;
             }
-            drawMode = prim->drawMode;
-            if (drawMode & DRAW_HIDE) {
+            if (var_s0->drawMode & DRAW_HIDE) {
                 continue;
             }
-            var_v0 = drawMode & DRAW_COLORS;
-            useShadeTex = var_v0 < 1;
-            if (D_800973EC != 0 && !(drawMode & DRAW_MENU)) {
+            if (var_s0->drawMode & DRAW_COLORS) {
+                var_s4 = false;
+            } else {
+                var_s4 = true;
+            }
+            if (D_800973EC != 0 && !(var_s0->drawMode & DRAW_MENU)) {
                 continue;
             }
-            if (prim->x0 < -512 || prim->x0 > 512) {
+            if (var_s0->x0 < -512 || var_s0->x0 > 512) {
                 continue;
             }
-            if (prim->y0 < -512 || prim->y0 > 512) {
+            if (var_s0->y0 < -512 || var_s0->y0 > 512) {
                 continue;
             }
-            if (drawMode & DRAW_UNK_400) {
-                dtd = 1;
-                if (var_a1 == 0) {
+            if (var_s0->drawMode & DRAW_UNK_400) {
+                var_s3 = true;
+                if (!var_a2) {
                     SetDrawMode(r->dr, 0, 0, 0, rect);
-                    addPrim(&r->ot[prim->priority], r->dr);
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                     r->dr++;
                     g_GpuUsage.drawModes++;
                 }
             } else {
-                dtd = 0;
+                var_s3 = false;
             }
-            switch (primType) {
+            switch (var_s2) {
             case PRIM_TILE:
             case PRIM_TILE_ALT:
                 setTile(&primbuf->tile);
                 if (g_GpuUsage.tile < MAX_TILE_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->tile, true);
-                    }
-                    primbuf->tile.r0 = prim->r0;
-                    primbuf->tile.g0 = prim->g0;
-                    primbuf->tile.b0 = prim->b0;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->tile.x0 = prim->x0;
-                        primbuf->tile.y0 = prim->y0;
+                    setSemiTrans(&primbuf->tile, var_s0->drawMode & DRAW_TRANSP);
+                    primbuf->tile.r0 = var_s0->r0;
+                    primbuf->tile.g0 = var_s0->g0;
+                    primbuf->tile.b0 = var_s0->b0;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->tile.x0 = var_s0->x0;
+                        primbuf->tile.y0 = var_s0->y0;
                     } else {
-                        primbuf->tile.x0 = prim->x0 + g_backbufferX;
-                        primbuf->tile.y0 = prim->y0 + g_backbufferY;
+                        primbuf->tile.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->tile.y0 = var_s0->y0 + g_backbufferY;
                     }
-                    primbuf->tile.w = prim->u0;
-                    primbuf->tile.h = prim->v0;
-                    __builtin_memcpy(r->tile, &primbuf->tile, sizeof(TILE));
-                    addPrim(&r->ot[prim->priority], r->tile);
+                    primbuf->tile.w = var_s0->u0;
+                    primbuf->tile.h = var_s0->v0;
+                    *r->tile = primbuf->tile;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->tile);
                     r->tile++;
                     g_GpuUsage.tile++;
-                    if ((primType & 0x10) == 0 &&
+                    if (!(var_s2 & 0x10) &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = prim->drawMode & 0x60;
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                        SetDrawMode(
+                            r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -1919,36 +1934,44 @@ void RenderPrimitives(void) {
             case 18:
                 setLineG2(&primbuf->g2);
                 if (g_GpuUsage.line < MAX_LINE_G2_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->g2, true);
-                    }
-                    setShadeTex(&primbuf->g2, !!useShadeTex);
-                    primbuf->g2.r0 = prim->r0;
-                    primbuf->g2.g0 = prim->g0;
-                    primbuf->g2.b0 = prim->b0;
-                    primbuf->g2.r1 = prim->r1;
-                    primbuf->g2.g1 = prim->g1;
-                    primbuf->g2.b1 = prim->b1;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->g2.x0 = prim->x0;
-                        primbuf->g2.y0 = prim->y0;
-                        primbuf->g2.x1 = prim->x1;
-                        primbuf->g2.y1 = prim->y1;
+                    setSemiTrans(&primbuf->g2, var_s0->drawMode & DRAW_TRANSP);
+                    setShadeTex(&primbuf->g2, var_s4);
+                    primbuf->g2.r0 = var_s0->r0;
+                    primbuf->g2.g0 = var_s0->g0;
+                    primbuf->g2.b0 = var_s0->b0;
+                    primbuf->g2.r1 = var_s0->r1;
+                    primbuf->g2.g1 = var_s0->g1;
+                    primbuf->g2.b1 = var_s0->b1;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->g2.x0 = var_s0->x0;
+                        primbuf->g2.y0 = var_s0->y0;
+                        primbuf->g2.x1 = var_s0->x1;
+                        primbuf->g2.y1 = var_s0->y1;
                     } else {
-                        primbuf->g2.x0 = prim->x0 + g_backbufferX;
-                        primbuf->g2.y0 = prim->y0 + g_backbufferY;
-                        primbuf->g2.x1 = prim->x1 + g_backbufferX;
-                        primbuf->g2.y1 = prim->y1 + g_backbufferY;
+                        primbuf->g2.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->g2.y0 = var_s0->y0 + g_backbufferY;
+                        primbuf->g2.x1 = var_s0->x1 + g_backbufferX;
+                        primbuf->g2.y1 = var_s0->y1 + g_backbufferY;
                     }
-                    __builtin_memcpy(r->g2, &primbuf->g2, sizeof(LINE_G2));
-                    addPrim(&r->ot[prim->priority], r->g2);
+                    *r->g2 = primbuf->g2;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->g2);
                     r->g2++;
                     g_GpuUsage.line++;
-                    if ((primType & 0x10) == 0 &&
+                    if ((var_s2 & 0x10) == 0 &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = prim->drawMode & 0x60;
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                        SetDrawMode(
+                            r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -1958,50 +1981,58 @@ void RenderPrimitives(void) {
             case 19:
                 setPolyG4(&primbuf->g4);
                 if (g_GpuUsage.g4 < MAX_POLY_G4_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->g4, true);
-                    }
-                    setShadeTex(&primbuf->g4, !!useShadeTex);
-                    primbuf->g4.r0 = prim->r0;
-                    primbuf->g4.g0 = prim->g0;
-                    primbuf->g4.b0 = prim->b0;
-                    primbuf->g4.r1 = prim->r1;
-                    primbuf->g4.g1 = prim->g1;
-                    primbuf->g4.b1 = prim->b1;
-                    primbuf->g4.r2 = prim->r2;
-                    primbuf->g4.g2 = prim->g2;
-                    primbuf->g4.b2 = prim->b2;
-                    primbuf->g4.r3 = prim->r3;
-                    primbuf->g4.g3 = prim->g3;
-                    primbuf->g4.b3 = prim->b3;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->g4.x0 = prim->x0;
-                        primbuf->g4.y0 = prim->y0;
-                        primbuf->g4.x1 = prim->x1;
-                        primbuf->g4.y1 = prim->y1;
-                        primbuf->g4.x2 = prim->x2;
-                        primbuf->g4.y2 = prim->y2;
-                        primbuf->g4.x3 = prim->x3;
-                        primbuf->g4.y3 = prim->y3;
+                    setSemiTrans(&primbuf->g4, var_s0->drawMode & DRAW_TRANSP);
+                    setShadeTex(&primbuf->g4, var_s4);
+                    primbuf->g4.r0 = var_s0->r0;
+                    primbuf->g4.g0 = var_s0->g0;
+                    primbuf->g4.b0 = var_s0->b0;
+                    primbuf->g4.r1 = var_s0->r1;
+                    primbuf->g4.g1 = var_s0->g1;
+                    primbuf->g4.b1 = var_s0->b1;
+                    primbuf->g4.r2 = var_s0->r2;
+                    primbuf->g4.g2 = var_s0->g2;
+                    primbuf->g4.b2 = var_s0->b2;
+                    primbuf->g4.r3 = var_s0->r3;
+                    primbuf->g4.g3 = var_s0->g3;
+                    primbuf->g4.b3 = var_s0->b3;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->g4.x0 = var_s0->x0;
+                        primbuf->g4.y0 = var_s0->y0;
+                        primbuf->g4.x1 = var_s0->x1;
+                        primbuf->g4.y1 = var_s0->y1;
+                        primbuf->g4.x2 = var_s0->x2;
+                        primbuf->g4.y2 = var_s0->y2;
+                        primbuf->g4.x3 = var_s0->x3;
+                        primbuf->g4.y3 = var_s0->y3;
                     } else {
-                        primbuf->g4.x0 = prim->x0 + g_backbufferX;
-                        primbuf->g4.y0 = prim->y0 + g_backbufferY;
-                        primbuf->g4.x1 = prim->x1 + g_backbufferX;
-                        primbuf->g4.y1 = prim->y1 + g_backbufferY;
-                        primbuf->g4.x2 = prim->x2 + g_backbufferX;
-                        primbuf->g4.y2 = prim->y2 + g_backbufferY;
-                        primbuf->g4.x3 = prim->x3 + g_backbufferX;
-                        primbuf->g4.y3 = prim->y3 + g_backbufferY;
+                        primbuf->g4.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->g4.y0 = var_s0->y0 + g_backbufferY;
+                        primbuf->g4.x1 = var_s0->x1 + g_backbufferX;
+                        primbuf->g4.y1 = var_s0->y1 + g_backbufferY;
+                        primbuf->g4.x2 = var_s0->x2 + g_backbufferX;
+                        primbuf->g4.y2 = var_s0->y2 + g_backbufferY;
+                        primbuf->g4.x3 = var_s0->x3 + g_backbufferX;
+                        primbuf->g4.y3 = var_s0->y3 + g_backbufferY;
                     }
-                    __builtin_memcpy(r->g4, &primbuf->g4, sizeof(POLY_G4));
-                    addPrim(&r->ot[prim->priority], r->g4);
+                    *r->g4 = primbuf->g4;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->g4);
                     r->g4++;
                     g_GpuUsage.g4++;
-                    if ((primType & 0x10) == 0 &&
+                    if ((var_s2 & 0x10) == 0 &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = prim->drawMode & 0x60;
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                        SetDrawMode(
+                            r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2010,59 +2041,67 @@ void RenderPrimitives(void) {
             case PRIM_GT4:
                 setPolyGT4(&primbuf->gt4);
                 if (g_GpuUsage.gt4 < MAX_POLY_GT4_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->gt4, true);
-                    }
-                    setShadeTex(&primbuf->gt4, !!useShadeTex);
-                    primbuf->gt4.r0 = prim->r0;
-                    primbuf->gt4.g0 = prim->g0;
-                    primbuf->gt4.b0 = prim->b0;
-                    primbuf->gt4.r1 = prim->r1;
-                    primbuf->gt4.g1 = prim->g1;
-                    primbuf->gt4.b1 = prim->b1;
-                    primbuf->gt4.r2 = prim->r2;
-                    primbuf->gt4.g2 = prim->g2;
-                    primbuf->gt4.b2 = prim->b2;
-                    primbuf->gt4.r3 = prim->r3;
-                    primbuf->gt4.g3 = prim->g3;
-                    primbuf->gt4.b3 = prim->b3;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->gt4.x0 = prim->x0;
-                        primbuf->gt4.y0 = prim->y0;
-                        primbuf->gt4.x1 = prim->x1;
-                        primbuf->gt4.y1 = prim->y1;
-                        primbuf->gt4.x2 = prim->x2;
-                        primbuf->gt4.y2 = prim->y2;
-                        primbuf->gt4.x3 = prim->x3;
-                        primbuf->gt4.y3 = prim->y3;
+                    setSemiTrans(&primbuf->gt4, var_s0->drawMode & DRAW_TRANSP);
+                    setShadeTex(&primbuf->gt4, var_s4);
+                    primbuf->gt4.r0 = var_s0->r0;
+                    primbuf->gt4.g0 = var_s0->g0;
+                    primbuf->gt4.b0 = var_s0->b0;
+                    primbuf->gt4.r1 = var_s0->r1;
+                    primbuf->gt4.g1 = var_s0->g1;
+                    primbuf->gt4.b1 = var_s0->b1;
+                    primbuf->gt4.r2 = var_s0->r2;
+                    primbuf->gt4.g2 = var_s0->g2;
+                    primbuf->gt4.b2 = var_s0->b2;
+                    primbuf->gt4.r3 = var_s0->r3;
+                    primbuf->gt4.g3 = var_s0->g3;
+                    primbuf->gt4.b3 = var_s0->b3;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->gt4.x0 = var_s0->x0;
+                        primbuf->gt4.y0 = var_s0->y0;
+                        primbuf->gt4.x1 = var_s0->x1;
+                        primbuf->gt4.y1 = var_s0->y1;
+                        primbuf->gt4.x2 = var_s0->x2;
+                        primbuf->gt4.y2 = var_s0->y2;
+                        primbuf->gt4.x3 = var_s0->x3;
+                        primbuf->gt4.y3 = var_s0->y3;
                     } else {
-                        primbuf->gt4.x0 = prim->x0 + g_backbufferX;
-                        primbuf->gt4.y0 = prim->y0 + g_backbufferY;
-                        primbuf->gt4.x1 = prim->x1 + g_backbufferX;
-                        primbuf->gt4.y1 = prim->y1 + g_backbufferY;
-                        primbuf->gt4.x2 = prim->x2 + g_backbufferX;
-                        primbuf->gt4.y2 = prim->y2 + g_backbufferY;
-                        primbuf->gt4.x3 = prim->x3 + g_backbufferX;
-                        primbuf->gt4.y3 = prim->y3 + g_backbufferY;
+                        primbuf->gt4.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->gt4.y0 = var_s0->y0 + g_backbufferY;
+                        primbuf->gt4.x1 = var_s0->x1 + g_backbufferX;
+                        primbuf->gt4.y1 = var_s0->y1 + g_backbufferY;
+                        primbuf->gt4.x2 = var_s0->x2 + g_backbufferX;
+                        primbuf->gt4.y2 = var_s0->y2 + g_backbufferY;
+                        primbuf->gt4.x3 = var_s0->x3 + g_backbufferX;
+                        primbuf->gt4.y3 = var_s0->y3 + g_backbufferY;
                     }
-                    primbuf->gt4.u0 = prim->u0;
-                    primbuf->gt4.v0 = prim->v0;
-                    primbuf->gt4.u1 = prim->u1;
-                    primbuf->gt4.v1 = prim->v1;
-                    primbuf->gt4.u2 = prim->u2;
-                    primbuf->gt4.v2 = prim->v2;
-                    primbuf->gt4.u3 = prim->u3;
-                    primbuf->gt4.v3 = prim->v3;
-                    primbuf->gt4.tpage = prim->tpage + (prim->drawMode & 0x60);
-                    primbuf->gt4.clut = g_ClutIds[prim->clut];
-                    __builtin_memcpy(r->gt4, &primbuf->gt4, sizeof(POLY_GT4));
-                    addPrim(&r->ot[prim->priority], r->gt4);
+                    primbuf->gt4.u0 = var_s0->u0;
+                    primbuf->gt4.v0 = var_s0->v0;
+                    primbuf->gt4.u1 = var_s0->u1;
+                    primbuf->gt4.v1 = var_s0->v1;
+                    primbuf->gt4.u2 = var_s0->u2;
+                    primbuf->gt4.v2 = var_s0->v2;
+                    primbuf->gt4.u3 = var_s0->u3;
+                    primbuf->gt4.v3 = var_s0->v3;
+                    primbuf->gt4.tpage =
+                        var_s0->tpage + (var_s0->drawMode & 0x60);
+                    primbuf->gt4.clut = g_ClutIds[var_s0->clut];
+                    *r->gt4 = primbuf->gt4;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->gt4);
                     r->gt4++;
                     g_GpuUsage.gt4++;
-                    if (dtd && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = 0;
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                    if (var_s3 && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
+                        SetDrawMode(r->dr, 0, var_s3, 0, rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2071,51 +2110,59 @@ void RenderPrimitives(void) {
             case PRIM_GT3:
                 setPolyGT3(&primbuf->gt3);
                 if (g_GpuUsage.gt3 < MAX_POLY_GT3_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->gt3, true);
-                    }
-                    setShadeTex(&primbuf->gt3, !!useShadeTex);
-                    primbuf->gt3.r0 = prim->r0;
-                    primbuf->gt3.g0 = prim->g0;
-                    primbuf->gt3.b0 = prim->b0;
-                    primbuf->gt3.r1 = prim->r1;
-                    primbuf->gt3.g1 = prim->g1;
-                    primbuf->gt3.b1 = prim->b1;
-                    primbuf->gt3.r2 = prim->r2;
-                    primbuf->gt3.g2 = prim->g2;
-                    primbuf->gt3.b2 = prim->b2;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->gt3.x0 = prim->x0;
-                        primbuf->gt3.y0 = prim->y0;
-                        primbuf->gt3.x1 = prim->x1;
-                        primbuf->gt3.y1 = prim->y1;
-                        primbuf->gt3.x2 = prim->x2;
-                        primbuf->gt3.y2 = prim->y2;
+                    setSemiTrans(&primbuf->gt3, var_s0->drawMode & DRAW_TRANSP);
+                    setShadeTex(&primbuf->gt3, var_s4);
+                    primbuf->gt3.r0 = var_s0->r0;
+                    primbuf->gt3.g0 = var_s0->g0;
+                    primbuf->gt3.b0 = var_s0->b0;
+                    primbuf->gt3.r1 = var_s0->r1;
+                    primbuf->gt3.g1 = var_s0->g1;
+                    primbuf->gt3.b1 = var_s0->b1;
+                    primbuf->gt3.r2 = var_s0->r2;
+                    primbuf->gt3.g2 = var_s0->g2;
+                    primbuf->gt3.b2 = var_s0->b2;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->gt3.x0 = var_s0->x0;
+                        primbuf->gt3.y0 = var_s0->y0;
+                        primbuf->gt3.x1 = var_s0->x1;
+                        primbuf->gt3.y1 = var_s0->y1;
+                        primbuf->gt3.x2 = var_s0->x2;
+                        primbuf->gt3.y2 = var_s0->y2;
                     } else {
-                        primbuf->gt3.x0 = prim->x0 + g_backbufferX;
-                        primbuf->gt3.y0 = prim->y0 + g_backbufferY;
-                        primbuf->gt3.x1 = prim->x1 + g_backbufferX;
-                        primbuf->gt3.y1 = prim->y1 + g_backbufferY;
-                        primbuf->gt3.x2 = prim->x2 + g_backbufferX;
-                        primbuf->gt3.y2 = prim->y2 + g_backbufferY;
+                        primbuf->gt3.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->gt3.y0 = var_s0->y0 + g_backbufferY;
+                        primbuf->gt3.x1 = var_s0->x1 + g_backbufferX;
+                        primbuf->gt3.y1 = var_s0->y1 + g_backbufferY;
+                        primbuf->gt3.x2 = var_s0->x2 + g_backbufferX;
+                        primbuf->gt3.y2 = var_s0->y2 + g_backbufferY;
                     }
-                    primbuf->gt3.u0 = prim->u0;
-                    primbuf->gt3.v0 = prim->v0;
-                    primbuf->gt3.u1 = prim->u1;
-                    primbuf->gt3.v1 = prim->v1;
-                    primbuf->gt3.u2 = prim->u2;
-                    primbuf->gt3.v2 = prim->v2;
-                    primbuf->gt3.tpage = prim->tpage + (prim->drawMode & 0x60);
-                    primbuf->gt3.clut = g_ClutIds[prim->clut];
+                    primbuf->gt3.u0 = var_s0->u0;
+                    primbuf->gt3.v0 = var_s0->v0;
+                    primbuf->gt3.u1 = var_s0->u1;
+                    primbuf->gt3.v1 = var_s0->v1;
+                    primbuf->gt3.u2 = var_s0->u2;
+                    primbuf->gt3.v2 = var_s0->v2;
+                    primbuf->gt3.tpage =
+                        var_s0->tpage + (var_s0->drawMode & 0x60);
+                    primbuf->gt3.clut = g_ClutIds[var_s0->clut];
 
-                    __builtin_memcpy(r->gt3, &primbuf->gt3, sizeof(POLY_GT3));
-                    addPrim(&r->ot[prim->priority], r->gt3);
+                    *r->gt3 = primbuf->gt3;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->gt3);
                     r->gt3++;
                     g_GpuUsage.gt3++;
-                    if (dtd && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = 0;
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                    if (var_s3 && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
+                        SetDrawMode(r->dr, 0, var_s3, 0, rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2125,34 +2172,43 @@ void RenderPrimitives(void) {
             case 22:
                 setSprt(&primbuf->sprt);
                 if (g_GpuUsage.sp < MAX_SPRT_COUNT) {
-                    if (prim->drawMode & DRAW_TRANSP) {
-                        setSemiTrans(&primbuf->sprt, true);
-                    }
-                    setShadeTex(&primbuf->sprt, !!useShadeTex);
-                    primbuf->sprt.r0 = prim->r0;
-                    primbuf->sprt.g0 = prim->g0;
-                    primbuf->sprt.b0 = prim->b0;
-                    if (prim->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
-                        primbuf->sprt.x0 = prim->x0;
-                        primbuf->sprt.y0 = prim->y0;
+                    setSemiTrans(&primbuf->sprt, var_s0->drawMode & DRAW_TRANSP);
+                    setShadeTex(&primbuf->sprt, var_s4);
+                    primbuf->sprt.r0 = var_s0->r0;
+                    primbuf->sprt.g0 = var_s0->g0;
+                    primbuf->sprt.b0 = var_s0->b0;
+                    if (var_s0->drawMode & (DRAW_ABSPOS | DRAW_MENU)) {
+                        primbuf->sprt.x0 = var_s0->x0;
+                        primbuf->sprt.y0 = var_s0->y0;
                     } else {
-                        primbuf->sprt.x0 = prim->x0 + g_backbufferX;
-                        primbuf->sprt.y0 = prim->y0 + g_backbufferY;
+                        primbuf->sprt.x0 = var_s0->x0 + g_backbufferX;
+                        primbuf->sprt.y0 = var_s0->y0 + g_backbufferY;
                     }
-                    primbuf->sprt.u0 = prim->u0;
-                    primbuf->sprt.v0 = prim->v0;
-                    primbuf->sprt.w = prim->u1;
-                    primbuf->sprt.h = prim->v1;
-                    primbuf->sprt.clut = g_ClutIds[prim->clut];
-                    __builtin_memcpy(r->sprt, &primbuf->sprt, sizeof(SPRT));
-                    addPrim(&r->ot[prim->priority], r->sprt);
+                    primbuf->sprt.u0 = var_s0->u0;
+                    primbuf->sprt.v0 = var_s0->v0;
+                    primbuf->sprt.w = var_s0->u1;
+                    primbuf->sprt.h = var_s0->v1;
+                    primbuf->sprt.clut = g_ClutIds[var_s0->clut];
+                    *r->sprt = primbuf->sprt;
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->sprt);
                     r->sprt++;
                     g_GpuUsage.sp++;
-                    if ((primType & 0x10) == 0 &&
+                    if ((var_s2 & 0x10) == 0 &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
-                        tpage = prim->tpage + (prim->drawMode & 0x60);
-                        SetDrawMode(r->dr, 0, dtd, tpage, rect);
-                        addPrim(&r->ot[prim->priority], r->dr);
+                        SetDrawMode(
+                            r->dr, 0, var_s3,
+                            var_s0->tpage + (var_s0->drawMode & 0x60), rect);
+                        #ifdef VERSION_PSP
+                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                            var_s0->priority = 0x1FF;
+                        }
+                        #endif
+                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2160,33 +2216,47 @@ void RenderPrimitives(void) {
                 break;
             case PRIM_ENV:
                 if (g_GpuUsage.env < MAX_ENV_COUNT) {
-                    env = *(DR_ENV**)&prim->r1;
-                    if (prim->drawMode & DRAW_UNK_1000) {
+                    env = *(DR_ENV**)&var_s0->r1;
+                    if (var_s0->drawMode & DRAW_UNK_1000) {
                         sp80 = g_CurrentBuffer->draw.ofs[0];
+                        #ifndef VERSION_PSP
                         *(s16*)&env->code[2] = sp80;
                         *(s16*)&env->code[7] = sp80;
+                        #endif
+                        #ifdef VERSION_PSP
+                        *(s16*)&env->code[3] = sp80;
+                        *(s16*)&env->code[1] = sp80;
+                        #endif
                     }
-                    if (prim->drawMode & DRAW_UNK_800) {
-                        __builtin_memcpy(
-                            &sp18, &g_CurrentBuffer->draw, sizeof(DRAWENV));
+                    if (var_s0->drawMode & DRAW_UNK_800) {
+                        sp18 = g_CurrentBuffer->draw;
                         sp18.isbg = 0;
                         SetDrawEnv(env, &sp18);
                     }
-                    __builtin_memcpy(r->env, env, sizeof(DR_ENV));
-                    if (prim->drawMode & DRAW_UNK_1000) {
+                    *r->env = *env;
+                    #ifndef VERSION_PSP
+                    if (var_s0->drawMode & DRAW_UNK_1000) {
                         env = r->env;
                         *(s16*)&env->code[0] += sp80;
                         *(s16*)&env->code[1] += sp80;
                     }
-                    addPrim(&r->ot[prim->priority], r->env);
+                    #endif
+                    #ifdef VERSION_PSP
+                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+                        var_s0->priority = 0x1FF;
+                    }
+                    #endif
+                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->env);
                     r->env++;
                     g_GpuUsage.env++;
                 }
                 break;
             }
-            var_v0 = primType & 0x10;
-            var_a1 = var_v0 != 0;
+            if (var_s2 & 0x10) {
+                var_a2 = true;
+            } else {
+                var_a2 = false;
+            }
         }
     }
 }
-#endif

--- a/src/dra/4A538.c
+++ b/src/dra/4A538.c
@@ -1768,8 +1768,7 @@ void FreePrimitives(s32 primitiveIndex) {
     }
 }
 
-typedef union
-{
+typedef union {
     TILE tile;
     LINE_G2 g2;
     POLY_G4 g4;
@@ -1778,17 +1777,16 @@ typedef union
     SPRT sprt;
 } PrimBuf;
 
-typedef struct 
-{
-  u_long *ot;
-  POLY_GT4 *gt4;
-  POLY_G4 *g4;
-  POLY_GT3 *gt3;
-  LINE_G2 *g2;
-  TILE *tile;
-  DR_MODE *dr;
-  SPRT *sprt;
-  DR_ENV *env;
+typedef struct {
+    u_long* ot;
+    POLY_GT4* gt4;
+    POLY_G4* g4;
+    POLY_GT3* gt3;
+    LINE_G2* g2;
+    TILE* tile;
+    DR_MODE* dr;
+    SPRT* sprt;
+    DR_ENV* env;
 } PrimitivesRenderer;
 
 #ifndef VERSION_PSP
@@ -1799,16 +1797,16 @@ typedef struct
 #endif
 
 void RenderPrimitives(void) {
-    #ifdef VERSION_PSP
-    #define RECT_LOC 0x12C
-    #endif
-    #ifndef VERSION_PSP
-    #define RECT_LOC 0x128
-    #endif
+#ifdef VERSION_PSP
+#define RECT_LOC 0x12C
+#endif
+#ifndef VERSION_PSP
+#define RECT_LOC 0x128
+#endif
     RECT* rect = (RECT*)SP(RECT_LOC);
     PrimitivesRenderer* r = (PrimitivesRenderer*)SP(0x000);
     PrimBuf* primbuf = (PrimBuf*)SP(0x024);
-    
+
     s32 var_s1;
     Primitive* var_s0;
     u8 var_s2;
@@ -1850,7 +1848,8 @@ void RenderPrimitives(void) {
     } else {
         var_a2 = 0;
         var_s1 = 0;
-        for (var_s0 = &g_PrimBuf[0]; var_s1 < MAX_PRIM_COUNT; var_s0++, var_s1++) {
+        for (var_s0 = &g_PrimBuf[0]; var_s1 < MAX_PRIM_COUNT; var_s0++,
+            var_s1++) {
             var_s2 = var_s0->type;
             if (!var_s2) {
                 continue;
@@ -1876,12 +1875,12 @@ void RenderPrimitives(void) {
                 var_s3 = true;
                 if (!var_a2) {
                     SetDrawMode(r->dr, 0, 0, 0, rect);
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                     r->dr++;
                     g_GpuUsage.drawModes++;
                 }
@@ -1893,7 +1892,8 @@ void RenderPrimitives(void) {
             case PRIM_TILE_ALT:
                 setTile(&primbuf->tile);
                 if (g_GpuUsage.tile < MAX_TILE_COUNT) {
-                    setSemiTrans(&primbuf->tile, var_s0->drawMode & DRAW_TRANSP);
+                    setSemiTrans(
+                        &primbuf->tile, var_s0->drawMode & DRAW_TRANSP);
                     primbuf->tile.r0 = var_s0->r0;
                     primbuf->tile.g0 = var_s0->g0;
                     primbuf->tile.b0 = var_s0->b0;
@@ -1907,24 +1907,24 @@ void RenderPrimitives(void) {
                     primbuf->tile.w = var_s0->u0;
                     primbuf->tile.h = var_s0->v0;
                     *r->tile = primbuf->tile;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->tile);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->tile);
                     r->tile++;
                     g_GpuUsage.tile++;
                     if (!(var_s2 & 0x10) &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
                         SetDrawMode(
                             r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -1954,24 +1954,24 @@ void RenderPrimitives(void) {
                         primbuf->g2.y1 = var_s0->y1 + g_backbufferY;
                     }
                     *r->g2 = primbuf->g2;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->g2);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->g2);
                     r->g2++;
                     g_GpuUsage.line++;
                     if ((var_s2 & 0x10) == 0 &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
                         SetDrawMode(
                             r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2015,24 +2015,24 @@ void RenderPrimitives(void) {
                         primbuf->g4.y3 = var_s0->y3 + g_backbufferY;
                     }
                     *r->g4 = primbuf->g4;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->g4);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->g4);
                     r->g4++;
                     g_GpuUsage.g4++;
                     if ((var_s2 & 0x10) == 0 &&
                         g_GpuUsage.drawModes < MAX_DRAW_MODES) {
                         SetDrawMode(
                             r->dr, 0, var_s3, var_s0->drawMode & 0x60, rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2086,22 +2086,22 @@ void RenderPrimitives(void) {
                         var_s0->tpage + (var_s0->drawMode & 0x60);
                     primbuf->gt4.clut = g_ClutIds[var_s0->clut];
                     *r->gt4 = primbuf->gt4;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->gt4);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->gt4);
                     r->gt4++;
                     g_GpuUsage.gt4++;
                     if (var_s3 && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
                         SetDrawMode(r->dr, 0, var_s3, 0, rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2147,22 +2147,22 @@ void RenderPrimitives(void) {
                     primbuf->gt3.clut = g_ClutIds[var_s0->clut];
 
                     *r->gt3 = primbuf->gt3;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->gt3);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->gt3);
                     r->gt3++;
                     g_GpuUsage.gt3++;
                     if (var_s3 && g_GpuUsage.drawModes < MAX_DRAW_MODES) {
                         SetDrawMode(r->dr, 0, var_s3, 0, rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2172,7 +2172,8 @@ void RenderPrimitives(void) {
             case 22:
                 setSprt(&primbuf->sprt);
                 if (g_GpuUsage.sp < MAX_SPRT_COUNT) {
-                    setSemiTrans(&primbuf->sprt, var_s0->drawMode & DRAW_TRANSP);
+                    setSemiTrans(
+                        &primbuf->sprt, var_s0->drawMode & DRAW_TRANSP);
                     setShadeTex(&primbuf->sprt, var_s4);
                     primbuf->sprt.r0 = var_s0->r0;
                     primbuf->sprt.g0 = var_s0->g0;
@@ -2190,12 +2191,12 @@ void RenderPrimitives(void) {
                     primbuf->sprt.h = var_s0->v1;
                     primbuf->sprt.clut = g_ClutIds[var_s0->clut];
                     *r->sprt = primbuf->sprt;
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->sprt);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->sprt);
                     r->sprt++;
                     g_GpuUsage.sp++;
                     if ((var_s2 & 0x10) == 0 &&
@@ -2203,12 +2204,12 @@ void RenderPrimitives(void) {
                         SetDrawMode(
                             r->dr, 0, var_s3,
                             var_s0->tpage + (var_s0->drawMode & 0x60), rect);
-                        #ifdef VERSION_PSP
-                        if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#ifdef VERSION_PSP
+                        if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                             var_s0->priority = 0x1FF;
                         }
-                        #endif
-                        addPrim(&r->ot[var_s0->priority*OT_MULT], r->dr);
+#endif
+                        addPrim(&r->ot[var_s0->priority * OT_MULT], r->dr);
                         r->dr++;
                         g_GpuUsage.drawModes++;
                     }
@@ -2219,14 +2220,14 @@ void RenderPrimitives(void) {
                     env = *(DR_ENV**)&var_s0->r1;
                     if (var_s0->drawMode & DRAW_UNK_1000) {
                         sp80 = g_CurrentBuffer->draw.ofs[0];
-                        #ifndef VERSION_PSP
+#ifndef VERSION_PSP
                         *(s16*)&env->code[2] = sp80;
                         *(s16*)&env->code[7] = sp80;
-                        #endif
-                        #ifdef VERSION_PSP
+#endif
+#ifdef VERSION_PSP
                         *(s16*)&env->code[3] = sp80;
                         *(s16*)&env->code[1] = sp80;
-                        #endif
+#endif
                     }
                     if (var_s0->drawMode & DRAW_UNK_800) {
                         sp18 = g_CurrentBuffer->draw;
@@ -2234,19 +2235,19 @@ void RenderPrimitives(void) {
                         SetDrawEnv(env, &sp18);
                     }
                     *r->env = *env;
-                    #ifndef VERSION_PSP
+#ifndef VERSION_PSP
                     if (var_s0->drawMode & DRAW_UNK_1000) {
                         env = r->env;
                         *(s16*)&env->code[0] += sp80;
                         *(s16*)&env->code[1] += sp80;
                     }
-                    #endif
-                    #ifdef VERSION_PSP
-                    if(var_s0->priority < 0 || var_s0->priority >= 0x200){
+#endif
+#ifdef VERSION_PSP
+                    if (var_s0->priority < 0 || var_s0->priority >= 0x200) {
                         var_s0->priority = 0x1FF;
                     }
-                    #endif
-                    addPrim(&r->ot[var_s0->priority*OT_MULT], r->env);
+#endif
+                    addPrim(&r->ot[var_s0->priority * OT_MULT], r->env);
                     r->env++;
                     g_GpuUsage.env++;
                 }


### PR DESCRIPTION
Got this working with the aid of PSP!

Scratches here:

PS1: https://decomp.me/scratch/FDWxW
PSP: https://decomp.me/scratch/SObUR

These are identical aside from the versions defined at the top of the context, and everything else is done with `ifdef`.

Several of the `ifdef` differences are in structs that are defined in `include/psxsdk/libgpu.h`, and since they're in the PSX SDK, I don't want to add those PSP differences into that file. I imagine at some point we'll have a PSP libgpu.h or something, but until then, this function will not actually match on PSP. But since PSP is not the focus of this decomp, I think that's okay.

This is 99% similar to Xeeynamo's scratch, the main difference is the treatment of the lines that look like `setSemiTrans(&primbuf->g2, var_s0->drawMode & DRAW_TRANSP);`.