### PR TITLE
Refactor File helper functions

### DIFF
--- a/.github/workflows/picci.yaml
+++ b/.github/workflows/picci.yaml
@@ -40,7 +40,10 @@ jobs:
       - name: Extract dependencies
         run: make extract_disk
       - name: Extract game assets
-        run: make -j extract_assets
+        run: |
+          make update-dependencies
+          make -j extract
+          make -j extract_assets
       - name: Export assets
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCE_FILES_PC
     src/pc/stubs.c
     src/pc/sotn.c
     src/pc/pc.c
+    src/pc/io.c
     src/pc/str.c
     src/pc/sim_pc.c
     src/pc/pl_arc.c

--- a/src/pc/io.c
+++ b/src/pc/io.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include "pc.h"
+
+struct FileAsStringCbParams {
+    bool (*callback)(const struct FileAsString*);
+    void* param;
+};
+static bool _FileAsStringCb(const struct FileOpenRead* f) {
+    void* content = malloc(f->length + 1);
+    if (!content) {
+        ERRORF("unable to allocate %d bytes for '%s'", f->length, f->filename);
+        fclose(f);
+        return false;
+    }
+
+    size_t bytesread = fread(content, 1, f->length, f->file);
+    if (bytesread != f->length) {
+        ERRORF("unable to read %d bytes for '%s'", f->length, f->filename);
+        fclose(f);
+        free(content);
+        return false;
+    }
+    ((char*)content)[f->length] = '\0';
+
+    struct FileAsStringCbParams* p = (struct FileAsStringCbParams*)f->param;
+    struct FileAsString fc = {
+        .path = f->filename,
+        .content = (const char*)content,
+        .length = f->length + 1,
+        .param = p->param,
+    };
+    bool r = p->callback(&fc);
+    free(content);
+    return true;
+}
+
+struct FileUseContentCbParams {
+    bool (*callback)(const struct FileUseContent*);
+    void* param;
+};
+static bool _FileUseContentCb(const struct FileOpenRead* f) {
+    void* content = malloc(f->length);
+    if (!content) {
+        ERRORF("unable to allocate %d bytes for '%s'", f->length, f->filename);
+        return false;
+    }
+
+    size_t bytesread = fread(content, 1, f->length, f->file);
+    if (bytesread != f->length) {
+        ERRORF("unable to read %d bytes for '%s'", f->length, f->filename);
+        free(content);
+        return false;
+    }
+
+    struct FileAsStringCbParams* p = (struct FileAsStringCbParams*)f->param;
+    struct FileUseContent fc = {
+        .path = f->filename,
+        .content = content,
+        .length = f->length,
+        .param = p->param,
+    };
+    bool r = p->callback(&fc);
+    free(content);
+    return r;
+};
+
+// Simply open a binary file and pass the handler to a reader callback by
+// performing error handling and ensuring the file always gets closed.
+// The callback will receive file name and file size, it will need to return
+// true if successful.
+bool FileOpenRead(
+    bool (*cb)(const struct FileOpenRead*), const char* filename, void* param) {
+    INFOF("open '%s'", filename);
+    FILE* f = fopen(filename, "rb");
+    if (f == NULL) {
+        ERRORF("unable to open '%s'", filename);
+        return false;
+    }
+    fseek(f, 0, SEEK_END);
+    size_t len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    struct FileOpenRead s = {
+        .filename = filename,
+        .file = f,
+        .length = len,
+        .param = param,
+    };
+    bool r = cb(&s);
+    fclose(f);
+    return r;
+}
+
+// Read the content of a binary file into the specified buffer by maxlen bytes.
+// The number of read bytes is returned; a negative value represents a failure.
+int FileReadToBuf(const char* filename, void* dst, int offset, size_t maxlen) {
+    INFOF("open '%s'", filename);
+    FILE* f = fopen(filename, "rb");
+    if (f == NULL) {
+        ERRORF("unable to open '%s'", filename);
+        return -1;
+    }
+    fseek(f, offset, SEEK_SET);
+    size_t bytesRead = fread(dst, 1, maxlen, f);
+    fclose(f);
+    return (int)(bytesRead);
+}
+
+// Read the content of a file as a null-terminated string and pass it to
+// the specified callback. The function will take care of both validation
+// and allocation of the unmanaged resources.
+// The callback needs to return true if the operation is successful.
+bool FileAsString(bool (*cb)(const struct FileAsString* file),
+                  const char* filename, void* param) {
+    struct FileAsStringCbParams p = {cb, param};
+    return FileOpenRead(_FileAsStringCb, filename, &p);
+}
+
+// Read the specified file into a buffer and pass it to the specified callback.
+// The function will take care of both validation and deallocation.
+// The callback needs to return true if the operation is successful.
+bool FileUseContent(bool (*cb)(const struct FileUseContent* file, void* param),
+                    const char* filename, void* param) {
+    struct FileUseContentCbParams p = {cb, param};
+    return FileOpenRead(_FileUseContentCb, filename, &p);
+}

