### PR TITLE
Added and updated SFX references 

### DIFF
--- a/include/sfx.h
+++ b/include/sfx.h
@@ -424,7 +424,7 @@ enum Sfx {
     SFX_UNK_BETA_630,      // MAD, TE1, TE2, TE3, TE4, TE5
     SFX_DEATH_AMBIENCE,    // BGM ambience during first Death cutscene
     SFX_MAGIC_GLASS_BREAK, // Subweapon Container
-    SFX_UI_SELECT,
+    SFX_UI_CONFIRM,
 };
 
 #endif

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -328,7 +328,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define SE_BOSS_DEFEATED 0x7D2
 
 // UI SOUNDS
-#define SE_UI_CONFIRM 0x633
 #define SE_UI_START 0x63D
 #define SE_UI_SELECT 0x67B
 #define SE_UI_MAIN_MENU_SELECT 0x67D
@@ -420,10 +419,10 @@ enum Sfx {
     SFX_SKELETON_DEATH_C,
     SFX_FIRE_BURST,
     SFX_WEAPON_STAB_A,
-    SFX_WEAPON_STAB_B, // Common stab sfx
-    SFX_WEAPON_APPEAR, // Item Crash, Neutron Bomb
-    SFX_UNK_BETA_630,  // MAD, TE1, TE2, TE3, TE4, TE5
-    SFX_DEATH_AMBIENCE,
+    SFX_WEAPON_STAB_B,     // Common stab sfx
+    SFX_WEAPON_APPEAR,     // Item Crash, Neutron Bomb
+    SFX_UNK_BETA_630,      // MAD, TE1, TE2, TE3, TE4, TE5
+    SFX_DEATH_AMBIENCE,    // BGM ambience during first Death cutscene
     SFX_MAGIC_GLASS_BREAK, // Subweapon Container
     SFX_UI_SELECT,
 };

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -417,7 +417,7 @@ enum Sfx {
     SFX_SKELETON_DEATH_A,
     SFX_SKELETON_DEATH_B,
     SFX_SKELETON_DEATH_C,
-    SFX_FIRE_BURST,
+    SFX_FIRE_SHOT,
     SFX_WEAPON_STAB_A,
     SFX_WEAPON_STAB_B,     // Common stab sfx
     SFX_WEAPON_APPEAR,     // Item Crash, Neutron Bomb

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -180,7 +180,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define JP_VO_SH_SONO_TEIDO 0x530 // Shaft: Sono teido no chikara de tatakai...
 #endif
 
-#define SFX_WEAPON_62C 0x62C
 #define NA_SE_EV_GLASS_BREAK 0x632
 #define NA_SE_BREAK_CANDLE 0x634
 #define SFX_UNK_635 0x635
@@ -293,7 +292,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define BIBLE_SUBWPN_SWOOSH 0x8C3
 
 // STAGE DRE
-#define NA_SE_SU_SHOOT_PINKBALLS 0x62C
 #define SE_SUC_REVEAL 0x637
 #define NA_SE_SU_LANDING 0x646
 #define SE_DRE_FADE_TO_WHITE 0x65A
@@ -326,7 +324,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 
 // SHARED SOUNDS
 // These are sounds that are shared across multiple BIN files
-#define SE_WEAPON_STAB 0x62E
 #define SE_DOOR_OPEN 0x642
 #define SE_DOOR_CLOSE 0x64F
 #define SE_WEAPON_WHACK 0x678

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -180,7 +180,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define JP_VO_SH_SONO_TEIDO 0x530 // Shaft: Sono teido no chikara de tatakai...
 #endif
 
-#define NA_SE_EV_GLASS_BREAK 0x632
 #define NA_SE_BREAK_CANDLE 0x634
 #define SFX_UNK_635 0x635
 #define NA_SE_PL_WARP 0x636
@@ -315,7 +314,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 
 // STAGE NO3 / NP3
 #define NA_SE_EV_WINDOW_LATCH 0x79D
-#define SE_DEATH_AMBIENCE 0x631
 #define SE_DEATH_TAKES_ITEMS 0x7A0
 #define NA_VO_DEATH_LAUGH 0x7A1
 #define SE_ITEM_YOINK 0x7A2
@@ -359,7 +357,6 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define SFX_DARK_SHIELD 0x63C
 
 // UNUSED SOUNDS
-#define SE_UNK_MAD_630 0x630
 #define SE_UNK_TE1_651 0x651
 #define SE_UNK_TE3_667 0x667
 #define SE_UNK_TE1_66F 0x66F
@@ -427,6 +424,8 @@ enum Sfx {
     SFX_WEAPON_APPEAR, // Item Crash, Neutron Bomb
     SFX_UNK_BETA_630,  // MAD, TE1, TE2, TE3, TE4, TE5
     SFX_DEATH_AMBIENCE,
+    SFX_MAGIC_GLASS_BREAK, // Subweapon Container
+    SFX_UI_SELECT,
 };
 
 #endif

--- a/src/dra/627C4.c
+++ b/src/dra/627C4.c
@@ -592,7 +592,7 @@ s32 HandleSaveMenu(s32 arg0) {
                 return 2;
             }
             if (g_pads[0].tapped & CONFIRM) {
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
                 FreePrimitives(D_80137E58);
                 FreePrimitives(D_80137E5C);
                 FreePrimitives(D_80137E60);
@@ -693,7 +693,7 @@ s32 HandleSaveMenu(s32 arg0) {
                 FreePrimitives(D_80137E60);
                 return 1;
             } else if (g_pads[0].tapped & CONFIRM) {
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
                 FreePrimitives(D_80137E58);
                 FreePrimitives(D_80137E5C);
                 FreePrimitives(D_80137E60);

--- a/src/dra/627C4.c
+++ b/src/dra/627C4.c
@@ -592,7 +592,7 @@ s32 HandleSaveMenu(s32 arg0) {
                 return 2;
             }
             if (g_pads[0].tapped & CONFIRM) {
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
                 FreePrimitives(D_80137E58);
                 FreePrimitives(D_80137E5C);
                 FreePrimitives(D_80137E60);
@@ -693,7 +693,7 @@ s32 HandleSaveMenu(s32 arg0) {
                 FreePrimitives(D_80137E60);
                 return 1;
             } else if (g_pads[0].tapped & CONFIRM) {
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
                 FreePrimitives(D_80137E58);
                 FreePrimitives(D_80137E5C);
                 FreePrimitives(D_80137E60);

--- a/src/dra/63ED4.c
+++ b/src/dra/63ED4.c
@@ -1270,7 +1270,7 @@ void func_80105428(void) {
         if (HandleSaveMenu(2) != 0) {
             if (D_80137E6C == 0) {
                 D_8006C378 = -1;
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
                 MemCardSetPort(D_80097924);
                 D_801379BC++;
             } else {

--- a/src/dra/63ED4.c
+++ b/src/dra/63ED4.c
@@ -1270,7 +1270,7 @@ void func_80105428(void) {
         if (HandleSaveMenu(2) != 0) {
             if (D_80137E6C == 0) {
                 D_8006C378 = -1;
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
                 MemCardSetPort(D_80097924);
                 D_801379BC++;
             } else {

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -847,7 +847,7 @@ void AlucardHandleDamage(DamageParam* damage, s16 arg1, s16 arg2) {
                 g_Player.unk40 = 0x8164;
             }
             if (damage->effects & 0x40) {
-                PlaySfx(SE_WEAPON_STAB);
+                PlaySfx(SFX_WEAPON_STAB_B);
                 g_Player.unk40 = 0x8166;
                 CreateEntFactoryFromEntity(
                     g_CurrentEntity, FACTORY(0x4200, 44), 0);

--- a/src/dra/menu.c
+++ b/src/dra/menu.c
@@ -3121,7 +3121,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
             if (func_800FB1EC(itemId) == false) {
                 g_EquipmentCursor = nav->cursorMain;
                 g_IsSelectingEquipment++;
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
             } else {
                 PlaySfx(SE_UI_ERROR);
             }
@@ -3139,7 +3139,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
                         g_EquipmentCursor, nav->cursorMain, D_801375CC);
                     ret = 2;
                     g_IsSelectingEquipment = 0;
-                    PlaySfx(SE_UI_CONFIRM);
+                    PlaySfx(SFX_UI_SELECT);
                 } else {
                     PlaySfx(SE_UI_ERROR);
                 }
@@ -3147,7 +3147,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
         } else if (var_s6 != 0) {
             PlaySfx(SE_UI_ERROR);
         } else {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             if (count[itemId] > 0) {
                 var_s4 = 1;
                 *selected = itemId;
@@ -3577,7 +3577,7 @@ block_4:
             }
             MenuHide(MENU_DG_MAIN);
             MenuHide(MENU_DG_BG);
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
         }
         break;
     case MENU_STEP_FAMILIAR_INIT:
@@ -3657,7 +3657,7 @@ block_4:
             if (g_MenuStep == MENU_STEP_SYSTEM) {
                 PlaySfx(SE_UI_ERROR);
             } else {
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
             }
         }
         break;
@@ -3667,7 +3667,7 @@ block_4:
             &g_Settings.buttonConfig[g_MenuNavigation.cursorButtons], 8, 5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
             if (CheckIfAllButtonsAreAssigned()) {
-                PlaySfx(SE_UI_CONFIRM);
+                PlaySfx(SFX_UI_SELECT);
                 MenuHide(MENU_DG_CFG_BUTTONS);
                 g_MenuStep = MENU_STEP_SYSTEM;
             } else {
@@ -3687,7 +3687,7 @@ block_4:
         if (!(g_pads[0].tapped & PAD_MENU_BACK_ALT)) {
             break;
         }
-        PlaySfx(SE_UI_CONFIRM);
+        PlaySfx(SFX_UI_SELECT);
         MenuHide(MENU_DG_CLOAK_LINING);
         g_MenuStep = MENU_STEP_SYSTEM;
         break;
@@ -3696,7 +3696,7 @@ block_4:
         MenuHandleCursorInput(
             &g_Settings.cloakColors[g_MenuNavigation.cursorCloak], 32, 5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             func_800FAC0C(MENU_DG_CLOAK_COLOR);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3707,7 +3707,7 @@ block_4:
             &g_Settings.windowColors[g_MenuNavigation.cursorWindowColors], 16,
             5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             MenuHide(MENU_DG_WINDOW_COLORS);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3716,7 +3716,7 @@ block_4:
         MenuHandleCursorInput(&g_Settings.isSoundMono, 2, 0);
         func_800E493C();
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             MenuHide(MENU_DG_CFG_SOUND);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3724,7 +3724,7 @@ block_4:
     case MENU_STEP_SYSTEM_TIME_ATTACK:
         MenuHandleCursorInput(&g_MenuNavigation.cursorTimeAttack, 0x10, 3);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             MenuHide(MENU_DG_TIME_ATTACK);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3771,7 +3771,7 @@ block_4:
 #endif
         if (g_pads[0].tapped & PAD_MENU_SELECT &&
             g_Status.relics[id] & RELIC_FLAG_FOUND) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             g_Status.relics[id] = g_Status.relics[id] ^ 2;
             if (g_RelicDefs[id].unk0C > 0) {
                 for (var_a0 = 0; var_a0 < NUM_RELICS; var_a0++) {
@@ -3918,7 +3918,7 @@ block_4:
             func_800FADC0();
         }
         if (g_pads[0].tapped & PAD_MENU_SORT && D_801375CC == 0) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             MenuShow(MENU_DG_EQUIP_SORT);
             g_MenuStep = MENU_STEP_EQUIP_SORT;
             g_EquipOrderType = 0;
@@ -3933,7 +3933,7 @@ block_4:
             D_80137608 = 0;
             g_MenuStep = MENU_STEP_OPENED;
         } else if (g_pads[0].tapped & PAD_MENU_SELECT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
         block_191:
             func_800FB0FC();
             if (g_MenuNavigation.cursorEquip < HEAD_SLOT) {
@@ -3948,7 +3948,7 @@ block_4:
         MenuHandleCursorInput(&g_EquipOrderType, 11, 0);
         MenuEquipHandlePageScroll(0);
         if (g_pads[0].tapped & PAD_MENU_SELECT_ALT) {
-            PlaySfx(SE_UI_CONFIRM);
+            PlaySfx(SFX_UI_SELECT);
             func_800FBAC4();
             g_MenuData.menus[MENU_DG_EQUIP_SELECTOR].unk16 = 0;
             g_MenuNavigation.cursorEquipType[0] = 0;

--- a/src/dra/menu.c
+++ b/src/dra/menu.c
@@ -3121,7 +3121,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
             if (func_800FB1EC(itemId) == false) {
                 g_EquipmentCursor = nav->cursorMain;
                 g_IsSelectingEquipment++;
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
             } else {
                 PlaySfx(SE_UI_ERROR);
             }
@@ -3139,7 +3139,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
                         g_EquipmentCursor, nav->cursorMain, D_801375CC);
                     ret = 2;
                     g_IsSelectingEquipment = 0;
-                    PlaySfx(SFX_UI_SELECT);
+                    PlaySfx(SFX_UI_CONFIRM);
                 } else {
                     PlaySfx(SE_UI_ERROR);
                 }
@@ -3147,7 +3147,7 @@ s32 func_800FB23C(MenuNavigation* nav, u8* order, u8* count, u32* selected) {
         } else if (var_s6 != 0) {
             PlaySfx(SE_UI_ERROR);
         } else {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             if (count[itemId] > 0) {
                 var_s4 = 1;
                 *selected = itemId;
@@ -3577,7 +3577,7 @@ block_4:
             }
             MenuHide(MENU_DG_MAIN);
             MenuHide(MENU_DG_BG);
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
         }
         break;
     case MENU_STEP_FAMILIAR_INIT:
@@ -3657,7 +3657,7 @@ block_4:
             if (g_MenuStep == MENU_STEP_SYSTEM) {
                 PlaySfx(SE_UI_ERROR);
             } else {
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
             }
         }
         break;
@@ -3667,7 +3667,7 @@ block_4:
             &g_Settings.buttonConfig[g_MenuNavigation.cursorButtons], 8, 5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
             if (CheckIfAllButtonsAreAssigned()) {
-                PlaySfx(SFX_UI_SELECT);
+                PlaySfx(SFX_UI_CONFIRM);
                 MenuHide(MENU_DG_CFG_BUTTONS);
                 g_MenuStep = MENU_STEP_SYSTEM;
             } else {
@@ -3687,7 +3687,7 @@ block_4:
         if (!(g_pads[0].tapped & PAD_MENU_BACK_ALT)) {
             break;
         }
-        PlaySfx(SFX_UI_SELECT);
+        PlaySfx(SFX_UI_CONFIRM);
         MenuHide(MENU_DG_CLOAK_LINING);
         g_MenuStep = MENU_STEP_SYSTEM;
         break;
@@ -3696,7 +3696,7 @@ block_4:
         MenuHandleCursorInput(
             &g_Settings.cloakColors[g_MenuNavigation.cursorCloak], 32, 5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             func_800FAC0C(MENU_DG_CLOAK_COLOR);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3707,7 +3707,7 @@ block_4:
             &g_Settings.windowColors[g_MenuNavigation.cursorWindowColors], 16,
             5);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             MenuHide(MENU_DG_WINDOW_COLORS);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3716,7 +3716,7 @@ block_4:
         MenuHandleCursorInput(&g_Settings.isSoundMono, 2, 0);
         func_800E493C();
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             MenuHide(MENU_DG_CFG_SOUND);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3724,7 +3724,7 @@ block_4:
     case MENU_STEP_SYSTEM_TIME_ATTACK:
         MenuHandleCursorInput(&g_MenuNavigation.cursorTimeAttack, 0x10, 3);
         if (g_pads[0].tapped & PAD_MENU_BACK_ALT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             MenuHide(MENU_DG_TIME_ATTACK);
             g_MenuStep = MENU_STEP_SYSTEM;
         }
@@ -3771,7 +3771,7 @@ block_4:
 #endif
         if (g_pads[0].tapped & PAD_MENU_SELECT &&
             g_Status.relics[id] & RELIC_FLAG_FOUND) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             g_Status.relics[id] = g_Status.relics[id] ^ 2;
             if (g_RelicDefs[id].unk0C > 0) {
                 for (var_a0 = 0; var_a0 < NUM_RELICS; var_a0++) {
@@ -3918,7 +3918,7 @@ block_4:
             func_800FADC0();
         }
         if (g_pads[0].tapped & PAD_MENU_SORT && D_801375CC == 0) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             MenuShow(MENU_DG_EQUIP_SORT);
             g_MenuStep = MENU_STEP_EQUIP_SORT;
             g_EquipOrderType = 0;
@@ -3933,7 +3933,7 @@ block_4:
             D_80137608 = 0;
             g_MenuStep = MENU_STEP_OPENED;
         } else if (g_pads[0].tapped & PAD_MENU_SELECT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
         block_191:
             func_800FB0FC();
             if (g_MenuNavigation.cursorEquip < HEAD_SLOT) {
@@ -3948,7 +3948,7 @@ block_4:
         MenuHandleCursorInput(&g_EquipOrderType, 11, 0);
         MenuEquipHandlePageScroll(0);
         if (g_pads[0].tapped & PAD_MENU_SELECT_ALT) {
-            PlaySfx(SFX_UI_SELECT);
+            PlaySfx(SFX_UI_CONFIRM);
             func_800FBAC4();
             g_MenuData.menus[MENU_DG_EQUIP_SELECTOR].unk16 = 0;
             g_MenuNavigation.cursorEquipType[0] = 0;

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -369,7 +369,7 @@ void EntitySubwpnCrashCross(Entity* self) {
             if (right >= 0x100) {
                 right = 0xFF;
             }
-            g_api.PlaySfx(0x62F);
+            g_api.PlaySfx(SFX_WEAPON_APPEAR);
             self->step += 1;
         }
         break;
@@ -1149,7 +1149,7 @@ void EntitySubwpnCrashAxe(Entity* self) {
         if (--self->ext.factory.unkA2 == 0) {
             if ((u8)self->params == 0) {
                 g_api.PlaySfx(0x635);
-                g_api.PlaySfx(0x62F);
+                g_api.PlaySfx(SFX_WEAPON_APPEAR);
             }
             g_Player.unk4E = 1;
             self->flags &= ~(FLAG_UNK_04000000 | FLAG_UNK_20000);

--- a/src/ric/319C4.c
+++ b/src/ric/319C4.c
@@ -343,7 +343,7 @@ void func_8016E46C(Entity* self) {
         if (++self->ext.et_8016E46C.unk80 >= 0x3C) {
             self->ext.et_8016E46C.unkB0 = 0x11;
             func_8015FAB8(self);
-            g_api.PlaySfx(0x62F);
+            g_api.PlaySfx(SFX_WEAPON_APPEAR);
             g_api.PlaySfx(0x635);
             self->step++;
         }

--- a/src/ric/319C4.c
+++ b/src/ric/319C4.c
@@ -540,7 +540,7 @@ void func_8016E9E4(Entity* self) {
         (self->ext.et_8016E9E4.unk7C == 0x900) ||
         (self->ext.et_8016E9E4.unk7C == 0xD00)) {
         if (self->step < 9) {
-            g_api.func_80134714(0x625, D_801758AC, 0);
+            g_api.func_80134714(SFX_ARROW_SHOT_A, D_801758AC, 0);
             if (self->step >= 5) {
                 D_801758AC -= 4;
             }

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -460,7 +460,7 @@ void HitDetection(void) {
                                 // as Alucard, this won't match
                                 g_api.PlaySfx(SFX_RICHTER_ATTACK_HIT);
                             } else if (iterEnt2->hitEffect & 0x80) {
-                                g_api.PlaySfx(SE_WEAPON_STAB);
+                                g_api.PlaySfx(SFX_WEAPON_STAB_B);
                             } else {
                                 g_api.PlaySfx(SE_WEAPON_WHACK);
                             }

--- a/src/st/dre/13E18.c
+++ b/src/st/dre/13E18.c
@@ -1,4 +1,5 @@
 #include "dre.h"
+#include "sfx.h"
 
 extern s32 D_80180660;
 
@@ -97,7 +98,7 @@ void EntityUnkId1C(Entity* self) {
         if (self->animFrameIdx == 5 && self->animFrameDuration == 0) {
             func_801A046C(0x872);
             func_801A046C(0x87C);
-            func_801A046C(0x62C);
+            func_801A046C(SFX_FIRE_BURST);
             self->ext.generic.unk84.S8.unk1 = 1;
         }
         break;

--- a/src/st/dre/13E18.c
+++ b/src/st/dre/13E18.c
@@ -98,7 +98,7 @@ void EntityUnkId1C(Entity* self) {
         if (self->animFrameIdx == 5 && self->animFrameDuration == 0) {
             func_801A046C(0x872);
             func_801A046C(0x87C);
-            func_801A046C(SFX_FIRE_BURST);
+            func_801A046C(SFX_FIRE_SHOT);
             self->ext.generic.unk84.S8.unk1 = 1;
         }
         break;

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -807,7 +807,7 @@ void EntitySuccubus(Entity* self) {
             if ((self->animFrameIdx == 5) && (self->animFrameDuration == 0)) {
                 func_801A046C(NA_VO_SU_GRUNT_2);
                 func_801A046C(NA_VO_SU_CRYSTAL_1);
-                func_801A046C(SFX_FIRE_BURST);
+                func_801A046C(SFX_FIRE_SHOT);
                 self->ext.succubus.unk85 = true;
             }
             break;
@@ -1139,7 +1139,7 @@ void EntitySuccubusClone(Entity* self) {
         if (self->animFrameIdx == 5 && self->animFrameDuration == 0) {
             func_801A046C(NA_VO_SU_GRUNT_2);
             func_801A046C(NA_VO_SU_CRYSTAL_1);
-            func_801A046C(SFX_FIRE_BURST);
+            func_801A046C(SFX_FIRE_SHOT);
             self->ext.succubus.unk85 = 1;
         }
         break;

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -6,6 +6,7 @@
  */
 
 #include "dre.h"
+#include "sfx.h"
 
 typedef enum {
     /* 0 */ SUCCUBUS_INIT,
@@ -806,7 +807,7 @@ void EntitySuccubus(Entity* self) {
             if ((self->animFrameIdx == 5) && (self->animFrameDuration == 0)) {
                 func_801A046C(NA_VO_SU_GRUNT_2);
                 func_801A046C(NA_VO_SU_CRYSTAL_1);
-                func_801A046C(NA_SE_SU_SHOOT_PINKBALLS);
+                func_801A046C(SFX_FIRE_BURST);
                 self->ext.succubus.unk85 = true;
             }
             break;
@@ -1138,7 +1139,7 @@ void EntitySuccubusClone(Entity* self) {
         if (self->animFrameIdx == 5 && self->animFrameDuration == 0) {
             func_801A046C(NA_VO_SU_GRUNT_2);
             func_801A046C(NA_VO_SU_CRYSTAL_1);
-            func_801A046C(NA_SE_SU_SHOOT_PINKBALLS);
+            func_801A046C(SFX_FIRE_BURST);
             self->ext.succubus.unk85 = 1;
         }
         break;

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -392,7 +392,7 @@ void HitDetection(void) {
                         if (entFrom5C->flags & FLAG_UNK_10) {
                             // Different on PSP vs PSX
                             if (iterEnt2->hitEffect & 0x80) {
-                                g_api.PlaySfx(SE_UNK_MAD_630);
+                                g_api.PlaySfx(SFX_UNK_BETA_630);
                             } else {
                                 g_api.PlaySfx(0x6DB);
                             }

--- a/src/st/no3/3FF00.c
+++ b/src/st/no3/3FF00.c
@@ -1,4 +1,5 @@
 #include "no3.h"
+#include "sfx.h"
 
 void EntityRoomTransition2(Entity* self) {
     Entity* newEntity;
@@ -9,7 +10,7 @@ void EntityRoomTransition2(Entity* self) {
     Tilemap* tilemap = &g_Tilemap;
 
     if (self->ext.roomTransition2.unk80 == 0 && self->step < 4) {
-        g_api.PlaySfx(SE_DEATH_AMBIENCE);
+        g_api.PlaySfx(SFX_DEATH_AMBIENCE);
         self->ext.roomTransition2.unk80 = 0x200;
     }
     self->ext.roomTransition2.unk80--;

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -5,9 +5,6 @@
 #define CASTLE_FLAG_BANK 0x34
 
 // NO3 Sound IDs
-#define SE_SKEL_DEATH 0x62B
-#define SE_DEATH_AMBIENCE 0x631
-// Also used for barrier in "Cube of Zoe" room
 #define SE_CASTLE_GATE_CLOSE 0x63D
 #define SE_WALL_BREAK 0x644
 // Normally used for Richter, but this sound is just

--- a/src/st/np3/4F5B8.c
+++ b/src/st/np3/4F5B8.c
@@ -1,4 +1,5 @@
 #include "np3.h"
+#include "sfx.h"
 
 void EntityHammerWeapon(Entity* self) {
     s16 temp_s0;
@@ -557,7 +558,7 @@ void EntityGurkhaSword(Entity* self) {
         }
 
         if ((g_Timer % 16) == 0) {
-            func_801916C4(0x625);
+            func_801916C4(SFX_ARROW_SHOT_A);
         }
 
         if (abs(self->velocityX) == 0x80000) {

--- a/src/st/np3/blade.c
+++ b/src/st/np3/blade.c
@@ -1,4 +1,5 @@
 #include "np3.h"
+#include "sfx.h"
 
 // The enemy called "Blade", his helper functions, and his swords
 
@@ -477,7 +478,7 @@ void EntityBlade(Entity* self) {
             func_801CE258(&D_80183494);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
                 (self->ext.GH_Props.unkB0[2] == 0)) {
-                func_801916C4(0x625);
+                func_801916C4(SFX_ARROW_SHOT_A);
                 (self + 15)->ext.GH_Props.unk8C = 1;
                 (self + 15)->ext.GH_Props.rotZ = 0x400;
                 (self + 15)->rotZ = 0x400;

--- a/src/st/np3/slogra.c
+++ b/src/st/np3/slogra.c
@@ -4,6 +4,7 @@
  */
 
 #include "np3.h"
+#include "sfx.h"
 
 #define GAIBON self[8]
 
@@ -462,7 +463,7 @@ void EntitySlograSpear(Entity* self) {
             self->velocityY += FIX(0.15625);
             self->rotZ += 0x80;
             if (!(self->rotZ & 0xFFF)) {
-                func_801916C4(0x625);
+                func_801916C4(SFX_ARROW_SHOT_A);
             }
         }
     }

--- a/src/st/nz0/47048.c
+++ b/src/st/nz0/47048.c
@@ -82,7 +82,7 @@ void EntitySubWeaponContainer(Entity* self) {
         i = 0;
         g_api.FreePrimitives(self->primIndex);
         self->flags &= ~FLAG_HAS_PRIMS;
-        g_api.PlaySfx(NA_SE_EV_GLASS_BREAK);
+        g_api.PlaySfx(SFX_MAGIC_GLASS_BREAK);
         while (i < ENTITY_SUBWPNCONT_DEBRIS_COUNT) {
             newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (newEntity != NULL) {

--- a/src/st/nz0/slogra.c
+++ b/src/st/nz0/slogra.c
@@ -1,4 +1,5 @@
 #include "nz0.h"
+#include "sfx.h"
 
 #define GAIBON self[8]
 
@@ -506,7 +507,7 @@ void EntitySlograSpear(Entity* self) {
             self->velocityY += FIX(0.15625);
             self->rotZ += 0x80;
             if (!(self->rotZ & 0xFFF)) {
-                func_801C29B0(0x625);
+                func_801C29B0(SFX_ARROW_SHOT_A);
             }
         }
     }

--- a/src/st/sel/2C048.c
+++ b/src/st/sel/2C048.c
@@ -6,6 +6,7 @@
 
 #include "sel.h"
 #include "memcard.h"
+#include "sfx.h"
 
 Overlay g_StageSel = {
     /* 0x00 */ SEL_Update,
@@ -1228,23 +1229,23 @@ void SEL_Update(void) {
         if (g_pads[0].tapped & PAD_CROSS) {
             switch (D_801D6B0C) {
             case 0:
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x10;
                 break;
             case 1:
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x30;
                 break;
             case 2:
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x90;
                 break;
             case 3:
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x50;
                 break;
             case 4:
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x70;
                 break;
             default:
@@ -1277,7 +1278,7 @@ void SEL_Update(void) {
             UpdateNameEntry();
             func_801AD78C();
             if (g_pads[0].tapped & PAD_START) {
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 func_801AD66C();
                 if (g_PlayableCharacter == 0) {
                     g_StageId = STAGE_ST0;
@@ -1369,7 +1370,7 @@ void SEL_Update(void) {
             func_801AD490();
             D_8003C9A4 = 2;
         } else if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = 0x10;
         }
         break;
@@ -1383,7 +1384,7 @@ void SEL_Update(void) {
             func_801B2608("", 5);
             D_8003C9A4 = 0x33;
         } else if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = 0x10;
         }
         break;
@@ -1419,7 +1420,7 @@ void SEL_Update(void) {
             D_801BAF0C = 0;
         }
         if ((g_pads[0].tapped & PAD_START) && D_801BAF14 != 0) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801B2608("You won’t be able to save", 4);
             func_801B2608("your game． Is that OK？", 5);
             func_801ADF94(0x81, 0);
@@ -1430,10 +1431,10 @@ void SEL_Update(void) {
             slot = D_801D6B04 % 15;
             icon = g_SaveSummary[port].icon[slot];
             if (icon >= 0) {
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x100;
             } else if (icon == -3) {
-                g_api.PlaySfx(0x633);
+                g_api.PlaySfx(SFX_UI_SELECT);
                 D_8003C9A4 = 0x10;
             } else {
                 g_api.PlaySfx(0x686);
@@ -1490,7 +1491,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1508,7 +1509,7 @@ void SEL_Update(void) {
                 port = D_801D6B04 / 15;
                 slot = D_801D6B04 % 15;
                 if (g_SaveSummary[port].icon[slot] >= 0) {
-                    g_api.PlaySfx(0x633);
+                    g_api.PlaySfx(SFX_UI_SELECT);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1549,7 +1550,7 @@ void SEL_Update(void) {
                     func_801ACBE4(GFX_UNK_15, 0);
                     func_801B2608("Changing Name．", 4);
                     func_801B2608("Do not remove Memory Card．", 5);
-                    g_api.PlaySfx(0x633);
+                    g_api.PlaySfx(SFX_UI_SELECT);
                     D_8003C9A4++;
                 }
             }
@@ -1591,7 +1592,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x90;
         }
@@ -1600,7 +1601,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = 146;
         }
         break;
@@ -1652,7 +1653,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1673,7 +1674,7 @@ void SEL_Update(void) {
                     func_801B2608("Where do you want", 4);
                     func_801B2608("to copy to？", 5);
                     D_801BC3EC = D_801D6B04;
-                    g_api.PlaySfx(0x633);
+                    g_api.PlaySfx(SFX_UI_SELECT);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1701,12 +1702,12 @@ void SEL_Update(void) {
                     if (icon >= 0) {
                         func_801B1F4C(5);
                         func_801B2608("OK to overwrite data？", 4);
-                        g_api.PlaySfx(0x633);
+                        g_api.PlaySfx(SFX_UI_SELECT);
                         D_8003C9A4 = 0x59;
                     } else if (icon != -2) {
                         func_801B2608("Copying data．", 4);
                         func_801B2608("Do not remove Memory Card．", 5);
-                        g_api.PlaySfx(0x633);
+                        g_api.PlaySfx(SFX_UI_SELECT);
                         D_8003C9A4++;
                     }
                 } else {
@@ -1754,7 +1755,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x50;
         }
@@ -1764,7 +1765,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_18, 8);
             func_801ACBE4(GFX_UNK_19, 8);
             func_801ACBE4(GFX_UNK_20, 8);
@@ -1776,7 +1777,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801B2608("Copying data．", 4);
             func_801B2608("Do not remove Memory Card．", 5);
             D_8003C9A4 = 0x55;
@@ -1838,7 +1839,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1859,7 +1860,7 @@ void SEL_Update(void) {
                 if (g_SaveSummary[port].icon[slot] >= 0) {
                     func_801B1F4C(5);
                     func_801B2608("Is it OK to erase file？", 4);
-                    g_api.PlaySfx(0x633);
+                    g_api.PlaySfx(SFX_UI_SELECT);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1876,7 +1877,7 @@ void SEL_Update(void) {
             D_8003C9A4--;
         } else if (g_pads[0].tapped & PAD_CROSS) {
             func_801ACBE4(GFX_UNK_15, 8);
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4++;
         }
         break;
@@ -1910,7 +1911,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x70;
         }
@@ -1919,7 +1920,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = 0x72;
         }
         break;
@@ -1986,7 +1987,7 @@ void SEL_Update(void) {
     case 513:
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_TRIANGLE) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_6, 8);
             MemCardSetPort(0);
             D_8003C9A4++;
@@ -2021,7 +2022,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = D_801BAFC8;
         }
@@ -2030,7 +2031,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = D_801BAFC8;
         }
         break;
@@ -2048,7 +2049,7 @@ void SEL_Update(void) {
     case 529:
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_TRIANGLE) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_6, 8);
             MemCardSetPort(1);
             D_8003C9A4++;
@@ -2083,7 +2084,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = D_801BAFC8;
         }
@@ -2092,7 +2093,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(0x633);
+            g_api.PlaySfx(SFX_UI_SELECT);
             D_8003C9A4 = D_801BAFC8;
         }
         break;

--- a/src/st/sel/2C048.c
+++ b/src/st/sel/2C048.c
@@ -1229,23 +1229,23 @@ void SEL_Update(void) {
         if (g_pads[0].tapped & PAD_CROSS) {
             switch (D_801D6B0C) {
             case 0:
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x10;
                 break;
             case 1:
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x30;
                 break;
             case 2:
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x90;
                 break;
             case 3:
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x50;
                 break;
             case 4:
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x70;
                 break;
             default:
@@ -1278,7 +1278,7 @@ void SEL_Update(void) {
             UpdateNameEntry();
             func_801AD78C();
             if (g_pads[0].tapped & PAD_START) {
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 func_801AD66C();
                 if (g_PlayableCharacter == 0) {
                     g_StageId = STAGE_ST0;
@@ -1370,7 +1370,7 @@ void SEL_Update(void) {
             func_801AD490();
             D_8003C9A4 = 2;
         } else if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = 0x10;
         }
         break;
@@ -1384,7 +1384,7 @@ void SEL_Update(void) {
             func_801B2608("", 5);
             D_8003C9A4 = 0x33;
         } else if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = 0x10;
         }
         break;
@@ -1420,7 +1420,7 @@ void SEL_Update(void) {
             D_801BAF0C = 0;
         }
         if ((g_pads[0].tapped & PAD_START) && D_801BAF14 != 0) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801B2608("You won’t be able to save", 4);
             func_801B2608("your game． Is that OK？", 5);
             func_801ADF94(0x81, 0);
@@ -1431,10 +1431,10 @@ void SEL_Update(void) {
             slot = D_801D6B04 % 15;
             icon = g_SaveSummary[port].icon[slot];
             if (icon >= 0) {
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x100;
             } else if (icon == -3) {
-                g_api.PlaySfx(SFX_UI_SELECT);
+                g_api.PlaySfx(SFX_UI_CONFIRM);
                 D_8003C9A4 = 0x10;
             } else {
                 g_api.PlaySfx(0x686);
@@ -1491,7 +1491,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1509,7 +1509,7 @@ void SEL_Update(void) {
                 port = D_801D6B04 / 15;
                 slot = D_801D6B04 % 15;
                 if (g_SaveSummary[port].icon[slot] >= 0) {
-                    g_api.PlaySfx(SFX_UI_SELECT);
+                    g_api.PlaySfx(SFX_UI_CONFIRM);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1550,7 +1550,7 @@ void SEL_Update(void) {
                     func_801ACBE4(GFX_UNK_15, 0);
                     func_801B2608("Changing Name．", 4);
                     func_801B2608("Do not remove Memory Card．", 5);
-                    g_api.PlaySfx(SFX_UI_SELECT);
+                    g_api.PlaySfx(SFX_UI_CONFIRM);
                     D_8003C9A4++;
                 }
             }
@@ -1592,7 +1592,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x90;
         }
@@ -1601,7 +1601,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = 146;
         }
         break;
@@ -1653,7 +1653,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1674,7 +1674,7 @@ void SEL_Update(void) {
                     func_801B2608("Where do you want", 4);
                     func_801B2608("to copy to？", 5);
                     D_801BC3EC = D_801D6B04;
-                    g_api.PlaySfx(SFX_UI_SELECT);
+                    g_api.PlaySfx(SFX_UI_CONFIRM);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1702,12 +1702,12 @@ void SEL_Update(void) {
                     if (icon >= 0) {
                         func_801B1F4C(5);
                         func_801B2608("OK to overwrite data？", 4);
-                        g_api.PlaySfx(SFX_UI_SELECT);
+                        g_api.PlaySfx(SFX_UI_CONFIRM);
                         D_8003C9A4 = 0x59;
                     } else if (icon != -2) {
                         func_801B2608("Copying data．", 4);
                         func_801B2608("Do not remove Memory Card．", 5);
-                        g_api.PlaySfx(SFX_UI_SELECT);
+                        g_api.PlaySfx(SFX_UI_CONFIRM);
                         D_8003C9A4++;
                     }
                 } else {
@@ -1755,7 +1755,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x50;
         }
@@ -1765,7 +1765,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_18, 8);
             func_801ACBE4(GFX_UNK_19, 8);
             func_801ACBE4(GFX_UNK_20, 8);
@@ -1777,7 +1777,7 @@ void SEL_Update(void) {
         func_801ADF94(0x82, 1);
         func_801AE6D0();
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801B2608("Copying data．", 4);
             func_801B2608("Do not remove Memory Card．", 5);
             D_8003C9A4 = 0x55;
@@ -1839,7 +1839,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801AE9A8();
             func_801AD490();
             D_8003C9A4 = 2;
@@ -1860,7 +1860,7 @@ void SEL_Update(void) {
                 if (g_SaveSummary[port].icon[slot] >= 0) {
                     func_801B1F4C(5);
                     func_801B2608("Is it OK to erase file？", 4);
-                    g_api.PlaySfx(SFX_UI_SELECT);
+                    g_api.PlaySfx(SFX_UI_CONFIRM);
                     D_8003C9A4++;
                 } else {
                     g_api.PlaySfx(0x686);
@@ -1877,7 +1877,7 @@ void SEL_Update(void) {
             D_8003C9A4--;
         } else if (g_pads[0].tapped & PAD_CROSS) {
             func_801ACBE4(GFX_UNK_15, 8);
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4++;
         }
         break;
@@ -1911,7 +1911,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = 0x70;
         }
@@ -1920,7 +1920,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x82, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = 0x72;
         }
         break;
@@ -1987,7 +1987,7 @@ void SEL_Update(void) {
     case 513:
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_TRIANGLE) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_6, 8);
             MemCardSetPort(0);
             D_8003C9A4++;
@@ -2022,7 +2022,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = D_801BAFC8;
         }
@@ -2031,7 +2031,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = D_801BAFC8;
         }
         break;
@@ -2049,7 +2049,7 @@ void SEL_Update(void) {
     case 529:
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_TRIANGLE) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_6, 8);
             MemCardSetPort(1);
             D_8003C9A4++;
@@ -2084,7 +2084,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             func_801ACBE4(GFX_UNK_15, 8);
             D_8003C9A4 = D_801BAFC8;
         }
@@ -2093,7 +2093,7 @@ void SEL_Update(void) {
         DrawNavigationTips(Tips_Confirm);
         func_801ADF94(0x80, 0);
         if (g_pads[0].tapped & PAD_CROSS) {
-            g_api.PlaySfx(SFX_UI_SELECT);
+            g_api.PlaySfx(SFX_UI_CONFIRM);
             D_8003C9A4 = D_801BAFC8;
         }
         break;

--- a/src/weapon/w_001.c
+++ b/src/weapon/w_001.c
@@ -35,7 +35,7 @@ void func_ptr_80170008(Entity* self) {
         self->enemyId = self->ext.factory.parent->enemyId;
         self->hitboxWidth = 10;
         self->hitboxHeight = 8;
-        g_api.PlaySfx(SFX_FIRE_BURST);
+        g_api.PlaySfx(SFX_FIRE_SHOT);
         self->step++;
         break;
 

--- a/src/weapon/w_001.c
+++ b/src/weapon/w_001.c
@@ -3,6 +3,7 @@
 // Unknown#187, Unknown#188
 #include "weapon_private.h"
 #include "shared.h"
+#include "sfx.h"
 
 INCLUDE_ASM("weapon/nonmatchings/w_001", EntityWeaponAttack);
 
@@ -34,7 +35,7 @@ void func_ptr_80170008(Entity* self) {
         self->enemyId = self->ext.factory.parent->enemyId;
         self->hitboxWidth = 10;
         self->hitboxHeight = 8;
-        g_api.PlaySfx(0x62C);
+        g_api.PlaySfx(SFX_FIRE_BURST);
         self->step++;
         break;
 

--- a/src/weapon/w_028.c
+++ b/src/weapon/w_028.c
@@ -2,6 +2,7 @@
 // Skull shield, Unknown#212
 #include "weapon_private.h"
 #include "shared.h"
+#include "sfx.h"
 
 extern SpriteParts D_C8000_8017A040[];
 extern s8 D_C8000_8017AA98[];
@@ -342,7 +343,7 @@ void EntityWeaponShieldSpell(Entity* self) {
                 prim = prim->next;
             }
             self->ext.shield.unk80 = 0;
-            g_api.PlaySfx(0x62F);
+            g_api.PlaySfx(SFX_WEAPON_APPEAR);
             self->step++;
         }
         break;

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -245,7 +245,7 @@ void func_ptr_80170008(Entity* self) {
         self->unk4C = D_12A000_8017A6AC;
         self->ext.weapon.equipId = self->ext.weapon.parent->ext.weapon.equipId;
         SetWeaponProperties(self, 0);
-        g_api.PlaySfx(0x628);
+        g_api.PlaySfx(SFX_ARROW_SHOT_D);
         self->step++;
         break;
     case 1:

--- a/src/weapon/w_051.c
+++ b/src/weapon/w_051.c
@@ -157,10 +157,10 @@ static u16* D_169000_8017ACBC[] = {
 };
 
 static WeaponAnimation D_169000_8017ACD8[] = {
-    {D_169000_8017AC68, hitboxes, 0, SFX_FIRE_BURST, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 2, SFX_FIRE_BURST, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 4, SFX_FIRE_BURST, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 6, SFX_FIRE_BURST, 0x68, 4},
+    {D_169000_8017AC68, hitboxes, 0, SFX_FIRE_SHOT, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 2, SFX_FIRE_SHOT, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 4, SFX_FIRE_SHOT, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 6, SFX_FIRE_SHOT, 0x68, 4},
 };
 
 static WeaponAnimation D_169000_8017AD18[] = {

--- a/src/weapon/w_051.c
+++ b/src/weapon/w_051.c
@@ -157,10 +157,10 @@ static u16* D_169000_8017ACBC[] = {
 };
 
 static WeaponAnimation D_169000_8017ACD8[] = {
-    {D_169000_8017AC68, hitboxes, 0, SFX_WEAPON_62C, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 2, SFX_WEAPON_62C, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 4, SFX_WEAPON_62C, 0x68, 4},
-    {D_169000_8017AC84, hitboxes, 6, SFX_WEAPON_62C, 0x68, 4},
+    {D_169000_8017AC68, hitboxes, 0, SFX_FIRE_BURST, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 2, SFX_FIRE_BURST, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 4, SFX_FIRE_BURST, 0x68, 4},
+    {D_169000_8017AC84, hitboxes, 6, SFX_FIRE_BURST, 0x68, 4},
 };
 
 static WeaponAnimation D_169000_8017AD18[] = {


### PR DESCRIPTION
Stopping at 0x633 (`SFX_UI_SELECT`) for now, but will continue to add and update more sfx references soon.  

So far we have 51 out of a potential 736 sfx IDs (`0x8E0` - `0x600`).  

For what it's worth, the last valid sound ID I have listed in my spreadsheet is `0x8D2` found in `DRA`, `RIC`, `BO4`, `BO6`, and `RBO5` so the actual number might be 722 enum IDs, but we'll see what happens since the last sfx group in the list belongs to vabid 3.