### PR TITLE
Attempt fixing analyze_calls build issue

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -229,8 +229,8 @@ def find_func_match(caller, candidates):
         for candidate in candidates:
             if candidate.unique_name.startswith("dra."):
                 return candidate
-        # Resolve rwrp matches by pulling from wrp. This may need to have different logic in future.
-        if "rwrp" in caller.asm_filename:
+        # Resolve wrp/rwrp matches by pulling from wrp. This may need to have different logic in future.
+        if "wrp" in caller.asm_filename:
             for candidate in candidates:
                 if "wrp" in candidate.unique_name:
                     return candidate


### PR DESCRIPTION
Iterating on this problem in master.

Now that wrp/rwrp are sharing so much code, analyze_calls is having trouble telling what functions call each other in which overlay.

I think this will resolve all the issues we have for now, but I'm sure more will appear over time.