### PR TITLE
Improve EntityWargExplosionPuffOpaque

### DIFF
--- a/config/splat.us.stnp3.yaml
+++ b/config/splat.us.stnp3.yaml
@@ -75,7 +75,7 @@ segments:
       - [0x2A124, .data, sprites]
       - [0x31EA0, data]
       - [0x31EA8, .rodata, 32830] # EntityStairwayPiece
-      - [0x31EBC, .rodata, 365FC] # func_801B65FC
+      - [0x31EBC, .rodata, 363FC] # func_801B63FC
       - [0x31ED0, .rodata, slogra] # EntitySlogra .rodata, 36990
       - [0x31EDC, .rodata, gaibon] # EntityGaibon .rodata, 36990
       - [0x31F00, .rodata, e_red_door] # EntityRedDoor
@@ -102,7 +102,7 @@ segments:
       - [0x3246C, c, st_debug]
       - [0x326FC, c, e_breakable]
       - [0x32830, c]
-      - [0x365FC, c]
+      - [0x363FC, c]
       - [0x36990, c, slogra]
       - [0x378BC, c, gaibon]
       - [0x390BC, c, st_update]

--- a/include/entity.h
+++ b/include/entity.h
@@ -616,7 +616,7 @@ typedef struct {
     /* 0x86 */ u8 pad86[2];
     /* 0x88 */ u8 unk88;
     /* 0x89 */ u8 unk89;
-} ET_801B3C38;
+} ET_WargExplosionPuffOpaque;
 
 typedef struct {
     /* 0x7C */ u16 unk7C;
@@ -1500,7 +1500,7 @@ typedef union { // offset=0x7C
     ET_Succubus succubus;
     ET_StageTitleCard stageTitleCard;
     ET_RoomTransition2 roomTransition2;
-    ET_801B3C38 et38;
+    ET_WargExplosionPuffOpaque wargpuff;
     ET_801BCC4C et_801BCC4C;
     ET_ShuttingWindow shuttingWindow;
     ET_CastleDoor castleDoor;

--- a/src/st/e_collect.h
+++ b/src/st/e_collect.h
@@ -236,7 +236,7 @@ static void CollectSubweapon(u16 subWeaponIdx) {
 #endif
         g_CurrentEntity->velocityY = FIX(-2.5);
         g_CurrentEntity->animCurFrame = 0;
-        g_CurrentEntity->ext.generic.unk88.S16.unk2 = 5;
+        g_CurrentEntity->ext.equipItemDrop.unk8A = 5;
         if (player->facingLeft != 1) {
             g_CurrentEntity->velocityX = FIX(-2);
             return;

--- a/src/st/no3/3FF00.c
+++ b/src/st/no3/3FF00.c
@@ -744,8 +744,8 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
                 break;
             }
             self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
-            self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
-            temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
+            self->rotZ = self->ext.wargpuff.unk84 & 0xFFF;
+            temp_s0 = self->ext.wargpuff.unk89 * 0x140;
             temp_s0 /= 28;
             self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
             self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));

--- a/src/st/no3/3FF00.c
+++ b/src/st/no3/3FF00.c
@@ -648,11 +648,12 @@ void func_801C13F8() {
     for (i = 0; i < 6; i++) {
         entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
-            CreateEntityFromEntity(E_ID_62, g_CurrentEntity, entity);
+            // Make a EntityWargExplosionPuffOpaque
+            CreateEntityFromEntity(E_WARG_EXP_OPAQUE, g_CurrentEntity, entity);
             entity->params = 2;
-            entity->ext.generic.unk88.S8.unk1 = 6 - i;
-            entity->ext.generic.unk84.S16.unk0 = temp_s3;
-            entity->ext.generic.unk88.S8.unk0 = temp_s4;
+            entity->ext.wargpuff.unk89 = 6 - i;
+            entity->ext.wargpuff.unk84 = temp_s3;
+            entity->ext.wargpuff.unk88 = temp_s4;
         }
     }
 }
@@ -678,7 +679,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
         self->drawMode = obj->drawMode;
         self->animSet = obj->animSet;
         self->unk5A = obj->unk2;
-        self->ext.et38.unk80 = obj->unk8;
+        self->ext.wargpuff.unk80 = obj->unk8;
         self->step = params + 1;
 
         temp_v0 = self->params & 0xFF00;
