### PR TITLE
Idea: allow postfixing of func names

### DIFF
--- a/tools/function_finder/helpers.py
+++ b/tools/function_finder/helpers.py
@@ -44,8 +44,7 @@ def find_scratches(name, platform, local_asm=None, use_local=False):
     for result in scratches["results"]:
         if not "name" in result:
             continue
-        # seems to give approximate matches, skip these
-        if result["name"] != name:
+        if not result["name"].startswith(name):
             continue
         if result["platform"] != platform:
             continue


### PR DESCRIPTION
Now that @sozud has added function similarity, I wonder if it's worth including prefix matches in the results of function_finder. This would let us name a scratch ex: `EntityWeaponAttack_w_053` and have it still show up in functions.md. Thoughts?