### PR TITLE
Fix crashing in RicEntityHolyWaterFlame

### DIFF
--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -280,8 +280,8 @@ void RicEntityHolyWaterFlame(Entity* self) {
             }
             prim->x0 = sp10[i] - 8;
             prim->x1 = sp10[i] + 8;
-            prim->y0 = sp10[i + 8];
-            prim->y1 = sp10[i + 8];
+            prim->y0 = sp20[i];
+            prim->y1 = sp20[i];
             prim->x2 = sp10[i + 1] - 8;
             prim->x3 = sp10[i + 1] + 8;
             prim->y2 = sp20[i + 1];


### PR DESCRIPTION
sp10 isn't large enough to do `i + 8`, tested ingame and seems to look correct