### PR TITLE
Decompile EntityWeaponAttack for all remaining shields

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -299,6 +299,29 @@ typedef struct {
 } ET_Shield;
 
 typedef struct {
+    /* 0x7C */ u8 unk7C;
+    /* 0x7D */ u8 unk7D;
+    /* 0x7E */ s16 unk7E;
+    /* 0x80 */ u16 unk80;
+    /* 0x82 */ s16 pal;
+    /* 0x84 */ s16* palettePtr;
+    /* 0x88 */ u16 childPalette;
+    /* 0x8A */ s16 unk8A;
+    /* 0x8C */ struct Entity* parent;
+    /* 0x90 */ s16 unk90;
+    /* 0x92 */ s16 unk92;
+    /* 0x94 */ s16 unk94;
+    /* 0x96 */ s16 unk96;
+    /* 0x98 */ s16 unk98;
+    /* 0x9A */ s16 unk9A;
+    /* 0x9C */ s16 unk9C;
+    /* 0x9E */ byte pad[14];
+    /* 0xAC */ u8 anim;
+    /* 0xAD */ u8 padAD;
+    /* 0xAE */ s16 unkAE;
+} ET_DarkShield;
+
+typedef struct {
     /* 0x7D */ u8 unk7C;
     /* 0x7D */ u8 unk7D;
     /* 0x7E */ s16 unk7E;
@@ -1331,6 +1354,7 @@ typedef union { // offset=0x7C
     ET_MessageBox messageBox;
     ET_Weapon weapon;
     ET_Shield shield;
+    ET_DarkShield darkShield;
     ET_KarmaCoin karmacoin;
     ET_HeavenSword heavenSword;
     ET_HeavenSword2 heavenSword2;

--- a/src/weapon/w_008.c
+++ b/src/weapon/w_008.c
@@ -3,7 +3,143 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_008", EntityWeaponAttack);
+extern SpriteParts D_3C000_8017A040[];
+extern s8 D_3C000_8017A9F8;
+extern AnimationFrame* D_3C000_8017AA40;
+
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_3C000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_3C000_8017A9F8, &D_3C000_8017AA40);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_009.c
+++ b/src/weapon/w_009.c
@@ -3,7 +3,143 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_009", EntityWeaponAttack);
+extern SpriteParts D_43000_8017A040[];
+extern s8 D_43000_8017A9F8;
+extern AnimationFrame* D_43000_8017AA40;
+
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_43000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_43000_8017A9F8, &D_43000_8017AA40);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_010.c
+++ b/src/weapon/w_010.c
@@ -4,6 +4,10 @@
 #include "shared.h"
 #include "items.h"
 
+extern SpriteParts D_4A000_8017A040[];
+extern s8 D_4A000_8017AB20;
+extern AnimationFrame* D_4A000_8017AB68;
+
 extern s32 D_4A000_8017CC1C; // g_DebugWaitInfoTimer
 
 void DebugShowWaitInfo(const char* msg) {
@@ -26,7 +30,148 @@ void DebugInputWait(const char* msg) {
         DebugShowWaitInfo(msg);
 }
 
-INCLUDE_ASM("weapon/nonmatchings/w_010", EntityWeaponAttack);
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    if (self->step == 1 || self->step == 2) {
+        if (self->hitFlags != 0) {
+            // Creates func_ptr_80170004
+            g_api.CreateEntFactoryFromEntity(
+                self, ((g_HandId + 1) << 0xC) + 56, 0);
+            g_api.func_8010E168(0, 0x60);
+            self->hitFlags = 0;
+        }
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_4A000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_4A000_8017AB20, &D_4A000_8017AB68);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 extern AnimationFrame D_4A000_8017ABA0[];
 

--- a/src/weapon/w_011.c
+++ b/src/weapon/w_011.c
@@ -3,7 +3,143 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_011", EntityWeaponAttack);
+extern SpriteParts D_51000_8017A040[];
+extern s8 D_51000_8017AB4C;
+extern AnimationFrame* D_51000_8017AB94;
+
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_51000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_51000_8017AB4C, &D_51000_8017AB94);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_023.c
+++ b/src/weapon/w_023.c
@@ -3,7 +3,155 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_023", EntityWeaponAttack);
+extern SpriteParts D_A5000_8017A040[];
+extern s8 D_A5000_8017AAD8;
+extern AnimationFrame* D_A5000_8017AB20;
+
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    if (self->step == 1 || self->step == 2) {
+        if (self->ext.shield.unk84 == 0) {
+            if (self->hitFlags == 3) {
+                g_api.AddHearts(1);
+                self->hitFlags = 0;
+                self->ext.shield.unk84 = 0x20;
+            }
+        }
+    }
+    if (self->ext.shield.unk84 != 0) {
+        self->ext.shield.unk84--;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_A5000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_A5000_8017AAD8, &D_A5000_8017AB20);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_024.c
+++ b/src/weapon/w_024.c
@@ -3,7 +3,169 @@
 #include "weapon_private.h"
 #include "shared.h"
 
