### PR TITLE
Decompile `memmove`

### DIFF
--- a/src/main/psxsdk/libc/memmove.c
+++ b/src/main/psxsdk/libc/memmove.c
@@ -1,3 +1,15 @@
-#include "common.h"
+#include "types.h"
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libc/memmove", memmove);
+void* memmove(u_char* dest, u_char* src, int count) {
+    if (dest >= src) {
+        while (count-- > 0) {
+            dest[count] = src[count];
+        }
+    } else {
+        while (count-- > 0) {
+            *dest++ = *src++;
+        }
+    }
+
+    return dest;
+}


### PR DESCRIPTION
Decompile `libc2`'s `memmove`.