### PR TITLE
Minor cleanup on wolf function func_8013136C

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -714,8 +714,8 @@ typedef struct Entity {
     /* 0x1A */ s16 rotX;
     /* 0x1C */ s16 rotY;
     /* 0x1E */ s16 rotZ;
-    /* 0x20 */ u16 rotPivotX;
-    /* 0x22 */ u16 rotPivotY;
+    /* 0x20 */ s16 rotPivotX;
+    /* 0x22 */ s16 rotPivotY;
     /* 0x24 */ u16 zPriority;
     /* 0x26 */ u16 entityId;
     /* 0x28 */ PfnEntityUpdate pfnUpdate;

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -509,8 +509,10 @@ void func_8012E7A4(void) {
         entity->entityId = 0x3B;
         entity->params = i;
     }
+    // We create entity #60, which is func_8013136C
     DestroyEntity(&g_Entities[30]);
-    g_Entities[30].entityId = 0x3C;
+    g_Entities[30].entityId = 60;
+
     func_8012CED4();
     PLAYER.animFrameIdx = 4;
     PLAYER.animFrameDuration = 4;

--- a/src/dra/90264.c
+++ b/src/dra/90264.c
@@ -528,32 +528,32 @@ void func_80130E94(Entity* self) {
         self->unk6C = ~MIN((abs(PLAYER.velocityX) - FIX(3)) >> 12, 128);
     }
 }
-static const u32 rodata_func_80130E94_padding = 0;
-
+// Entity #60. This is created manually at g_Entities[30].
+// Creation is in func_8012E7A4.
 void func_8013136C(Entity* self) {
     if (!(g_Player.unk0C & PLAYER_STATUS_WOLF_FORM)) {
         DestroyEntity(self);
         return;
     }
-    if (self->step == 0) {
+    if (!self->step) {
         self->animSet = 0xF;
         self->unk5A = 0x7E;
         self->palette = PLAYER.palette;
         self->flags = FLAG_UNK_04000000 | FLAG_UNK_20000 | FLAG_UNK_40000;
         self->drawFlags = DRAW_COLORS;
-        LOH(self->rotPivotX) = -8;
+        self->rotPivotX = -8;
         self->step++;
     }
     self->animCurFrame = 80;
     self->facingLeft = PLAYER.facingLeft;
     self->posX.val = g_Entities[UNK_ENTITY_13].posX.val;
     self->posY.val = g_Entities[UNK_ENTITY_13].posY.val;
-    if (PLAYER.facingLeft == 0) {
+    if (!PLAYER.facingLeft) {
         self->zPriority = PLAYER.zPriority - 5;
-        self->posX.i.hi = self->posX.i.hi + 8;
+        self->posX.i.hi += 8;
     } else {
         self->zPriority = PLAYER.zPriority + 5;
-        self->posX.i.hi = self->posX.i.hi - 8;
+        self->posX.i.hi -= 8;
     }
     self->posY.i.hi += 3;
     self->rotZ = g_Entities[UNK_ENTITY_12].rotZ;
@@ -561,7 +561,7 @@ void func_8013136C(Entity* self) {
     case 1:
         if (D_800B0914 == 1) {
             self->posY.i.hi -= 2;
-            if (PLAYER.facingLeft == 0) {
+            if (!PLAYER.facingLeft) {
                 self->posX.i.hi -= 8;
             } else {
                 self->posX.i.hi += 8;
@@ -573,14 +573,14 @@ void func_8013136C(Entity* self) {
         case 0:
             if (PLAYER.animCurFrame == 33) {
                 self->animCurFrame = 81;
-                if (PLAYER.facingLeft == 0) {
+                if (!PLAYER.facingLeft) {
                     self->posX.i.hi += 3;
                 } else {
                     self->posX.i.hi += 6;
                 }
             }
             if (PLAYER.animCurFrame == 34) {
-                if (PLAYER.facingLeft == 0) {
+                if (!PLAYER.facingLeft) {
                     self->posX.i.hi += 3;
                 } else {
                     self->posX.i.hi += 13;
@@ -588,15 +588,22 @@ void func_8013136C(Entity* self) {
                 self->animCurFrame = 82;
             }
             break;
+        // Might be possible to unify these fake empty cases.
         case 1:
-            break;
+#ifdef VERSION_PSP
+        case 3:
+        case 2:
+#else
         case 255:
+#endif
             break;
         }
         break;
     case 3:
         break;
     case 4:
+        D_800B0914 == 0;
+        break;
     case 5:
     case 6:
     case 7:


### PR DESCRIPTION
This is a relatively unimportant function, but it messes with some variables that I am interested in learning more about, so I went ahead and compared it to the PSP version.

This PR incorporates some lessons I learned from that PSP version. Most importantly, the rotPivotX and rotPivotY in Entity are signed.

I also tracked down how this entity is created, it's a bit odd since it doesn't call any entity creation function, and instead does a direct write into g_Entities to create it.

On exit, this function calls `func_8012C600`, which I will be doing a similar analysis for next.

There was a leftover rodata padding that doesn't do anything, so I removed that too.