@@ -696,13 +697,13 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY = FIX(1.0);
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
 
     case 2:
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) != 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) != 0) {
             switch (self->step_s) {
             case 0:
                 self->drawFlags = FLAG_DRAW_UNK8;
@@ -728,25 +729,26 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 3:
         if (self->step_s == 0) {
             self->drawFlags |= 4;
-            switch (self->ext.et38.unk88) {
+            switch (self->ext.wargpuff.unk88) {
             case 1:
-                if (self->ext.et38.unk89 >= 0x4) {
-                    self->ext.et38.unk89 += 0xFD;
-                    self->ext.et38.unk84 -= 0x800;
+                if (self->ext.wargpuff.unk89 >= 0x4) {
+                    self->ext.wargpuff.unk89 += 0xFD;
+                    self->ext.wargpuff.unk84 -= 0x800;
                 }
                 break;
 
             case 2:
-                self->ext.et38.unk84 = (u16)self->ext.et38.unk84 +
-                                       ((u8)self->ext.et38.unk89 * 0xC0);
+                self->ext.wargpuff.unk84 =
+                    (u16)self->ext.wargpuff.unk84 +
+                    ((u8)self->ext.wargpuff.unk89 * 0xC0);
                 break;
             }
-            self->ext.et38.unk84 = self->ext.et38.unk84 & 0xFFF;
+            self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
             self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
             temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
             temp_s0 /= 28;
-            self->velocityX = temp_s0 * rsin(self->ext.et38.unk84);
-            self->velocityY = -(temp_s0 * rcos(self->ext.et38.unk84));
+            self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
+            self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));
             self->step_s++;
         }
 
@@ -768,7 +770,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->velocityY = velocityY - (adjVelocityY >> 2);
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
@@ -783,7 +785,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->step_s++;
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -76,7 +76,7 @@ typedef enum EntityIDs {
     /* 0x5B */ E_ID_5B = 0x5B,
     /* 0x5D */ E_FALLING_ROCK = 0x5D,
     /* 0x5E */ E_ID_5E,
-    /* 0x62 */ E_ID_62 = 0x62,
+    /* 0x62 */ E_WARG_EXP_OPAQUE = 0x62,
 } EntityIDs;
 
 extern void CreateEntityFromCurrentEntity(u16, Entity*);

--- a/src/st/np3/32830.c
+++ b/src/st/np3/32830.c
@@ -1770,21 +1770,3 @@ void EntityUnkId49(Entity* self) {
         break;
     }
 }
-
-void func_801B653C(void) {
-    Entity* entity;
-    s8 temp_s4 = Random() & 3;
-    s16 temp_s3 = ((Random() & 0xF) << 8) - 0x800;
-    s32 i;
-
-    for (i = 0; i < 6; i++) {
-        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
-        if (entity != NULL) {
-            CreateEntityFromEntity(E_ID_4D, g_CurrentEntity, entity);
-            entity->params = 2;
-            entity->ext.generic.unk88.U8.unk1 = 6 - i;
-            entity->ext.generic.unk84.S16.unk0 = temp_s3;
-            entity->ext.generic.unk88.U8.unk0 = temp_s4;
-        }
-    }
-}

--- a/src/st/np3/363FC.c
+++ b/src/st/np3/363FC.c
@@ -105,8 +105,8 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
                 break;
             }
             self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
-            self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
-            temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
+            self->rotZ = self->ext.wargpuff.unk84 & 0xFFF;
+            temp_s0 = self->ext.wargpuff.unk89 * 0x140;
             temp_s0 /= 28;
             self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
             self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));

--- a/src/st/np3/363FC.c
+++ b/src/st/np3/363FC.c
@@ -1,5 +1,25 @@
 #include "np3.h"
 
