### PR TITLE
Cleanup on func_800F24F4

### DIFF
--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -984,8 +984,8 @@ void func_800F24F4(void) {
         if (g_StageId == STAGE_RNO0 && x == 32 && y == 36) {
             if (TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
                                      TIMEATTACK_GET_RECORD) == 0) {
-                TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
-                                     TIMEATTACK_SET_RECORD);
+                TimeAttackController(
+                    TIMEATTACK_EVENT_FINAL_SAVEPOINT, TIMEATTACK_SET_RECORD);
             }
         }
 
@@ -1005,7 +1005,7 @@ void func_800F24F4(void) {
                 }
             }
             var_a0 = 1;
-        } 
+        }
         func_801042C4(var_a0);
         D_80137598 = 1;
         func_80105428();

--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -978,42 +978,40 @@ void func_800F24F4(void) {
     s32 y;
     s32 var_a0;
 
-    x = (g_PlayerX >> 8) + g_Tilemap.left;
-    y = (g_PlayerY >> 8) + g_Tilemap.top;
+    x = g_Tilemap.left + (g_PlayerX >> 8);
+    y = g_Tilemap.top + (g_PlayerY >> 8);
     if (D_8003C708.flags & STAGE_INVERTEDCASTLE_FLAG) {
-        if (g_StageId == STAGE_RNO0) {
-            if (x == 32 && y == 36) {
-                if (TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
-                                         TIMEATTACK_GET_RECORD) == 0) {
-                    TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
-                                         TIMEATTACK_SET_RECORD);
-                }
+        if (g_StageId == STAGE_RNO0 && x == 32 && y == 36) {
+            if (TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
+                                     TIMEATTACK_GET_RECORD) == 0) {
+                TimeAttackController(TIMEATTACK_EVENT_FINAL_SAVEPOINT,
+                                     TIMEATTACK_SET_RECORD);
             }
         }
 
-        var_a0 = 0; // FAKE?
-        if (g_StageId != STAGE_RNO4 || x != 18 || y != 30) {
-            if (g_StageId == STAGE_NO4 && x == 45 && y == 33) {
-                if (g_Entities[var_a0].posX.i.hi == 128) {
-                    D_8003C730 = 1;
-                    func_801042C4(1);
-                } else {
-                    if (TimeAttackController(TIMEATTACK_EVENT_SUCCUBUS_DEFEAT,
-                                             TIMEATTACK_GET_RECORD)) {
-                        D_80137598 = 0;
-                        return;
-                    }
-                    func_801042C4(1);
-                }
-            } else {
-                func_801042C4(var_a0);
-            }
-            D_80137598 = 1;
-            func_80105428();
+        var_a0 = 0;
+        if (g_StageId == STAGE_RNO4 && x == 18 && y == 30) {
+            D_80137598 = 0;
             return;
         }
+        if (g_StageId == STAGE_NO4 && x == 45 && y == 33) {
+            if (PLAYER.posX.i.hi == 128) {
+                D_8003C730 = 1;
+            } else {
+                if (TimeAttackController(TIMEATTACK_EVENT_SUCCUBUS_DEFEAT,
+                                         TIMEATTACK_GET_RECORD)) {
+                    D_80137598 = 0;
+                    return;
+                }
+            }
+            var_a0 = 1;
+        } 
+        func_801042C4(var_a0);
+        D_80137598 = 1;
+        func_80105428();
+    } else {
+        D_80137598 = 0;
     }
-    D_80137598 = 0;
 }
 
 void DrawMapCursor(void) {


### PR DESCRIPTION
Lots of small changes here, but ultimately this ends up rewriting the whole function.

I opened this one in PSP (it's `-O4`!) and found several differences which I corrected. I also rewrote some of the if-statements to be a bit more readable.

Kind of a weird function the way it's testing for hard-coded X and Y values. Not sure what this function actually does.

We also end up only calling `func_801042C4` once, which is a nice improvement for readability.

`func_801042C4` is not decompiled, so I'll move on to that next.