### PR TITLE
Rename unknown members of Zombie Spawner struct

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -1463,10 +1463,10 @@ typedef struct {
 
 typedef struct {
     /* 0x7C */ s32 : 32;
-    /* 0x80 */ s16 unk80;
+    /* 0x80 */ s16 spawnDelay;
     /* 0x82 */ s16 : 16;
     /* 0x84 */ s32 : 32;
-    /* 0x88 */ s32 unk88;
+    /* 0x88 */ s32 spawnSide;
 } ET_ZombieSpawner;
 
 typedef union { // offset=0x7C

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -90,25 +90,25 @@ void EntityZombieSpawner(Entity* self) {
 
     if (self->step == 0) {
         InitializeEntity(D_80180AD0);
-        self->ext.zombieSpawner.unk80 = 1;
+        self->ext.zombieSpawner.spawnDelay = 1;
         self->flags &= FLAG_UNK_2000;
     }
 
     if (g_CastleFlags[0x37]) {
         self->posX.i.hi = 128;
-        if (--self->ext.zombieSpawner.unk80 == 0) {
+        if (--self->ext.zombieSpawner.spawnDelay == 0) {
             newEntity = AllocEntity(g_Entities + 160, g_Entities + 168);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_ZOMBIE, self, newEntity);
                 rnd = (Random() & 0x3F) + 96;
 
-                if (self->ext.zombieSpawner.unk88 != 0) {
+                if (self->ext.zombieSpawner.spawnSide != 0) {
                     newEntity->posX.i.hi += rnd;
                 } else {
                     newEntity->posX.i.hi -= rnd;
                 }
                 newEntity->posY.i.hi -= 48;
-                self->ext.zombieSpawner.unk88 ^= 1;
+                self->ext.zombieSpawner.spawnSide ^= 1;
 
                 // Zombies are prevented from spawning too close to the
                 // edges of the room.
@@ -119,7 +119,7 @@ void EntityZombieSpawner(Entity* self) {
                     DestroyEntity(newEntity);
                 }
             }
-            self->ext.zombieSpawner.unk80 = (Random() & 0x3F) + 32;
+            self->ext.zombieSpawner.spawnDelay = (Random() & 0x3F) + 32;
         }
     }
 }

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -90,25 +90,25 @@ void EntityZombieSpawner(Entity* self) {
 
     if (self->step == 0) {
         InitializeEntity(D_80180A60);
-        self->ext.zombieSpawner.unk80 = 1;
+        self->ext.zombieSpawner.spawnDelay = 1;
         self->flags &= FLAG_UNK_2000;
     }
 
     if (g_CastleFlags[0x37]) {
         self->posX.i.hi = 128;
-        if (--self->ext.zombieSpawner.unk80 == 0) {
+        if (--self->ext.zombieSpawner.spawnDelay == 0) {
             newEntity = AllocEntity(g_Entities + 160, g_Entities + 168);
             if (newEntity != NULL) {
                 CreateEntityFromEntity(E_ZOMBIE, self, newEntity);
                 rnd = (Random() & 0x3F) + 96;
 
-                if (self->ext.zombieSpawner.unk88 != 0) {
+                if (self->ext.zombieSpawner.spawnSide != 0) {
                     newEntity->posX.i.hi += rnd;
                 } else {
                     newEntity->posX.i.hi -= rnd;
                 }
                 newEntity->posY.i.hi -= 48;
-                self->ext.zombieSpawner.unk88 ^= 1;
+                self->ext.zombieSpawner.spawnSide ^= 1;
 
                 // Zombies are prevented from spawning too close to the
                 // edges of the room.
@@ -119,7 +119,7 @@ void EntityZombieSpawner(Entity* self) {
                     DestroyEntity(newEntity);
                 }
             }
-            self->ext.zombieSpawner.unk80 = (Random() & 0x3F) + 32;
+            self->ext.zombieSpawner.spawnDelay = (Random() & 0x3F) + 32;
         }
     }
 }


### PR DESCRIPTION
A minor PR that only aims to give a meaningful name to two of the unknown variables in the `ET_ZombieSpawner` struct:
- `spawnDelay`: Number of frames until the next time the Zombie Spawner will attempt to spawn another zombie
- `spawnSide`: Which side of the player the Zombie Spawner will attempt to spawn the next zombie (zero for left, non-zero for right)