### PR TITLE
Added MAD and e_red_door SFX

### DIFF
--- a/include/sfx.h
+++ b/include/sfx.h
@@ -180,16 +180,9 @@ typedef enum { MONO_SOUND, STEREO_SOUND } soundMode;
 #define JP_VO_SH_SONO_TEIDO 0x530 // Shaft: Sono teido no chikara de tatakai...
 #endif
 
-#if defined(VERSION_BETA)
-#define SFX_OPEN_DOOR 0x640
-#define SFX_DOOR_UNKNOWN 0x64D
-#else
-#define SFX_OPEN_DOOR 0x642
 #define SFX_UNK_647 0x647
 #define SFX_UNK_64B 0x64B
 #define SFX_UNK_64C 0x64C
-#define SFX_DOOR_UNKNOWN 0x64F
-#endif
 
 #define SFX_UNK_641 0x641
 #define NA_SE_EN_COG_CLICK 0x642
@@ -464,7 +457,7 @@ enum MAD_Sfx {
     SFX_MAD_WEAPON_STAB_B = 0x630,
     SFX_MAD_CANDLE_HIT = 0x635,
     SFX_MAD_DOOR_OPEN = 0x640,
-    SFX_MAD_DOOR_CLOSE = 0x64D,
+    SFX_MAD_DOOR_CLOSE_A = 0x64D,
     SFX_MAD_HEART_PICKUP = 0x670,
     SFX_MAD_ITEM_PICKUP = 0x672,
     SFX_MAD_GOLD_PICKUP = 0x69D,

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -459,4 +459,16 @@ enum Sfx {
     SFX_EXPLODE_SMALL, // Zombie death explosion
 };
 
+// MAD uses an earlier build and has different sfx IDs
+enum MAD_Sfx {
+    SFX_MAD_WEAPON_STAB_B = 0x630,
+    SFX_MAD_CANDLE_HIT = 0x635,
+    SFX_MAD_DOOR_OPEN = 0x640,
+    SFX_MAD_DOOR_CLOSE = 0x64D,
+    SFX_MAD_HEART_PICKUP = 0x670,
+    SFX_MAD_ITEM_PICKUP = 0x672,
+    SFX_MAD_GOLD_PICKUP = 0x69D,
+    SFX_MAD_WEAPON_HIT = 0x6DB
+};
+
 #endif

--- a/src/st/collect_gold.h
+++ b/src/st/collect_gold.h
@@ -1,9 +1,11 @@
 extern u32 c_GoldPrizes[];
 extern const char* g_goldCollectTexts[];
 
+#include "sfx.h"
+
 void CollectGold(u16 goldSize) {
 #ifdef VERSION_BETA
-    g_api.PlaySfx(0x69D); // MAD seems to use its own sfx id set.
+    g_api.PlaySfx(SFX_MAD_GOLD_PICKUP); // MAD seems to use its own sfx id set.
 #else
     g_api.PlaySfx(SFX_COLLECT_GOLD);
 #endif

--- a/src/st/e_red_door.h
+++ b/src/st/e_red_door.h
@@ -1,4 +1,5 @@
 #include <stage.h>
+#include "sfx.h"
 
 extern u16 g_eInitGeneric2[];
 extern u16 g_eRedDoorTiles[2][8];
@@ -103,11 +104,19 @@ void EntityRedDoor(Entity* self) {
         }
         if (EntityIsNearPlayer(self)) {
             if (!(self->params & 0x100)) {
-                g_api.func_80134714(SFX_OPEN_DOOR, 0x60, -6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_OPEN, 0x60, -6);
+#else
+                g_api.func_80134714(SFX_DOOR_OPEN, 0x60, -6);
+#endif
                 self->ext.door.angle = 0x1000;
             }
             if (self->params & 0x100) {
-                g_api.func_80134714(SFX_OPEN_DOOR, 0x60, 6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_OPEN, 0x60, 6);
+#else
+                g_api.func_80134714(SFX_DOOR_OPEN, 0x60, 6);
+#endif
                 self->ext.door.angle = 0x800;
             }
             self->animCurFrame = 0;
@@ -141,10 +150,18 @@ void EntityRedDoor(Entity* self) {
 #endif
         {
             if (!(self->params & 0x100)) {
-                g_api.func_80134714(SFX_OPEN_DOOR, 0x60, -6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_OPEN, 0x60, -6);
+#else
+                g_api.func_80134714(SFX_DOOR_OPEN, 0x60, -6);
+#endif
             }
             if (self->params & 0x100) {
-                g_api.func_80134714(SFX_OPEN_DOOR, 0x60, 6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_OPEN, 0x60, 6);
+#else
+                g_api.func_80134714(SFX_DOOR_OPEN, 0x60, 6);
+#endif
             }
             prim = &g_PrimBuf[self->primIndex];
             i = 0;
@@ -230,10 +247,18 @@ void EntityRedDoor(Entity* self) {
                 prim->drawMode |= 8;
             }
             if (!(self->params & 0x100)) {
-                g_api.func_80134714(SFX_DOOR_UNKNOWN, 0x60, -6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_CLOSE_A, 0x60, -6);
+#else
+                g_api.func_80134714(SFX_DOOR_CLOSE_A, 0x60, -6);
+#endif
             }
             if (self->params & 0x100) {
-                g_api.func_80134714(SFX_DOOR_UNKNOWN, 0x60, 6);
+#ifdef VERSION_BETA
+                g_api.func_80134714(SFX_MAD_DOOR_CLOSE_A, 0x60, 6);
+#else
+                g_api.func_80134714(SFX_DOOR_CLOSE_A, 0x60, 6);
+#endif
             }
             self->animCurFrame = 1;
             self->step = 1;

--- a/src/st/mad/11D3C.c
+++ b/src/st/mad/11D3C.c
@@ -1,6 +1,7 @@
 #include "mad.h"
 
 #include "../entity.h"
+#include "sfx.h"
 
 u8 func_80191F24(u8 frames[], Entity* self, u8 arg2) {
     u16 animFrameStart = self->animFrameIdx * 2;
@@ -447,7 +448,7 @@ void CollectHeart(u16 arg0) {
 
     counts = D_8018D830;
     unknown = D_8018D834;
-    g_api.PlaySfx(0x670);
+    g_api.PlaySfx(SFX_MAD_HEART_PICKUP);
     g_Status.hearts += counts.count[arg0];
     if (g_Status.hearts > g_Status.heartsMax) {
         g_Status.hearts = g_Status.heartsMax;
@@ -465,7 +466,7 @@ void CollectSubweapon(u16 subWeaponIdx) {
     Entity* player = &PLAYER;
     u16 subWeapon;
 
-    g_api.PlaySfx(0x672);
+    g_api.PlaySfx(SFX_MAD_ITEM_PICKUP);
     subWeapon = g_Status.subWeapon;
     g_Status.subWeapon = D_80180D1C[subWeaponIdx];
 
@@ -497,13 +498,13 @@ void CollectSubweapon(u16 subWeaponIdx) {
 
 // Different from "collect_heart_vessel.h"
 void CollectHeartVessel(void) {
-    g_api.PlaySfx(0x670);
+    g_api.PlaySfx(SFX_MAD_HEART_PICKUP);
     g_api.func_800FE044(HEART_VESSEL_INCREASE, 0x4000);
     DestroyEntity(g_CurrentEntity);
 }
 
 void CollectLifeVessel(void) {
-    g_api.PlaySfx(0x670);
+    g_api.PlaySfx(SFX_MAD_HEART_PICKUP);
     g_api.func_800FE044(LIFE_VESSEL_INCREASE, 0x8000);
     DestroyEntity(g_CurrentEntity);
 }

--- a/src/st/mad/139E0.c
+++ b/src/st/mad/139E0.c
@@ -1,4 +1,5 @@
 #include "mad.h"
+#include "sfx.h"
 
 extern u16 D_80180D4C[];
 extern u8* D_80180DB0[];
@@ -353,7 +354,7 @@ void EntityEquipItemDrop(Entity* self) {
             g_api.FreePrimitives(g_unkGraphicsStruct.BottomCornerTextPrims);
             g_unkGraphicsStruct.BottomCornerTextTimer = 0;
         }
-        g_api.PlaySfx(0x672);
+        g_api.PlaySfx(SFX_MAD_ITEM_PICKUP);
         if (itemId < NUM_HAND_ITEMS + 4) {
             name = g_api.equipDefs[itemId].name;
             g_api.AddToInventory(itemId, EQUIP_HAND);

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -171,7 +171,7 @@ void EntityBreakable(Entity* entity) {
         AnimateEntity(g_eBreakableAnimations[breakableType], entity);
         if (entity->unk44) { // If the candle is destroyed
             Entity* entityDropItem;
-            g_api.PlaySfx(0x635);
+            g_api.PlaySfx(SFX_MAD_CANDLE_HIT);
             entityDropItem = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entityDropItem != NULL) {
                 CreateEntityFromCurrentEntity(E_EXPLOSION, entityDropItem);

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -392,9 +392,9 @@ void HitDetection(void) {
                         if (entFrom5C->flags & FLAG_UNK_10) {
                             // Different on PSP vs PSX
                             if (iterEnt2->hitEffect & 0x80) {
-                                g_api.PlaySfx(SFX_UNK_BETA_630);
+                                g_api.PlaySfx(SFX_MAD_WEAPON_STAB_B);
                             } else {
-                                g_api.PlaySfx(0x6DB);
+                                g_api.PlaySfx(SFX_MAD_WEAPON_HIT);
                             }
                         }
                         if (entFrom5C->hitPoints != 0x7FFE) {


### PR DESCRIPTION
By looking at how the gold pickup sfx are handled using `#ifdef`, I chose to do the same thing here with swapping the sfx references in `e_red_door.h`.

`SFX_METAL_CLANG_E` is the only sound effect that seems to be the same between MAD and the final collision handler.