### PR TITLE
Document RIC Vibhuti crash cloud

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -1133,6 +1133,15 @@ typedef struct {
 } ET_VibhutiCrash;
 
 typedef struct {
+    s16 unk7C;
+    s16 : 16;
+    s32 : 32;
+    s32 : 32;
+    s32 : 32;
+    struct Entity* parent;
+} ET_VibhutiCrashCloud;
+
+typedef struct {
     PrimLineG2* lines[4];
     s16 unk8C;
     s16 unk8E;
@@ -1370,6 +1379,7 @@ typedef union { // offset=0x7C
     ET_AguneaCrash aguneaCrash;
     ET_AxeCrash axeCrash;
     ET_VibhutiCrash vibhutiCrash;
+    ET_VibhutiCrashCloud vibCrashCloud;
     ET_RicRevivalColumn ricColumn;
     ET_GiantSpinningCross giantcross;
     ET_EquipItemDrop equipItemDrop;

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -1369,7 +1369,7 @@ PfnEntityUpdate g_RicEntityTbl[] = {
     RicEntitySubwpnAgunea,
     RicEntityAguneaHitEnemy,
     EntitySubwpnCrashVibhuti,
-    func_8016D328,
+    RicEntityVibhutiCrashCloud,
     func_8016E324,
     func_8016D9C4,
     func_8016DF74,

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -2294,8 +2294,8 @@ void RicEntityVibhutiCrashCloud(Entity* entity) {
                 entity->ext.vibCrashCloud.parent->ext.vibhutiCrash.unk84;
             entity->posY.val =
                 entity->ext.vibCrashCloud.parent->ext.vibhutiCrash.unk88;
-            entity->facingLeft = entity->ext.vibCrashCloud.parent->ext
-                                     .vibhutiCrash.unk8C;
+            entity->facingLeft =
+                entity->ext.vibCrashCloud.parent->ext.vibhutiCrash.unk8C;
             entity->ext.factory.unkB0 = 0x18;
             RicSetSubweaponParams(entity);
             entity->unk5A = 0x79;

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -2279,7 +2279,8 @@ void RicEntityAguneaHitEnemy(Entity* self) {
     }
 }
 
-void func_8016D328(Entity* entity) {
+// White cloud that comes out of Richter's finger with the Vibhuti crash
+void RicEntityVibhutiCrashCloud(Entity* entity) {
     s16 primIndex;
     s32 newVelocity;
 
@@ -2290,12 +2291,12 @@ void func_8016D328(Entity* entity) {
         if (primIndex != -1) {
             entity->flags = FLAG_UNK_08000000 | FLAG_HAS_PRIMS;
             entity->posX.val =
-                entity->ext.generic.unk8C.entityPtr->ext.generic.unk84.unk;
+                entity->ext.vibCrashCloud.parent->ext.vibhutiCrash.unk84;
             entity->posY.val =
-                entity->ext.generic.unk8C.entityPtr->ext.generic.unk88.unk;
-            entity->facingLeft = entity->ext.generic.unk8C.entityPtr->ext
-                                     .generic.unk8C.modeU16.unk0;
-            entity->ext.generic.unkB0 = 0x18;
+                entity->ext.vibCrashCloud.parent->ext.vibhutiCrash.unk88;
+            entity->facingLeft = entity->ext.vibCrashCloud.parent->ext
+                                     .vibhutiCrash.unk8C;
+            entity->ext.factory.unkB0 = 0x18;
             RicSetSubweaponParams(entity);
             entity->unk5A = 0x79;
             entity->animSet = ANIMSET_DRA(14);
@@ -2317,7 +2318,7 @@ void func_8016D328(Entity* entity) {
         break;
 
     case 1:
-        if (++entity->ext.generic.unk7C.s >= 39) {
+        if (++entity->ext.vibCrashCloud.unk7C >= 39) {
             DestroyEntity(entity);
         } else {
             entity->posX.val += entity->velocityX;
@@ -2396,6 +2397,7 @@ void EntitySubwpnCrashVibhuti(Entity* self) {
                     self->ext.vibhutiCrash.unk84 = prim->posX.val;
                     self->ext.vibhutiCrash.unk88 = prim->posY.val;
                     self->ext.vibhutiCrash.unk8C = prim->velocityX.val < 1;
+                    // Creates RicEntityVibhutiCrashCloud
                     RicCreateEntFactoryFromEntity(self, FACTORY(0, 55), 0);
                 } else {
                     prim->posX.val += prim->velocityX.val;

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -147,7 +147,7 @@ void RicEntitySubwpnThrownVibhuti(Entity* self);
 void RicEntitySubwpnAgunea(Entity* self);
 void RicEntityAguneaHitEnemy(Entity* self);
 void EntitySubwpnCrashVibhuti(Entity* self);
-void func_8016D328(Entity* self);
+void RicEntityVibhutiCrashCloud(Entity* self);
 void func_8016E324(Entity* self);
 void func_8016D9C4(Entity* self);
 void func_8016DF74(Entity* self);


### PR DESCRIPTION
Got away from using `generic`. Only two fields are used, but unk8C was taken in the main Vibhuti crash, so can't reuse it.

Trying to start using the `s32 : 32` syntax to indicate unused fields moving forward, may help with figuring out how to handle the problem of `Ext` and its mysteries.