+// Make a EntityWargExplosionPuffOpaque
+void func_801B653C(void) {
+    Entity* entity;
+    s8 temp_s4 = Random() & 3;
+    s16 temp_s3 = ((Random() & 0xF) << 8) - 0x800;
+    s32 i;
+
+    for (i = 0; i < 6; i++) {
+        entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
+        if (entity != NULL) {
+            // Make a EntityWargExplosionPuffOpaque
+            CreateEntityFromEntity(E_WARG_EXP_OPAQUE, g_CurrentEntity, entity);
+            entity->params = 2;
+            entity->ext.wargpuff.unk89 = 6 - i;
+            entity->ext.wargpuff.unk84 = temp_s3;
+            entity->ext.wargpuff.unk88 = temp_s4;
+        }
+    }
+}
+
 void EntityWargExplosionPuffOpaque(Entity* self) {
     Unkstruct_80180FE0* obj;
     s32 velocityX;
@@ -20,7 +40,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
         self->drawMode = obj->drawMode;
         self->animSet = obj->animSet;
         self->unk5A = obj->unk2;
-        self->ext.et38.unk80 = obj->unk8;
+        self->ext.wargpuff.unk80 = obj->unk8;
         self->step = params + 1;
 
         temp_v0 = self->params & 0xFF00;
@@ -38,13 +58,13 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY = FIX(1.0);
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
 
     case 2:
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) != 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) != 0) {
             switch (self->step_s) {
             case 0:
                 self->drawFlags = FLAG_DRAW_UNK8;
@@ -70,25 +90,26 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 3:
         if (self->step_s == 0) {
             self->drawFlags |= 4;
-            switch (self->ext.et38.unk88) {
+            switch (self->ext.wargpuff.unk88) {
             case 1:
-                if (self->ext.et38.unk89 >= 0x4) {
-                    self->ext.et38.unk89 += 0xFD;
-                    self->ext.et38.unk84 -= 0x800;
+                if (self->ext.wargpuff.unk89 >= 0x4) {
+                    self->ext.wargpuff.unk89 += 0xFD;
+                    self->ext.wargpuff.unk84 -= 0x800;
                 }
                 break;
 
             case 2:
-                self->ext.et38.unk84 = (u16)self->ext.et38.unk84 +
-                                       ((u8)self->ext.et38.unk89 * 0xC0);
+                self->ext.wargpuff.unk84 =
+                    (u16)self->ext.wargpuff.unk84 +
+                    ((u8)self->ext.wargpuff.unk89 * 0xC0);
                 break;
             }
-            self->ext.et38.unk84 = self->ext.et38.unk84 & 0xFFF;
+            self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
             self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
             temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
             temp_s0 /= 28;
-            self->velocityX = temp_s0 * rsin(self->ext.et38.unk84);
-            self->velocityY = -(temp_s0 * rcos(self->ext.et38.unk84));
+            self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
+            self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));
             self->step_s++;
         }
 
@@ -110,7 +131,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->velocityY = velocityY - (adjVelocityY >> 2);
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
@@ -125,7 +146,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->step_s++;
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -58,7 +58,7 @@ typedef enum {
     /* 0x4A */ E_BLOOD_SPLATTER,
     /* 0x4B */ E_STAIRWAY_PIECE,
     /* 0x4C */ E_FALLING_ROCK,
-    /* 0x4D */ E_ID_4D,
+    /* 0x4D */ E_WARG_EXP_OPAQUE,
     /* 0x4F */ E_SLOGRA_SPEAR = 0x4F,
     /* 0x50 */ E_SLOGRA_SPEAR_PROJECTILE,
     /* 0x51 */ E_GAIBON,

--- a/src/st/nz0/311C0.c
+++ b/src/st/nz0/311C0.c
@@ -1279,11 +1279,12 @@ void func_801B3B78() {
     for (i = 0; i < 6; i++) {
         entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
         if (entity != NULL) {
-            CreateEntityFromEntity(0x38, g_CurrentEntity, entity);
+            // Make a EntityWargExplosionPuffOpaque
+            CreateEntityFromEntity(E_WARG_EXP_OPAQUE, g_CurrentEntity, entity);
             entity->params = 2;
-            entity->ext.generic.unk88.S8.unk1 = 6 - i;
-            entity->ext.generic.unk84.S16.unk0 = temp_s3;
-            entity->ext.generic.unk88.S8.unk0 = temp_s4;
+            entity->ext.wargpuff.unk89 = 6 - i;
+            entity->ext.wargpuff.unk84 = temp_s3;
+            entity->ext.wargpuff.unk88 = temp_s4;
         }
     }
 }
@@ -1309,7 +1310,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
         self->drawMode = obj->drawMode;
         self->animSet = obj->animSet;
         self->unk5A = obj->unk2;
-        self->ext.et38.unk80 = obj->unk8;
+        self->ext.wargpuff.unk80 = obj->unk8;
         self->step = params + 1;
 
         temp_v0 = self->params & 0xFF00;
@@ -1327,13 +1328,13 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY = FIX(-1);
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
 
     case 2:
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) != 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) != 0) {
             switch (self->step_s) {
             case 0:
                 self->drawFlags = FLAG_DRAW_UNK8;
@@ -1359,25 +1360,26 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
     case 3:
         if (self->step_s == 0) {
             self->drawFlags |= 4;
-            switch (self->ext.et38.unk88) {
+            switch (self->ext.wargpuff.unk88) {
             case 1:
-                if (self->ext.et38.unk89 >= 0x4) {
-                    self->ext.et38.unk89 += 0xFD;
-                    self->ext.et38.unk84 -= 0x800;
+                if (self->ext.wargpuff.unk89 >= 0x4) {
+                    self->ext.wargpuff.unk89 += 0xFD;
+                    self->ext.wargpuff.unk84 -= 0x800;
                 }
                 break;
 
             case 2:
-                self->ext.et38.unk84 = (u16)self->ext.et38.unk84 +
-                                       ((u8)self->ext.et38.unk89 * 0xC0);
+                self->ext.wargpuff.unk84 =
+                    (u16)self->ext.wargpuff.unk84 +
+                    ((u8)self->ext.wargpuff.unk89 * 0xC0);
                 break;
             }
-            self->ext.et38.unk84 = self->ext.et38.unk84 & 0xFFF;
+            self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
             self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
             temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
             temp_s0 /= 28;
-            self->velocityX = temp_s0 * rsin(self->ext.et38.unk84);
-            self->velocityY = -(temp_s0 * rcos(self->ext.et38.unk84));
+            self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
+            self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));
             self->step_s++;
         }
 
@@ -1399,7 +1401,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->velocityY = velocityY - (adjVelocityY >> 2);
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;
@@ -1414,7 +1416,7 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
             self->step_s++;
         }
         MoveEntity();
-        if (AnimateEntity((u8*)self->ext.et38.unk80, self) == 0) {
+        if (AnimateEntity((u8*)self->ext.wargpuff.unk80, self) == 0) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/nz0/311C0.c
+++ b/src/st/nz0/311C0.c
@@ -1375,8 +1375,8 @@ void EntityWargExplosionPuffOpaque(Entity* self) {
                 break;
             }
             self->ext.wargpuff.unk84 = self->ext.wargpuff.unk84 & 0xFFF;
-            self->rotZ = self->ext.generic.unk84.S16.unk0 & 0xFFF;
-            temp_s0 = self->ext.generic.unk88.U8.unk1 * 0x140;
+            self->rotZ = self->ext.wargpuff.unk84 & 0xFFF;
+            temp_s0 = self->ext.wargpuff.unk89 * 0x140;
             temp_s0 /= 28;
             self->velocityX = temp_s0 * rsin(self->ext.wargpuff.unk84);
             self->velocityY = -(temp_s0 * rcos(self->ext.wargpuff.unk84));

--- a/src/st/nz0/gaibon.c
+++ b/src/st/nz0/gaibon.c
@@ -527,7 +527,7 @@ void EntityGaibon(Entity* self) {
                 func_801C29B0(NA_SE_EN_GAIBON_FLAME);
                 other = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (other != NULL) {
-                    CreateEntityFromEntity(E_FIRE, self, other);
+                    CreateEntityFromEntity(E_WARG_EXP_OPAQUE, self, other);
                     other->posY.i.hi += 28;
                     // Scatter bones randomly between +- 32
                     other->posX.i.hi += ((Random() & 63) - 32);

--- a/src/st/nz0/nz0.h
+++ b/src/st/nz0/nz0.h
@@ -30,7 +30,7 @@ typedef enum {
     /* 0x31 */ E_SPITTLEBONE = 0x31,
     /* 0x32 */ E_ROTATE_SPITTLEBONE,
     /* 0x33 */ E_SPITTLEBONE_SPIT,
-    /* 0x38 */ E_FIRE = 0x38,
+    /* 0x38 */ E_WARG_EXP_OPAQUE = 0x38,
     /* 0x3F */ E_BOSS_ROOM_BLOCK = 0x3F,
     /* 0x40 */ E_SLOGRA,
     /* 0x41 */ E_SLOGRA_SPEAR,


### PR DESCRIPTION
Main changes here involve renaming the Ext member from `et38` to `wargpuff` which seems more descriptive.

Also added entity ID numbers across the overlays, to be used in the function right before the warg puff function, which spawns the warg puffs with a call to `CreateEntityFromEntity`.