### PR TITLE
Attempt to fix cross shadow

### DIFF
--- a/src/pc/sotn.c
+++ b/src/pc/sotn.c
@@ -121,7 +121,7 @@ bool InitGame(void) {
     api.g_pfn_800EA5AC = func_800EA5AC;
     api.func_801027C4 = NULL;
     api.func_800EB758 = NULL;
-    api.CreateEntFactoryFromEntity = NULL;
+    api.CreateEntFactoryFromEntity = CreateEntFactoryFromEntity;
     api.func_80131F68 = func_80131F68;
     api.func_800EDB08 = NULL;
     api.func_80106A28 = func_80106A28;

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -1328,7 +1328,7 @@ PfnEntityUpdate g_RicEntityTbl[] = {
     EntityCrossBoomerang,
     func_80169C10,
     func_8016147C,
-    func_80169D74,
+    EntityCrossShadow,
     RicEntityHolyWater,
     RicEntityHolyWaterFlame,
     func_80161C2C,
@@ -1477,14 +1477,14 @@ Entity* RicCreateEntFactoryFromEntity(
     if (entity != NULL) {
         DestroyEntity(entity);
         entity->entityId = E_ENTITYFACTORY;
-        entity->ext.generic.unk8C.entityPtr = source;
+        // the parent pointer must align for anything the factory creates
+        entity->ext.factory.parent = source;
         entity->posX.val = source->posX.val;
         entity->posY.val = source->posY.val;
         entity->facingLeft = source->facingLeft;
         entity->zPriority = source->zPriority;
         entity->params = factoryParams & 0xFFF;
         entity->ext.generic.unkA0 = (factoryParams >> 8) & 0xFF00;
-
         if (source->flags & FLAG_UNK_10000) {
             entity->flags |= FLAG_UNK_10000;
         }

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -507,6 +507,7 @@ void EntityCrossBoomerang(Entity* self) {
     switch (self->step) {
     case 0:
         self->flags = FLAG_UNK_08000000 | FLAG_UNK_04000000 | FLAG_UNK_100000;
+        // gets used by shadow, must align with that entity
         self->ext.crossBoomerang.unk84 = &D_80175088[D_80175888];
         D_80175888++;
         D_80175888 &= 3;
@@ -684,15 +685,18 @@ void func_80169C10(Entity* entity) {
     }
 }
 
-void func_80169D74(Entity* entity) {
-    Multi temp;
+// made by blueprint #5, see step 0 of EntityCrossBoomerang
+void EntityCrossShadow(Entity* entity) {
+    Point16* temp;
     s16* ptr;
 
     switch (entity->step) {
     case 0:
         entity->flags = FLAG_UNK_04000000 | FLAG_UNK_08000000;
-        entity->ext.generic.unk84.unk =
-            entity->ext.generic.unk8C.entityPtr->ext.generic.unk84.unk;
+        // the parent pointer is set in RicEntityEntFactory.
+        // the value of unk84 is set in EntityCrossBoomerang
+        entity->ext.crossBoomerang.unk84 =
+            entity->ext.factory.parent->ext.crossBoomerang.unk84;
         entity->animSet = ANIMSET_OVL(17);
         entity->animCurFrame = D_80155E68[entity->params];
         entity->unk5A = 0x66;
@@ -707,7 +711,7 @@ void func_80169D74(Entity* entity) {
 
     case 1:
         entity->rotZ -= 0x80;
-        if (entity->ext.generic.unk8C.entityPtr->step == 7) {
+        if (entity->ext.factory.parent->step == 7) {
             entity->step++;
             entity->ext.generic.unk7C.s = (entity->params + 1) * 4;
         }
@@ -722,10 +726,12 @@ void func_80169D74(Entity* entity) {
         }
         break;
     }
-    temp = entity->ext.generic.unk84;
-    ptr = temp.unk + ((u16)entity->ext.generic.unk80.modeS16.unk0 * 4);
-    entity->posX.i.hi = ptr[0] - g_Tilemap.scrollX.i.hi;
-    entity->posY.i.hi = ptr[1] - g_Tilemap.scrollY.i.hi;
+
+    // get the x and y position from the parent (must align)
+    temp = entity->ext.crossBoomerang.unk84;
+    ptr = temp + entity->ext.crossBoomerang.unk80 * 4;
+    entity->posX.i.hi = temp->x - g_Tilemap.scrollX.i.hi;
+    entity->posY.i.hi = temp->y - g_Tilemap.scrollY.i.hi;
     entity->ext.generic.unk80.modeS16.unk0 =
         (entity->ext.generic.unk80.modeS16.unk0 + 1) & 0x3F;
 }

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -686,54 +686,53 @@ void func_80169C10(Entity* entity) {
 }
 
 // made by blueprint #5, see step 0 of EntityCrossBoomerang
-void EntityCrossShadow(Entity* entity) {
-    Point16* temp;
-    s16* ptr;
+void EntityCrossShadow(Entity* self) {
+    s16* temp;
 
-    switch (entity->step) {
+    switch (self->step) {
     case 0:
-        entity->flags = FLAG_UNK_04000000 | FLAG_UNK_08000000;
+        self->flags = FLAG_UNK_04000000 | FLAG_UNK_08000000;
         // the parent pointer is set in RicEntityEntFactory.
         // the value of unk84 is set in EntityCrossBoomerang
-        entity->ext.crossBoomerang.unk84 =
-            entity->ext.factory.parent->ext.crossBoomerang.unk84;
-        entity->animSet = ANIMSET_OVL(17);
-        entity->animCurFrame = D_80155E68[entity->params];
-        entity->unk5A = 0x66;
-        entity->palette = 0x81B0;
-        entity->drawMode = DRAW_TPAGE;
-        entity->facingLeft = PLAYER.facingLeft;
-        entity->zPriority = PLAYER.zPriority;
-        entity->drawFlags = FLAG_DRAW_ROTZ;
-        entity->rotZ = 0xC00;
-        entity->step++;
+        self->ext.crossBoomerang.unk84 =
+            self->ext.factory.parent->ext.crossBoomerang.unk84;
+        self->animSet = ANIMSET_OVL(17);
+        self->animCurFrame = D_80155E68[self->params];
+        self->unk5A = 0x66;
+        self->palette = 0x81B0;
+        self->drawMode = DRAW_TPAGE;
+        self->facingLeft = PLAYER.facingLeft;
+        self->zPriority = PLAYER.zPriority;
+        self->drawFlags = FLAG_DRAW_ROTZ;
+        self->rotZ = 0xC00;
+        self->step++;
         break;
 
     case 1:
-        entity->rotZ -= 0x80;
-        if (entity->ext.factory.parent->step == 7) {
-            entity->step++;
-            entity->ext.generic.unk7C.s = (entity->params + 1) * 4;
+        self->rotZ -= 0x80;
+        if (self->ext.factory.parent->step == 7) {
+            self->step++;
+            self->ext.timer.t = (self->params + 1) * 4;
         }
         break;
 
     case 2:
-        entity->rotZ -= 0x80;
-        entity->ext.generic.unk7C.s--;
-        if (entity->ext.generic.unk7C.s == 0) {
-            DestroyEntity(entity);
+        self->rotZ -= 0x80;
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
             return;
         }
         break;
     }
 
     // get the x and y position from the parent (must align)
-    temp = entity->ext.crossBoomerang.unk84;
-    ptr = temp + entity->ext.crossBoomerang.unk80 * 4;
-    entity->posX.i.hi = temp->x - g_Tilemap.scrollX.i.hi;
-    entity->posY.i.hi = temp->y - g_Tilemap.scrollY.i.hi;
-    entity->ext.generic.unk80.modeS16.unk0 =
-        (entity->ext.generic.unk80.modeS16.unk0 + 1) & 0x3F;
+    temp = &self->ext.crossBoomerang.unk84[0];
+    temp += self->ext.crossBoomerang.unk80 * 2;
+    self->posX.i.hi = *temp - g_Tilemap.scrollX.i.hi;
+    temp++;
+    self->posY.i.hi = *temp - g_Tilemap.scrollY.i.hi;
+    self->ext.crossBoomerang.unk80++;
+    self->ext.crossBoomerang.unk80 &= 0x3F;
 }
 
 // Entity ID #32. Comes from blueprint 34.

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -712,13 +712,13 @@ void EntityCrossShadow(Entity* self) {
         self->rotZ -= 0x80;
         if (self->ext.factory.parent->step == 7) {
             self->step++;
-            self->ext.timer.t = (self->params + 1) * 4;
+            self->ext.crossBoomerang.timer = (self->params + 1) * 4;
         }
         break;
 
     case 2:
         self->rotZ -= 0x80;
-        if (--self->ext.timer.t == 0) {
+        if (--self->ext.crossBoomerang.timer == 0) {
             DestroyEntity(self);
             return;
         }

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -54,7 +54,7 @@ void func_80160FC4(Entity* self);
 void EntityCrossBoomerang(Entity* self);
 void func_80169C10(Entity* self);
 void func_8016147C(Entity* self);
-void func_80169D74(Entity* self);
+void EntityCrossShadow(Entity* self);
 void RicEntityHolyWater(Entity* self);
 void RicEntityHolyWaterFlame(Entity* self);
 void func_80161C2C(Entity* self);


### PR DESCRIPTION
We have a problem where pointers across the various entity structs do not align. This causes the game to crash because it tries to reference the wrong offsets. I don't think this should be the final version of this fix but I'm putting it up for feedback.

This can be tested with this change to give the cross:
```
             // Richter gets a random subweapon.
             if ((g_StageId != STAGE_ST0) && (g_StageId != STAGE_NO3)) {
+                g_Status.subWeapon = SUBWPN_CROSS;
             }
```
The cross spawns a transparent object behind it using the entity factory system. We go from:

EntityCrossBoomerang which creates Entity factory 5, which calls RicCreateEntFactoryFromEntity

The parent pointer there has to align with the children
```
        // the parent pointer must align for anything the factory creates
        entity->ext.factory.parent = source;
```

Then we go through RicEntityEntFactory, which creates EntityCrossShadow.

EntityCrossShadow requires the parent pointer to get unk84 data from the parent, which is used to set the x and y positions of the shadow.

This is currently nonmatching.