### PR TITLE
Decompile w52 (Alucard Shield) func_ptr_80170004

### DIFF
--- a/config/symbols.us.weapon.txt.in
+++ b/config/symbols.us.weapon.txt.in
@@ -1485,6 +1485,7 @@ WeaponUnused30 = 0x8017CB64; // type:func rom:0x170000 allow_duplicated:True
 WeaponUnused34 = 0x8017CB6C; // type:func rom:0x170000 allow_duplicated:True
 WeaponUnused38 = 0x8017CB74; // type:func rom:0x170000 allow_duplicated:True
 WeaponUnused3C = 0x8017CB7C; // type:func rom:0x170000 allow_duplicated:True
+D_170000_8017CBD0 = 0x8017CBD0; // type:label rom:0x170000 allow_duplicated:True
 EntityWeaponAttack = 0x8017B620; // type:func rom:0x177000 allow_duplicated:True
 func_ptr_80170004 = 0x8017B914; // type:func rom:0x177000 allow_duplicated:True
 func_ptr_80170008 = 0x8017BFCC; // type:func rom:0x177000 allow_duplicated:True

--- a/src/weapon/w_052.c
+++ b/src/weapon/w_052.c
@@ -3,6 +3,9 @@
 #include "weapon_private.h"
 #include "shared.h"
 
+extern u8 D_170000_8017ABC4[];
+extern f32 D_170000_8017CBD0[11][4];
+
 INCLUDE_ASM("weapon/nonmatchings/w_052", EntityWeaponAttack);
 
 void func_ptr_80170008(Entity* self) {}
@@ -17,7 +20,138 @@ int GetWeaponId(void) { return 52; }
 
 INCLUDE_ASM("weapon/nonmatchings/w_052", EntityWeaponShieldSpell);
 
-INCLUDE_ASM("weapon/nonmatchings/w_052", func_ptr_80170004);
+s32 func_ptr_80170004(Entity* self) {
+    Primitive* prim;
+    s16 playerY;
+    s16 primWidth;
+    s16 primXCenter;
+    s16 primYCenter;
+    u16 playerX;
+    s16 primHeight;
+    u8* uvPtr;
+
+    s32 i;
+
+    switch (self->step) {
+    case 0:
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 11);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
+        }
+        if (g_HandId) {
+            self->ext.shield.unk86 = 0x129;
+            self->ext.shield.unk7D = 0x80;
+        } else {
+            self->ext.shield.unk86 = 0x111;
+            self->ext.shield.unk7D = 0;
+        }
+        uvPtr = &D_170000_8017ABC4;
+        playerX = PLAYER.posX.i.hi;
+        playerY = PLAYER.posY.i.hi - 8;
+        self->flags = FLAG_UNK_04000000 | FLAG_HAS_PRIMS | FLAG_UNK_10000;
+        prim = &g_PrimBuf[self->primIndex];
+        for (i = 0; i < 11; i++) {
+            prim->u0 = prim->u2 = *uvPtr++;
+            prim->v0 = prim->v1 = *uvPtr++;
+            prim->u1 = prim->u3 = *uvPtr++;
+            prim->v2 = prim->v3 = *uvPtr++;
+            prim->v0 += self->ext.shield.unk7D;
+            prim->v1 += self->ext.shield.unk7D;
+            prim->v2 += self->ext.shield.unk7D;
+            prim->v3 += self->ext.shield.unk7D;
+            prim->tpage = 0x19;
+            prim->clut = self->ext.shield.unk86 + i;
+            prim->priority = self->zPriority - 2;
+            prim->drawMode = DRAW_DEFAULT;
+            prim->r0 = (rand() & 0xF) + 1;
+            D_170000_8017CBD0[i][0].i.hi = playerX;
+            D_170000_8017CBD0[i][1].i.hi = playerY;
+            D_170000_8017CBD0[i][2].val = (rand() * 6) + FIX(-1.5);
+            D_170000_8017CBD0[i][3].val = FIX(-2) - (rand() * 4);
+            prim = prim->next;
+        }
+        self->ext.shield.unk94 = 0x20;
+        self->ext.shield.unk80 = 0x20;
+        self->step++;
+        break;
+    case 1:
+        self->ext.shield.unk94 += 0x10;
+        if (self->ext.shield.unk94 > 0xC0) {
+            self->ext.shield.unk94 = 0xC0;
+        }
+        for (i = 0; i < 11; i++) {
+            D_170000_8017CBD0[i][0].val += D_170000_8017CBD0[i][2].val;
+            D_170000_8017CBD0[i][1].val += D_170000_8017CBD0[i][3].val;
+            D_170000_8017CBD0[i][3].val += 0x2000;
+        }
+        if (--self->ext.shield.unk80 == 0) {
+            prim = &g_PrimBuf[self->primIndex];
+            for (i = 0; i < 11; i++) {
+                prim->g0 = 1;
+                prim = prim->next;
+            }
+            self->ext.shield.unk80 = 0x60;
+            self->step++;
+        }
+        break;
+    case 2:
+        if ((self->ext.shield.unk80 >= 0x48) &&
+            (self->ext.shield.unk80 % 4 == 0)) {
+            g_api.PlaySfx(SFX_SUBWPN_THROW);
+        }
+        if (--self->ext.shield.unk80 == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    prim = &g_PrimBuf[self->primIndex];
+    for (i = 0; i < 11; i++) {
+        switch (prim->g0) {
+        case 0:
+            primXCenter = D_170000_8017CBD0[i][0].i.hi;
+            primYCenter = D_170000_8017CBD0[i][1].i.hi;
+            if (i == 6) {
+                primHeight = self->ext.shield.unk94 * 12 / 256;
+            } else {
+                primHeight = self->ext.shield.unk94 * 16 / 256;
+            }
+            primWidth = self->ext.shield.unk94 * 12 / 256;
+            prim->x0 = prim->x2 = primXCenter - primWidth;
+            prim->x1 = prim->x3 = primXCenter + primWidth;
+            prim->y0 = prim->y1 = primYCenter - primHeight;
+            prim->y2 = prim->y3 = primYCenter + primHeight;
+            break;
+        case 1:
+            if (--prim->r0 == 0) {
+                prim->g0++;
+            }
+            break;
+        case 2:
+            if ((prim->x1 - prim->x0) >= 5) {
+                prim->x0++;
+                prim->x1--;
+            } else {
+                prim->x0 = prim->x1 - 2;
+            }
+            prim->y0 -= 18;
+            prim->y2 -= 6;
+            prim->y1 = prim->y0;
+            prim->y3 = prim->y2;
+            prim->x2 = prim->x0;
+            prim->x3 = prim->x1;
+            if (prim->y2 < 0) {
+                prim->g0++;
+            }
+            break;
+        case 3:
+            prim->drawMode = DRAW_HIDE;
+            break;
+        }
+        prim = prim->next;
+    }
+}
 
 void func_ptr_80170024(Entity* self) {}
 


### PR DESCRIPTION
The most important thing here is that D_170000_8017CBD0 is an array of f32 values. But since entry 0 is only accessed with `.i.hi`, the auto-detected symbol was `CBD2`, offset by 2, so I had to manually make the symbol for this one variable. I studied the symbols file to figure out how to declare it, and this ended up working. Now that I know how to make weapon symbols, I can start making useful names for these in the future. Not for this one though, this doesn't make any sense.