### PR TITLE
Fix analyze calls for RWRP PR

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Analyze calls dry run
         if: matrix.version == 'us'
         run: |
+          make force_symbols
           make force_extract
           ./tools/analyze_calls.py --ultradry
       - name: Remove clutter from build folder

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -230,7 +230,7 @@ def find_func_match(caller, candidates):
             if candidate.unique_name.startswith("dra."):
                 return candidate
         # Resolve rwrp matches by pulling from wrp. This may need to have different logic in future.
-        if("rwrp" in caller.asm_filename):
+        if "rwrp" in caller.asm_filename:
             for candidate in candidates:
                 if candidate.unique_name.startswith("wrp."):
                     return candidate

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -232,7 +232,7 @@ def find_func_match(caller, candidates):
         # Resolve rwrp matches by pulling from wrp. This may need to have different logic in future.
         if "rwrp" in caller.asm_filename:
             for candidate in candidates:
-                if candidate.unique_name.startswith("wrp."):
+                if "wrp" in candidate.unique_name:
                     return candidate
         print("Unbreakable tie found, exiting!")
         exit(4)

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -189,10 +189,19 @@ def is_decompiled(srcfile, fname):
 
 def get_c_filename(asm_filename):
     assert "asm/us" in asm_filename and "/nonmatchings/" in asm_filename
-    # Step 1: Replace asm/us for src
+    # Convert a path in asm/us to a path in src
     srcpath = asm_filename.replace("asm/us", "src")
-    # Step 2: Remove the nonmatchings
-    no_nonmatchings = srcpath.replace("/nonmatchings/", "/")
+    # Count the number of paths after "nonmatchings". If there are two directories,
+    # then the file must be specifying a path in src. If not, then it's a path in the overlay.
+    # Example: specifying wrp/collision should be treated differently than if it was just "collision"
+    paths_after_nonmatchings = srcpath.split("/nonmatchings/")[1].count("/")
+    # Raw file which goes in the default overlay directory
+    if paths_after_nonmatchings == 1 or srcpath.startswith("src/main"):
+        no_nonmatchings = srcpath.replace("/nonmatchings/", "/")
+    # Has an extra directory, so remove overlay specified before /nonmatchings/
+    if paths_after_nonmatchings == 2:
+        overlay = srcpath.split("/")[2]
+        no_nonmatchings = srcpath.replace("/" + overlay + "/nonmatchings/", "/")
     # Little known rpartition drops the function name to get the last directory, which should be c file name.
     c_filename = no_nonmatchings.rpartition("/")[0] + ".c"
     assert os.path.exists(c_filename)
@@ -220,7 +229,12 @@ def find_func_match(caller, candidates):
         for candidate in candidates:
             if candidate.unique_name.startswith("dra."):
                 return candidate
-        print("Can't resolve tie, none in DRA!")
+        # Resolve rwrp matches by pulling from wrp. This may need to have different logic in future.
+        if("rwrp" in caller.asm_filename):
+            for candidate in candidates:
+                if candidate.unique_name.startswith("wrp."):
+                    return candidate
+        print("Unbreakable tie found, exiting!")
         exit(4)
     else:
         print("No candidates!")


### PR DESCRIPTION
The new setup with RWRP sharing files with WRP means some of the assumptions made while developing analyze_calls no longer hold.

The new code adds some checks and tweaks the logic to now handle these situations. This works on my computer.

This PR is into the rwrp_merge branch, not into master, so that we can make sure that branch builds successfully without needing to rebase.