### PR TITLE
Compare function similiarity in function_finder

### DIFF
--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -90,7 +90,7 @@ def get_asm_files(asm_path):
     return files
 
 def find_wip(o):
-    result = find_scratches(o[1], "ps1")
+    result = find_scratches(o[1], "ps1", o[7])
 
     if result:
         return {"link": result[0], "percent": result[1]}
@@ -146,6 +146,7 @@ if __name__ == "__main__":
                 jump_table,
                 wip,
                 wip_percentage,
+                f["text"] # local asm
             ]
         )
 
@@ -173,5 +174,10 @@ if __name__ == "__main__":
             if os.path.exists(svg_path):
                 o[1] = f"[{o[1]}]({base_url}/{svg_path})"
 
+    # delete asm text
+    for o in output:
+        del o[7:]
+
     headers = ["Ovl", "Function", "Length", "Branches", "Jtbl", "WIP", "%"]
     print(tabulate(output, headers=headers, tablefmt="github"))
+

--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -90,7 +90,7 @@ def get_asm_files(asm_path):
     return files
 
 def find_wip(o):
-    result = find_scratches(o[1], "ps1", o[7])
+    result = find_scratches(o[1], "ps1", o[7], True)
 
     if result:
         return {"link": result[0], "percent": result[1]}

--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -126,6 +126,10 @@ if __name__ == "__main__":
         if "/psxsdk/" in name:
             ovl_name = name.split("/")[5]  # grab library name
             func_name = os.path.splitext(os.path.basename(name))[0]
+        elif "/weapon/" in name:
+            # use the weapon name
+            ovl_name = name.split("/")[4]  # grab library name
+            func_name = os.path.splitext(os.path.basename(name))[0]
         else:
             matches = re.search(r"\/(\w+)\/nonmatchings\/\w+\/(\w+)\.s", name)
             if matches:

--- a/tools/function_finder/helpers.py
+++ b/tools/function_finder/helpers.py
@@ -2,9 +2,31 @@
 import json
 import requests
 import sys
+import zipfile
+from io import BytesIO
+import difflib
 
+def are_strings_similar(str1, str2, threshold=0.8):
+    similarity = difflib.SequenceMatcher(None, str1, str2).ratio()
+    return similarity >= threshold
 
-def find_scratches(name, platform):
+def get_asm(slug):
+    url = f'https://decomp.me/api/scratch/{slug}/export'
+    response = requests.get(url)
+    if response.status_code == 200:
+        with zipfile.ZipFile(BytesIO(response.content)) as the_zip:
+            zip_contents = the_zip.namelist()
+            if 'target.s' in zip_contents:
+                with the_zip.open('target.s') as file:
+                    target_content = file.read().decode('utf-8')
+                return target_content
+            else:
+                print("target.s not found in the zip file")
+    else:
+        print(f"Failed to download the zip file: Status code {response.status_code}")
+    return None
+
+def find_scratches(name, platform, local_asm=None, use_local=False):
     try:
         response = requests.get(f"https://decomp.me/api/scratch?search={name}")
         response.raise_for_status()
@@ -27,6 +49,12 @@ def find_scratches(name, platform):
             continue
         if result["platform"] != platform:
             continue
+
+        if use_local:
+            remote_asm = get_asm(result['slug'])
+
+            if not are_strings_similar(local_asm, remote_asm):
+                continue
 
         score = result["score"]
         max_score = result["max_score"]


### PR DESCRIPTION
This changes the psx function finder to compare the local and remote asm to find a match. Right now there's a lot of false positives due to name collisions. The new output looks like this:

https://gist.github.com/sozud/4eaa80c2ebb475551986b4f55d42d036

This should be off by default for the other platforms but I can't check saturn locally right now.