### PR TITLE
Added SFX enum and SFX_RIC_WHIP_RATTLE_A

### DIFF
--- a/include/sfx.h
+++ b/include/sfx.h
@@ -386,13 +386,18 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define SE_UNK_TE3_6B8 0x6B8
 #define NA_VO_MAR_AIM_HEAD 0x87F
 
+// The VAB IDs appear in large chunks so all sounds proceeding
+// a vabid label comment will belong in that VAB group unless noted.
+
 enum Sfx {
-    SFX_HARPY_WING_FLAP = 0x601,   // vabid 0
-    SFX_RIC_WHIP_RATTLE_A = 0x602, // vabid 0 (also used in BO6 & RBO1)
-    SFX_RIC_WHIP_RATTLE_B = 0x603, // vabid 0 (603-606 are unused)
-    SFX_RIC_WHIP_RATTLE_C = 0x604, // vabid 0
-    SFX_RIC_WHIP_RATTLE_D = 0x605, // vabid 0
-    SFX_RIC_WHIP_RATTLE_E = 0x606, // vabid 0
+    // vabid 0
+    SFX_HARPY_WING_FLAP = 0x601,
+    SFX_RIC_WHIP_RATTLE_A,
+    // (RATTLE_B through E appear to be unused)
+    SFX_RIC_WHIP_RATTLE_B,
+    SFX_RIC_WHIP_RATTLE_C,
+    SFX_RIC_WHIP_RATTLE_D,
+    SFX_RIC_WHIP_RATTLE_E,
 };
 
 #endif

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -335,9 +335,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define SE_TREE_BRANCH_SNAP 0x7A4
 #define SE_CASTLE_GATE_RISE 0x7A5
 
-// NZ1
-#define SE_HARPY_WING_FLAP 0x601
-
 // SHARED SOUNDS
 // These are sounds that are shared across multiple BIN files
 #define SE_WEAPON_STAB 0x62E
@@ -388,5 +385,14 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define SE_UNK_TE2_6B6 0x6B6
 #define SE_UNK_TE3_6B8 0x6B8
 #define NA_VO_MAR_AIM_HEAD 0x87F
+
+enum Sfx {
+    SFX_HARPY_WING_FLAP = 0x601,   // vabid 0
+    SFX_RIC_WHIP_RATTLE_A = 0x602, // vabid 0 (also used in BO6 & RBO1)
+    SFX_RIC_WHIP_RATTLE_B = 0x603, // vabid 0 (603-606 are unused)
+    SFX_RIC_WHIP_RATTLE_C = 0x604, // vabid 0
+    SFX_RIC_WHIP_RATTLE_D = 0x605, // vabid 0
+    SFX_RIC_WHIP_RATTLE_E = 0x606, // vabid 0
+};
 
 #endif

--- a/src/ric/2A060.c
+++ b/src/ric/2A060.c
@@ -447,7 +447,7 @@ void func_80166784(Entity* self) {
                     a0 = self;
                 }
                 if (self->ext.et_80166784.unkA6 == 0) {
-                    g_api.PlaySfx(0x602);
+                    g_api.PlaySfx(SFX_RIC_WHIP_RATTLE_A);
                     self->ext.et_80166784.unkA6 = 0x20;
                 }
                 if (upperParams == 0) {


### PR DESCRIPTION
Starting off with something simple.  Per [sozud](https://github.com/sozud)'s suggestion in #1441 , I put in a new enum for sounds.  There's only one reference to Richter's whip sound in the codebase so far.  According to my research, BO6 and RBO1 reference this ID as well.  

There's several other whip rattle sounds (0x603-0x606) immediately following the commonly heard 0x602 cue.  Unless BO6 or RBO1 uses random sound calls (like Alucard's randomized grunts), I don't believe these are referenced in the game and are unused.