### PR TITLE
Miscelaneous Header Cleanup

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -4,6 +4,7 @@
 
 #include "common.h"
 
+struct Entity;
 typedef void (*PfnEntityUpdate)(struct Entity*);
 
 typedef union {

--- a/src/pc/io.c
+++ b/src/pc/io.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "pc.h"
 
 struct FileAsStringCbParams {

--- a/src/pc/pc.h
+++ b/src/pc/pc.h
@@ -3,7 +3,9 @@
 
 #define LEN(x) ((s32)(sizeof(x) / sizeof(*(x))))
 
+#ifndef VERSION_PC
 #define VERSION_PC
+#endif
 #define VERSION_US
 #define VERSION "us"
 

--- a/src/pc/pl_arc.c
+++ b/src/pc/pl_arc.c
@@ -1,6 +1,8 @@
 #include <game.h>
 #include <log.h>
 #include "pc.h"
+#include <stdlib.h>
+#include <string.h>
 
 u8* g_PlOvlSpritesheet[256];
 static u8* sprite_data = NULL;

--- a/src/pc/render_shared.c
+++ b/src/pc/render_shared.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "pc.h"
 #include <assert.h>
+#include <string.h>
 #include "sdl_defs.h"
 
 enum Renderers render_mode = RENDER_SOFT;

--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -307,7 +307,7 @@ bool LoadFilePc(const struct FileUseContent* file) {
     return true;
 }
 
-int readToBuf(char* filename, char* dest) {
+int readToBuf(const char* filename, char* dest) {
     FILE* file = fopen(filename, "rb");
 
     if (file == NULL) {

--- a/src/pc/stages/stage_loader.c
+++ b/src/pc/stages/stage_loader.c
@@ -1,4 +1,5 @@
 #include <game.h>
+#include <stdlib.h>
 #include <string.h>
 #include <cJSON/cJSON.h>
 #include "stage_loader.h"

--- a/src/pc/stages/stage_sel.c
+++ b/src/pc/stages/stage_sel.c
@@ -2,8 +2,9 @@
 #include "../../st/sel/sel.h"
 #include "../pc.h"
 #include "sfx.h"
+#include <string.h>
 
-extern void* SEL_g_EntityGfxs[] = {NULL, NULL};
+void* SEL_g_EntityGfxs[] = {NULL, NULL};
 
 // stubs
 RECT D_80182584 = {0};

--- a/src/pc/str.c
+++ b/src/pc/str.c
@@ -1,5 +1,6 @@
 #include "pc.h"
 #include <stdlib.h>
+#include <string.h>
 
 // Converts UTF-8 strings into a byte sequence that menu.c can render using the
 // original game font.

--- a/src/pc/weapon_pc.c
+++ b/src/pc/weapon_pc.c
@@ -1,5 +1,6 @@
 #include "weapon.h"
 #include "pc.h"
+#include <string.h>
 
 // main variable
 u16 D_8006EDCC[2][N_WEAPON_PAL * PALETTE_LEN];


### PR DESCRIPTION
* forward declaration for `struct Entity` prior to `PfnEntityUpdate`
* definition guard around `VERSION_PC` in `pc.h`
* various libc includes to avoid implicit signatures
* `const` string arguments to avoid dropping a const qualifier

This cleans up most of the warnings from the cmake build. There are still a few from `libgte` and one more `const` to mutable assigment but most have been resolved.