### PR TITLE
Remove Multi type from g_zEntityCenter

### DIFF
--- a/include/unkstruct.h
+++ b/include/unkstruct.h
@@ -149,7 +149,7 @@ typedef struct {
     /* 0x800973FC */ s32 D_800973FC;
     /* 0x80097400 */ s32 unk0;
     /* 0x80097404 */ s32 unk4;
-    /* 0x80097408 */ Multi g_zEntityCenter;
+    /* 0x80097408 */ s32 g_zEntityCenter;
     /* 0x8009740C */ s32 unkC;
     /* 0x80097410 */ s32 BottomCornerTextTimer;
     /* 0x80097414 */ s32 BottomCornerTextPrims;

--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -973,7 +973,7 @@ void func_800F2404(s32 arg0) {
 
     g_unkGraphicsStruct.BottomCornerTextTimer = 0;
     g_unkGraphicsStruct.BottomCornerTextPrims = 0;
-    g_unkGraphicsStruct.g_zEntityCenter.unk = 148;
+    g_unkGraphicsStruct.g_zEntityCenter = 148;
     for (i = 0; i < LEN(g_unkGraphicsStruct.D_80097428); i++) {
         g_unkGraphicsStruct.D_80097428[i] = 0;
     }
@@ -1682,7 +1682,7 @@ void func_800F298C(void) {
                 g_PlayerX = PLAYER.posX.i.hi + g_Tilemap.scrollX.i.hi;
                 g_PlayerY = PLAYER.posY.i.hi + g_Tilemap.scrollY.i.hi;
                 func_8011A9D8();
-                PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+                PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
                 func_800F0CD8(0);
                 func_8010BFFC();
                 g_PlayerX = PLAYER.posX.i.hi + g_Tilemap.scrollX.i.hi;

--- a/src/dra/627C4.c
+++ b/src/dra/627C4.c
@@ -286,7 +286,7 @@ void func_80102EB8(void) {
         func_801072DC(poly1);
         poly1->tpage = 0x10;
         poly1->clut = 0x1A1;
-        poly1->priority = g_unkGraphicsStruct.g_zEntityCenter.unk + 32;
+        poly1->priority = g_unkGraphicsStruct.g_zEntityCenter + 32;
         poly1->drawMode = DRAW_HIDE;
         poly1->p1 = 0;
         SetPrimRect(poly2, 80, 79, 96, 0);
@@ -296,7 +296,7 @@ void func_80102EB8(void) {
         poly2->g0 = poly2->g1 = poly2->g2 = poly2->g3 = poly2->r0 = poly2->r1 =
             poly2->r2 = poly2->r3 = 0;
         poly2->tpage = 0x1F;
-        poly2->priority = g_unkGraphicsStruct.g_zEntityCenter.unk + 31;
+        poly2->priority = g_unkGraphicsStruct.g_zEntityCenter + 31;
         poly2->drawMode = DRAW_HIDE;
         poly1 = poly1->next;
         poly2 = poly2->next;
@@ -304,7 +304,7 @@ void func_80102EB8(void) {
 
     for (i = 0; i < 12; i++) {
         func_80107250(poly3, 255);
-        poly3->priority = g_unkGraphicsStruct.g_zEntityCenter.unk + 32;
+        poly3->priority = g_unkGraphicsStruct.g_zEntityCenter + 32;
         poly3->drawMode = DRAW_HIDE;
         poly3 = poly3->next;
     }

--- a/src/dra/63ED4.c
+++ b/src/dra/63ED4.c
@@ -846,9 +846,9 @@ void func_80104790(s32 arg0, s32 arg1, s32 arg2) {
             continue;
         }
         if (temp_v0_5 >= 0) {
-            prim->priority = g_unkGraphicsStruct.g_zEntityCenter.unk + 4;
+            prim->priority = g_unkGraphicsStruct.g_zEntityCenter + 4;
         } else {
-            prim->priority = g_unkGraphicsStruct.g_zEntityCenter.unk - 4;
+            prim->priority = g_unkGraphicsStruct.g_zEntityCenter - 4;
         }
         prim->drawMode = DRAW_COLORS;
         if (((D_80137E4C == 6) || (D_80137EE0 != 0)) &&
@@ -955,9 +955,9 @@ void func_80105078(s32 arg0, s32 arg1) {
         prim->type = 2;
         if (sp7C < 0xF0) {
             if (temp_v0_4 >= 0) {
-                prim->priority = g_unkGraphicsStruct.g_zEntityCenter.unk + 3;
+                prim->priority = g_unkGraphicsStruct.g_zEntityCenter + 3;
             } else {
-                prim->priority = g_unkGraphicsStruct.g_zEntityCenter.unk - 3;
+                prim->priority = g_unkGraphicsStruct.g_zEntityCenter - 3;
             }
             if (arg1 != 0) {
                 if (arg1 & 0x80) {

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -183,7 +183,7 @@ void func_80109594() {
     PLAYER.facingLeft = 0;
     PLAYER.rotX = 0x100;
     PLAYER.rotY = 0x100;
-    PLAYER.zPriority = (u16)g_unkGraphicsStruct.g_zEntityCenter.unk;
+    PLAYER.zPriority = (u16)g_unkGraphicsStruct.g_zEntityCenter;
 
     memset_len = sizeof(PlayerState) / sizeof(s32);
     memset_ptr = &g_Player;

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -509,7 +509,7 @@ void func_8010E4D0(void) {
     func_80111CC0();
 
     PLAYER.palette = 0x8100;
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
 
     if ((u32)(g_Player.unk72 - 1) < 2U) {
         SetPlayerAnim(0xC7);

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -599,7 +599,7 @@ void func_80113EE0(void) {
     g_Player.unk44 = 0;
     g_Player.unk46 = 0;
     PLAYER.rotZ = 0;
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
     if (g_Entities[E_WEAPON].entityId == E_UNK_22) {
         func_8010FAF4();
     }

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -552,7 +552,7 @@ void func_8012E7A4(void) {
     PLAYER.velocityX = 0;
     PLAYER.velocityY = 0;
     PLAYER.palette = 0x810D;
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 2;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter - 2;
 #if defined(VERSION_HD)
     if (g_Entities[16].entityId != 0x22) {
         CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x2300, 44), 0);
@@ -641,14 +641,14 @@ void func_8012EAD0(void) {
             D_800ACEDC_hd = 0x18;
 #endif
             g_Player.unk44 |= 0x100;
-            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
             func_80111CC0();
         }
         return;
     case 2:
         if (g_Player.unk66 == 3) {
 #if defined(VERSION_US)
-            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
 #endif
 
             func_8010E4D0();
@@ -715,7 +715,7 @@ void func_8012EF2C(void) {
     PLAYER.drawMode = DRAW_DEFAULT;
 // HD version lacks this line!
 #if defined(VERSION_US)
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 2;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter - 2;
 #endif
     if (WolfFormFinished()) {
         return;
@@ -784,7 +784,7 @@ void func_8012EF2C(void) {
     // HD version lacks this line!
 
 #if defined(VERSION_US)
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 2;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter - 2;
 #endif
 }
 

--- a/src/ric/1AC60.c
+++ b/src/ric/1AC60.c
@@ -92,7 +92,7 @@ void func_80156F40(s16 arg0) {
     PLAYER.rotX = PLAYER.rotY = 0x100;
     PLAYER.facingLeft = 0;
     PLAYER.rotPivotY = 0x18;
-    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+    PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
     memset_len = sizeof(PlayerState) / sizeof(s32);
     memset_ptr = &g_Player;
     for (i = 0; i < memset_len; i++) {

--- a/src/st/dre/11A64.c
+++ b/src/st/dre/11A64.c
@@ -112,7 +112,7 @@ void EntityBreakable(Entity* entity) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 20;
+        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 20;
         entity->drawMode = g_eBreakableDrawModes[temp_s0];
         entity->hitboxHeight = g_eBreakableHitboxes[temp_s0];
         entity->animSet = g_eBreakableanimSets[temp_s0];

--- a/src/st/e_breakable.h
+++ b/src/st/e_breakable.h
@@ -53,7 +53,7 @@ void EntityBreakable(Entity* entity) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 20;
+        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 20;
         entity->drawMode = g_eBreakableDrawModes[breakableType];
         entity->hitboxHeight = g_eBreakableHitboxes[breakableType];
         entity->animSet = g_eBreakableanimSets[breakableType];

--- a/src/st/e_collect.h
+++ b/src/st/e_collect.h
@@ -311,7 +311,7 @@ void EntityPrizeDrop(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_InitializeData0);
-        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 0x14;
+        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0x14;
         self->drawMode = DRAW_DEFAULT;
 #if STAGE == STAGE_ST0
         if (itemId >= 23) {

--- a/src/st/init_entity.h
+++ b/src/st/init_entity.h
@@ -23,7 +23,6 @@ void InitializeEntity(u16 arg0[]) {
     g_CurrentEntity->step++;
     g_CurrentEntity->step_s = 0;
     if (!g_CurrentEntity->zPriority) {
-        g_CurrentEntity->zPriority =
-            g_unkGraphicsStruct.g_zEntityCenter.unk - 0xC;
+        g_CurrentEntity->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0xC;
     }
 }

--- a/src/st/mad/D8C8.c
+++ b/src/st/mad/D8C8.c
@@ -182,7 +182,7 @@ void EntityBreakable(Entity* entity) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 0x14;
+        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0x14;
         entity->drawMode = g_eBreakableDrawModes[breakableType];
         entity->hitboxHeight = g_eBreakableHitboxes[breakableType];
         entity->animSet = g_eBreakableanimSets[breakableType];

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -108,7 +108,7 @@ void EntityBreakable(Entity* entity) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 0x14;
+        entity->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0x14;
         entity->drawMode = g_eBreakableDrawModes[breakableType];
         entity->hitboxHeight = g_eBreakableHitboxes[breakableType];
         entity->animSet = g_eBreakableanimSets[breakableType];

--- a/src/st/nz0/e_breakable.c
+++ b/src/st/nz0/e_breakable.c
@@ -59,7 +59,7 @@ void EntityBreakableNZ0(Entity* self) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 20;
+        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 20;
         self->drawMode = g_eBreakableDrawModes[breakableType];
         self->hitboxHeight = g_eBreakableHitboxes[breakableType];
         self->animSet = g_eBreakableanimSets[breakableType];

--- a/src/st/rwrp/warp.c
+++ b/src/st/rwrp/warp.c
@@ -193,7 +193,7 @@ void EntityRWarpRoom(Entity* self) {
         g_Player.padSim = 0;
         g_Player.D_80072EFC = 0x80;
         D_8003C8B8 = 0;
-        g_unkGraphicsStruct.g_zEntityCenter.unk = PLAYER.zPriority = 0x5C;
+        g_unkGraphicsStruct.g_zEntityCenter = PLAYER.zPriority = 0x5C;
         prim = self->ext.warpRoom.primFade;
         prim->drawMode = DRAW_TRANSP | DRAW_TPAGE | DRAW_TPAGE2;
         prim->g0 = prim->b0 = prim->r0 += 2;
@@ -209,7 +209,7 @@ void EntityRWarpRoom(Entity* self) {
         g_Player.D_80072EFC = 0x80;
         D_8003C8B8 = 0;
         entity = &PLAYER;
-        g_unkGraphicsStruct.g_zEntityCenter.unk = entity->zPriority = 0x5C;
+        g_unkGraphicsStruct.g_zEntityCenter = entity->zPriority = 0x5C;
         prim = self->ext.warpRoom.primFade;
         prim->drawMode = DRAW_TRANSP | DRAW_TPAGE | DRAW_TPAGE2;
         if (prim->r0 < 0xF0) {

--- a/src/st/st0/27D64.c
+++ b/src/st/st0/27D64.c
@@ -160,7 +160,7 @@ void func_801A805C(Entity* self) {
         }
     } else {
         InitializeEntity(g_eBreakableInit);
-        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 0x14;
+        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0x14;
         self->drawMode = D_8018074C[params];
         self->hitboxHeight = D_801806F8[params];
         self->animSet = D_80180724[params];

--- a/src/st/st0/2B0C8.c
+++ b/src/st/st0/2B0C8.c
@@ -95,7 +95,7 @@ void EntityStageTitleFadeout(Entity* self) {
         if (prim->r0 > 248) {
             prim->r0 = 0;
             prim->drawMode = DRAW_HIDE;
-            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk;
+            PLAYER.zPriority = g_unkGraphicsStruct.g_zEntityCenter;
             self->step = 1;
         }
         prim->g0 = prim->b0 = LOW(prim->r0);
@@ -146,7 +146,7 @@ void EntityStageTitleFadeout(Entity* self) {
             self->ext.stageTitleCard.unk88--;
             if (self->ext.stageTitleCard.unk88 == 0) {
                 g_Entities[PLAYER_CHARACTER].zPriority =
-                    g_unkGraphicsStruct.g_zEntityCenter.unk;
+                    g_unkGraphicsStruct.g_zEntityCenter;
             }
         }
         temp_a0 = self->ext.stageTitleCard.unk80;

--- a/src/st/wrp/warp.c
+++ b/src/st/wrp/warp.c
@@ -194,7 +194,7 @@ void EntityWarpRoom(Entity* self) {
         g_Player.D_80072EFC = 0x80;
         D_8003C8B8 = 0;
         entity = &PLAYER;
-        g_unkGraphicsStruct.g_zEntityCenter.unk = entity->zPriority = 0x5C;
+        g_unkGraphicsStruct.g_zEntityCenter = entity->zPriority = 0x5C;
         prim = self->ext.warpRoom.primFade;
         prim->drawMode = DRAW_TRANSP | DRAW_TPAGE | DRAW_TPAGE2;
         prim->g0 = prim->b0 = prim->r0 += 2;
@@ -210,7 +210,7 @@ void EntityWarpRoom(Entity* self) {
         g_Player.D_80072EFC = 0x80;
         D_8003C8B8 = 0;
         entity = &PLAYER;
-        g_unkGraphicsStruct.g_zEntityCenter.unk = entity->zPriority = 0x5C;
+        g_unkGraphicsStruct.g_zEntityCenter = entity->zPriority = 0x5C;
         prim = self->ext.warpRoom.primFade;
         prim->drawMode = DRAW_TRANSP | DRAW_TPAGE | DRAW_TPAGE2;
         if (prim->r0 < 0xF0) {

--- a/src/st/wrp_psp/e_collect.c
+++ b/src/st/wrp_psp/e_collect.c
@@ -257,7 +257,7 @@ void EntityPrizeDrop(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_InitializeData0);
-        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter.unk - 0x14;
+        self->zPriority = g_unkGraphicsStruct.g_zEntityCenter - 0x14;
         self->drawMode = DRAW_DEFAULT;
         if (itemId > 23) {
             itemId = self->params = 0;


### PR DESCRIPTION
This is actually what I was initially going for in my previous PR.

g_zEntityCenter was almost always used as an s32, but some of the duplicates of e_collect which were scattered across overlays had weird misuses that acted like it was s16, which necessitated the use of the Multi.

Now that e_collect is unified across overlays, we can make this data field a proper s32. Nice!

The only change made in this PR is the type of this variable, and a find-and-replace to change it to not need to access the .unk element of the Multi struct anymore, since now it's just a bare s32 (but still contained in the unkGraphicsStruct of course).