--- a/src/pc/io.c
+++ b/src/pc/io.c
@@ -24,7 +24,7 @@ static bool _FileAsStringCb(const struct FileOpenRead* f) {
 
     struct FileAsStringCbParams* p = (struct FileAsStringCbParams*)f->param;
     struct FileAsString fc = {
-        .path = f->filename,
+        .filename = f->filename,
         .content = (const char*)content,
         .length = f->length + 1,
         .param = p->param,
@@ -54,7 +54,7 @@ static bool _FileUseContentCb(const struct FileOpenRead* f) {
 
     struct FileAsStringCbParams* p = (struct FileAsStringCbParams*)f->param;
     struct FileUseContent fc = {
-        .path = f->filename,
+        .filename = f->filename,
         .content = content,
         .length = f->length,
         .param = p->param,

--- a/src/pc/pc.h
+++ b/src/pc/pc.h
@@ -18,13 +18,6 @@
 #define VRAM_H 512
 #define VRAM_STRIDE 2048
 
-typedef struct FileUseContent {
-    const char* path;
-    const void* content;
-    size_t length;
-    void* param;
-} FileLoad;
-
 struct FileOpenRead {
     const char* filename;
     FILE* file;
@@ -33,19 +26,26 @@ struct FileOpenRead {
 };
 
 struct FileAsString {
-    const char* path;
+    const char* filename;
     const char* content;
     size_t length;
     void* param;
 };
 
+typedef struct FileUseContent {
+    const char* filename;
+    const void* content;
+    size_t length;
+    void* param;
+} FileLoad;
+
 bool FileOpenRead(
     bool (*cb)(const struct FileOpenRead*), const char* filename, void* param);
 int FileReadToBuf(const char* filename, void* dst, int offset, size_t maxlen);
-bool FileAsString(
-    bool (*cb)(const struct FileAsString* file), const char* path, void* param);
+bool FileAsString(bool (*cb)(const struct FileAsString* file),
+                  const char* filename, void* param);
 bool FileUseContent(bool (*cb)(const struct FileUseContent* file, void* param),
-                    const char* path, void* param);
+                    const char* filename, void* param);
 
 const char* AnsiToSotnMenuString(const char* str);
 

--- a/src/pc/pc.h
+++ b/src/pc/pc.h
@@ -18,24 +18,34 @@
 #define VRAM_H 512
 #define VRAM_STRIDE 2048
 
-typedef struct {
+typedef struct FileUseContent {
     const char* path;
     const void* content;
     size_t length;
+    void* param;
 } FileLoad;
 
-typedef struct {
+struct FileOpenRead {
+    const char* filename;
+    FILE* file;
+    size_t length;
+    void* param;
+};
+
+struct FileAsString {
     const char* path;
     const char* content;
     size_t length;
     void* param;
-} FileStringified;
+};
 
-bool FileRead(bool (*cb)(FILE* file), const char* path);
-bool FileStringify(
-    bool (*cb)(FileStringified* file), const char* path, void* param);
-bool FileUseContent(
-    bool (*cb)(FileLoad* file, void* param), const char* path, void* param);
+bool FileOpenRead(
+    bool (*cb)(const struct FileOpenRead*), const char* filename, void* param);
+int FileReadToBuf(const char* filename, void* dst, int offset, size_t maxlen);
+bool FileAsString(
+    bool (*cb)(const struct FileAsString* file), const char* path, void* param);
+bool FileUseContent(bool (*cb)(const struct FileUseContent* file, void* param),
+                    const char* path, void* param);
 
 const char* AnsiToSotnMenuString(const char* str);
 

--- a/src/pc/pl_arc.c
+++ b/src/pc/pl_arc.c
@@ -5,7 +5,7 @@
 u8* g_PlOvlSpritesheet[256];
 static u8* sprite_data = NULL;
 
-void InitPlayerArc(FileLoad* file) {
+void InitPlayerArc(const struct FileUseContent* file) {
     int i;
 
     g_PlayableCharacter = PLAYER_ALUCARD;

--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -173,7 +173,7 @@ void LoadStageTileset(u8* pTilesetData, size_t len, s32 y) {
 void InitStageDummy(Overlay* o);
 void InitStageWrp(Overlay* o);
 void InitStageSel(Overlay* o);
-void InitPlayerArc(FileLoad* file);
+void InitPlayerArc(const struct FileUseContent* file);
 void InitPlayerRic(void);
 void func_80131EBC(const char* str, s16 arg1);
 s32 LoadFileSimToMem(SimKind kind) {
@@ -275,7 +275,8 @@ s32 LoadFileSimToMem(SimKind kind) {
     return 0;
 }
 
-bool LoadFilePc(FileLoad* file, SimFile* sim) {
+bool LoadFilePc(const struct FileUseContent* file) {
+    SimFile* sim = (SimFile*)file->param;
     sim->addr = file->content;
     switch (sim->kind) { // slowly replacing the original func
     case SIM_1:

--- a/src/pc/stages/stage_loader.c
+++ b/src/pc/stages/stage_loader.c
@@ -14,7 +14,7 @@ typedef struct {
     const char* assetPath;
 } RoomLoadDesc;
 static TileDefinition* g_TileDefToLoad = NULL;
-static bool LoadRoomTileDef(FileStringified* file) {
+static bool LoadRoomTileDef(struct FileAsString* file) {
     INFOF("load");
     RoomLoadDesc* desc = (RoomLoadDesc*)file->param;
     cJSON* jitem = cJSON_Parse(file->content);
@@ -27,42 +27,29 @@ static bool LoadRoomTileDef(FileStringified* file) {
     char buf[0x100];
     snprintf(buf, sizeof(buf), "%s/%s", desc->assetPath,
              JITEM("gfxPage")->valuestring);
-    f = fopen(buf, "rb");
-    if (f) {
-        fread(g_TileDefToLoad->gfxPage, 0x1000, 1, f);
-        fclose(f);
-    } else {
-        ERRORF("unable to load '%s'", buf);
+    if (FileReadToBuf(buf, g_TileDefToLoad->gfxPage, 0, 0x1000) < 0) {
+        cJSON_Delete(jitem);
         return false;
     }
+
     snprintf(buf, sizeof(buf), "%s/%s", desc->assetPath,
              JITEM("gfxIndex")->valuestring);
-    f = fopen(buf, "rb");
-    if (f) {
-        fread(g_TileDefToLoad->gfxIndex, 0x1000, 1, f);
-        fclose(f);
-    } else {
-        ERRORF("unable to load '%s'", buf);
+    if (FileReadToBuf(buf, g_TileDefToLoad->gfxIndex, 0, 0x1000) < 0) {
+        cJSON_Delete(jitem);
         return false;
     }
+
     snprintf(
         buf, sizeof(buf), "%s/%s", desc->assetPath, JITEM("clut")->valuestring);
-    f = fopen(buf, "rb");
-    if (f) {
-        fread(g_TileDefToLoad->clut, 0x1000, 1, f);
-        fclose(f);
-    } else {
-        ERRORF("unable to load '%s'", buf);
+    if (FileReadToBuf(buf, g_TileDefToLoad->clut, 0, 0x1000) < 0) {
+        cJSON_Delete(jitem);
         return false;
     }
+
     snprintf(buf, sizeof(buf), "%s/%s", desc->assetPath,
              JITEM("collision")->valuestring);
-    f = fopen(buf, "rb");
-    if (f) {
-        fread(g_TileDefToLoad->collision, 0x1000, 1, f);
-        fclose(f);
-    } else {
-        ERRORF("unable to load '%s'", buf);
+    if (FileReadToBuf(buf, g_TileDefToLoad->collision, 0, 0x1000) < 0) {
+        cJSON_Delete(jitem);
         return false;
     }
 
@@ -122,13 +109,13 @@ static bool LoadRoomLayerDef(LayerDef* l, cJSON* jitem, RoomLoadDesc* desc) {
 
     g_TileDefToLoad = l->tileDef;
 
-    return FileStringify(LoadRoomTileDef, buf, desc);
+    return FileAsString(LoadRoomTileDef, buf, desc);
 }
 
 static int g_LayerDefIndex = 0;
 static LayerDef g_LayerDefPool[0x40];
 static RoomDef g_TileLayers[0x100];
-static bool LoadTileLayers(FileStringified* file) {
+static bool LoadTileLayers(struct FileAsString* file) {
     int i;
     RoomLoadDesc* desc = (RoomLoadDesc*)file->param;
     cJSON* json = cJSON_Parse(file->content);
@@ -200,7 +187,7 @@ RoomDef* LoadRoomsLayers(const char* filePath) {
 
     RoomLoadDesc desc;
     desc.assetPath = assetPath;
-    if (!FileStringify(LoadTileLayers, filePath, &desc)) {
+    if (!FileAsString(LoadTileLayers, filePath, &desc)) {
         ERRORF("failed to load '%s'", filePath);
         return NULL;
     }
@@ -210,7 +197,7 @@ RoomDef* LoadRoomsLayers(const char* filePath) {
 
 static int g_LayoutEntityIndex = 0;
 static LayoutEntity g_LayoutEntityPool[0x200];
-static bool _LoadObjLayout(const FileStringified* file) {
+static bool _LoadObjLayout(const struct FileAsString* file) {
     int i;
     cJSON* json = cJSON_Parse(file->content);
     if (!json) {
@@ -241,7 +228,7 @@ static bool _LoadObjLayout(const FileStringified* file) {
 }
 LayoutEntity* LoadObjLayout(const char* filePath) {
     int start = g_LayoutEntityIndex;
-    if (!FileStringify(_LoadObjLayout, filePath, NULL)) {
+    if (!FileAsString(_LoadObjLayout, filePath, NULL)) {
         // if the load fails, resets the pool as it was before
         g_LayoutEntityIndex = start;
         return NULL;
@@ -251,7 +238,7 @@ LayoutEntity* LoadObjLayout(const char* filePath) {
 }
 
 RoomHeader room_headers[0x100];
-static bool _LoadRoomDefArray(const FileStringified* file) {
+static bool _LoadRoomDefArray(const struct FileAsString* file) {
     int i;
     cJSON* json = cJSON_Parse(file->content);
     if (!json) {
@@ -282,7 +269,7 @@ static bool _LoadRoomDefArray(const FileStringified* file) {
     return true;
 }
 RoomHeader* LoadRoomDefs(const char* filePath) {
-    if (!FileStringify(_LoadRoomDefArray, filePath, NULL)) {
+    if (!FileAsString(_LoadRoomDefArray, filePath, NULL)) {
         return NULL;
     }
     return room_headers;
@@ -292,7 +279,7 @@ static int g_SpritePartPtrIndex = 0;
 static SpriteParts* g_SpritePartPtrPool[0x100];
 static int g_SpritePartIndex = 0;
 static u16 g_SpritePartPool[0x200 * sizeof(SpritePart)];
-static bool _LoadSpriteParts(FileStringified* file) {
+static bool _LoadSpriteParts(struct FileAsString* file) {
     int i, j;
     cJSON* json = cJSON_Parse(file->content);
     if (!json) {
@@ -345,7 +332,7 @@ static bool _LoadSpriteParts(FileStringified* file) {
 SpritePart* LoadSpriteParts(const char* filePath) {
     int start = g_SpritePartPtrIndex;
     int spriteStart = g_SpritePartIndex;
-    if (!FileStringify(_LoadSpriteParts, filePath, NULL)) {
+    if (!FileAsString(_LoadSpriteParts, filePath, NULL)) {
         // if the load fails, resets the pool as it was before
         g_SpritePartPtrIndex = start;
         g_SpritePartIndex = spriteStart;

--- a/src/pc/stages/stage_wrp.c
+++ b/src/pc/stages/stage_wrp.c
@@ -52,34 +52,12 @@ static Overlay g_StageDesc = {
 void InitStageWrp(Overlay* o) {
     LoadReset();
 
-    FILE* f = fopen("assets/st/wrp/D_80181D08.dec", "rb");
-    if (f) {
-        fseek(f, 0, SEEK_END);
-        size_t len = ftell(f);
-        fseek(f, 0, SEEK_SET);
-        fread(D_80181D08, MIN(len, sizeof(D_80181D08)), 1, f);
-        fclose(f);
-    }
-
-    f = fopen("assets/st/wrp/D_80181420.dec", "rb");
-    if (f) {
-        fseek(f, 0, SEEK_END);
-        size_t len = ftell(f);
-        fseek(f, 0, SEEK_SET);
-        fread(D_80181420, MIN(len, sizeof(D_80181420)), 1, f);
-        fclose(f);
-    }
-
-    f = fopen("assets/st/wrp/D_80181764.dec", "rb");
-    if (f) {
-        fseek(f, 0, SEEK_END);
-        size_t len = ftell(f);
-        fseek(f, 0, SEEK_SET);
-        fread(D_80181764, MIN(len, sizeof(D_80181764)), 1, f);
-        fclose(f);
-    }
-
-    //
+    FileReadToBuf(
+        "assets/st/wrp/D_80181D08.dec", D_80181D08, 0, sizeof(D_80181D08));
+    FileReadToBuf(
+        "assets/st/wrp/D_80181420.dec", D_80181420, 0, sizeof(D_80181420));
+    FileReadToBuf(
+        "assets/st/wrp/D_80181764.dec", D_80181764, 0, sizeof(D_80181764));
 
     memcpy(o, &g_StageDesc, sizeof(Overlay));
 }

--- a/src/pc/weapon_pc.c
+++ b/src/pc/weapon_pc.c
@@ -1,5 +1,4 @@
 #include "weapon.h"
-#include <cJSON/cJSON.h>
 #include "pc.h"
 
 // main variable
@@ -868,7 +867,11 @@ void HandleWeapon0Prg(int fileId) {
 }
 
 void HandleWeapon0Chr(int fileId) {
-    readSubsetToBuf(
-        "disks/us/BIN/WEAPON0.BIN", &g_Pix[0], fileId * 0x07000, 0x4000);
-    LoadTPage(&g_Pix[0], 0, 0, 0x240, 0x100, 0x100, 0x80);
+    const int Width = 256;
+    const int Height = 128;
+    const int PixLen = Width * Height / 2;
+    const int EntryLen = 0x3000 + PixLen;
+    FileReadToBuf(
+        "disks/us/BIN/WEAPON0.BIN", &g_Pix[0], fileId * EntryLen, PixLen);
+    LoadTPage(&g_Pix[0], 0, 0, 0x240, 0x100, Width, Height);
 }


### PR DESCRIPTION
Use the following input endpoints `FileOpenRead`, `FileReadToBuf`, `FileAsString` and `FileUseContent`. 

There was a lot of redundant and inconsistent code scattered across all the functions responsible of opening and processing files. I also realised the purpose of some File helpers was not entirely clear, so I spent some effort to document them.

This is a small part of a bigger effort on refactoring `sim_pc.c`. I am also planning on adding support for paths such as `disk://` to load from `disks/us/`, `asset://` to load from `asset/`, `card://` to start adding support for simulated memcards and so on. This is setting the very basics to plan that out.