-INCLUDE_ASM("weapon/nonmatchings/w_024", EntityWeaponAttack);
+extern SpriteParts D_AC000_8017A040[];
+extern s8 D_AC000_8017ABD8;
+extern AnimationFrame* D_AC000_8017AC20;
+extern s16* D_AC000_8017ACF8[];
+
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_AC000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->ext.darkShield.pal = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->ext.darkShield.pal = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        self->ext.darkShield.palettePtr = D_AC000_8017ACF8[rand() & 3];
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.darkShield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.darkShield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.darkShield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_AC000_8017ABD8, &D_AC000_8017AC20);
+    }
+    if (self->ext.darkShield.unk80 == 0) {
+        self->ext.darkShield.unk80 =
+            self->ext.darkShield
+                .palettePtr[self->ext.darkShield.childPalette * 2];
+        self->palette =
+            self->ext.darkShield
+                .palettePtr[self->ext.darkShield.childPalette * 2 + 1] +
+            self->ext.darkShield.pal;
+    } else if (--self->ext.darkShield.unk80 == 0) {
+        self->ext.darkShield.childPalette =
+            self->ext.darkShield.childPalette + 1;
+        self->ext.darkShield.unk80 =
+            self->ext.darkShield
+                .palettePtr[self->ext.darkShield.childPalette * 2];
+        self->palette =
+            self->ext.darkShield
+                .palettePtr[self->ext.darkShield.childPalette * 2 + 1] +
+            self->ext.darkShield.pal;
+        if (self->ext.darkShield.unk80 == 0xFFFF) {
+            self->ext.darkShield.childPalette = 0;
+            self->ext.darkShield.unk80 = 0;
+            self->ext.darkShield.palettePtr = D_AC000_8017ACF8[rand() & 3];
+        }
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_025.c
+++ b/src/weapon/w_025.c
@@ -3,6 +3,10 @@
 #include "weapon_private.h"
 #include "shared.h"
 
+extern SpriteParts D_B3000_8017A040[];
+extern s8 D_B3000_8017AA18;
+extern AnimationFrame* D_B3000_8017AA60;
+
 void func_B3000_8017AF14(const char* fmt, u_long end) {
     while (PadRead(0) != end) {
         FntPrint(fmt);
@@ -12,7 +16,139 @@ void func_B3000_8017AF14(const char* fmt, u_long end) {
     }
 }
 
-INCLUDE_ASM("weapon/nonmatchings/w_025", EntityWeaponAttack);
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (self->params & 0x8000) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_B3000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_B3000_8017AA18, &D_B3000_8017AA60);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 

--- a/src/weapon/w_026.c
+++ b/src/weapon/w_026.c
@@ -4,6 +4,8 @@
 #include "shared.h"
 
 extern SpriteParts D_BA000_8017A040[];
+extern s8 D_BA000_8017AA18;
+extern AnimationFrame* D_BA000_8017AA60;
 extern s16 D_BA000_8017AA98;
 extern s16 D_BA000_8017AA9A;
 extern s32 D_BA000_8017AA9C[];
@@ -11,7 +13,139 @@ extern u8 D_BA000_8017AADC[];
 
 extern s32 D_BA000_8017CC3C;
 
-INCLUDE_ASM("weapon/nonmatchings/w_026", EntityWeaponAttack);
+void EntityWeaponAttack(Entity* self) {
+    s32 anim1;
+    s32 anim2;
+    s32 attackButton;
+
+    anim1 = 0;
+    anim2 = 0;
+    if (g_HandId) {
+        attackButton = PAD_CIRCLE;
+    } else {
+        attackButton = PAD_SQUARE;
+    }
+    if (!(attackButton & g_Player.padPressed) && (self->step < 3)) {
+        self->animFrameDuration = 0;
+        self->animFrameIdx = 0;
+        self->step = 3;
+    }
+    if (self->step != 4) {
+        self->posX.val = PLAYER.posX.val;
+        self->posY.val = PLAYER.posY.val;
+        self->facingLeft = PLAYER.facingLeft;
+    }
+    if ((g_Player.unk0C & PLAYER_STATUS_UNK10000) && (self->step != 4)) {
+        self->zPriority = PLAYER.zPriority + 2;
+        self->step = 4;
+        if (g_Player.pl_vram_flag & 1) {
+            self->velocityX = PLAYER.velocityX;
+        } else {
+            self->velocityX = PLAYER.velocityX * 2;
+        }
+        self->velocityY = FIX(-3.5);
+        self->ext.timer.t = 0x80;
+        self->flags = FLAG_UNK_08000000;
+        self->animCurFrame = 0x3E;
+    }
+    if ((PLAYER.step == Player_Crouch) && (PLAYER.step_s != 2)) {
+        anim2++;
+    }
+    switch (self->step) {
+    case 0:
+        SetSpriteBank1(D_BA000_8017A040);
+        if (g_HandId != 0) {
+            self->animSet = ANIMSET_OVL(0x12);
+            self->palette = 0x128;
+            self->unk5A = 0x66;
+        } else {
+            self->animSet = ANIMSET_OVL(0x10);
+            self->palette = 0x110;
+            self->unk5A = 0x64;
+        }
+        self->flags = FLAG_UNK_40000 | FLAG_UNK_20000;
+        self->zPriority = PLAYER.zPriority - 2;
+        g_Player.unk48 = 1;
+        SetWeaponProperties(self, 0);
+        self->step++;
+        /* fallthrough */
+    case 1:
+        self->ext.shield.anim = anim2 + 10;
+        if (self->animFrameDuration < 0) {
+            self->step++;
+        }
+        break;
+    case 2:
+        switch (PLAYER.ext.player.anim) {
+        case 9:
+        case 10:
+        case 11:
+            anim1++;
+            /* fallthrough */
+        case 7:
+            anim1++;
+            /* fallthrough */
+        case 8:
+            anim1++;
+            /* fallthrough */
+        case 12:
+            anim1++;
+            /* fallthrough */
+        case 13:
+            anim1++;
+            /* fallthrough */
+        case 24:
+        case 25:
+            anim1++;
+            /* fallthrough */
+        case 14:
+        case 15:
+            anim1++;
+            /* fallthrough */
+        case 26:
+            anim1 += 2;
+            self->animFrameIdx = PLAYER.animFrameIdx;
+            break;
+        default:
+            self->animFrameIdx = 0;
+            anim1 += anim2;
+            break;
+        }
+        self->ext.shield.anim = anim1;
+        self->animFrameDuration = 2;
+        break;
+    case 3:
+        g_Player.unk48 = 0;
+        self->ext.shield.anim = anim2 + 12;
+        if (self->animFrameDuration < 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    case 4:
+        self->hitboxState = 0;
+        g_Player.unk48 = 0;
+        self->drawFlags |= FLAG_DRAW_ROTZ;
+        self->posY.val += self->velocityY;
+        self->posX.val += self->velocityX;
+        self->velocityY += FIX(20.0 / 128);
+        self->rotZ += 0x80;
+        if (--self->ext.timer.t < 0x10) {
+            self->drawFlags |= FLAG_DRAW_UNK80;
+        }
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
+            return;
+        }
+        break;
+    }
+    if (self->step != 4) {
+        g_api.PlayAnimation(&D_BA000_8017AA18, &D_BA000_8017AA60);
+    }
+    self->drawFlags = PLAYER.drawFlags;
+    self->rotY = PLAYER.rotY;
+    self->rotPivotY = PLAYER.rotPivotY;
+}
 
 s32 func_ptr_80170004(Entity* self) {}
 


### PR DESCRIPTION
This PR is big, but it's because these functions are almost perfect duplicates of each other. I figured it would make more sense to process them all at once than to have 9 more PRs for essentially the same function.

This basically handles the animation of holding up/putting down a shield, so it makes sense that the shields are all mostly the same.

The differences are with shields that have an effect when something hits them - this includes the Iron Shield, Dark Shield, and Herald Shield. Aside from these ones, this function is a perfect copy-paste, only requiring variables to be renamed. And with those three, it's still the same function, just with a few lines added to create their special effect. Search for "hitFlags" to see the effects on Iron and Herald, and for ext.darkShield to see the madness going on with the Dark Shield.

Please let me know if you'd like this PR handled differently; hopefully despite the size here, the level of shared code makes it reasonable to have such a big PR.