### PR TITLE
Decompile `SetVertex` functions in `reg03.c`

### DIFF
--- a/include/psxsdk/libgte.h
+++ b/include/psxsdk/libgte.h
@@ -105,6 +105,16 @@ extern long ratan2(long y, long x);
                      "lwc2	$1, 4( %0 )"                                        \
                      :                                                         \
                      : "r"(r0))
+#define gte_ldv1(r0)                                                           \
+    __asm__ volatile("lwc2	$2, 0( %0 );"                                       \
+                     "lwc2	$3, 4( %0 )"                                        \
+                     :                                                         \
+                     : "r"(r0))
+#define gte_ldv2(r0)                                                           \
+    __asm__ volatile("lwc2	$4, 0( %0 );"                                       \
+                     "lwc2	$5, 4( %0 )"                                        \
+                     :                                                         \
+                     : "r"(r0))
 
 // NOTE: These are not the official defines in the SDK.
 // They were identified by looking at functions which used them.

--- a/src/main/psxsdk/libgte/reg03.c
+++ b/src/main/psxsdk/libgte/reg03.c
@@ -1,12 +1,17 @@
 #include "common.h"
+#include "psxsdk/libgte.h"
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex0);
+void SetVertex0(SVECTOR* vector) { gte_ldv0(vector); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex1);
+void SetVertex1(SVECTOR* vector) { gte_ldv1(vector); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertex2);
+void SetVertex2(SVECTOR* vector) { gte_ldv2(vector); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetVertexTri);
+void SetVertexTri(SVECTOR* vector1, SVECTOR* vector2, SVECTOR* vector3) {
+    gte_ldv0(vector1);
+    gte_ldv1(vector2);
+    gte_ldv2(vector3);
+}
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetRGBfifo);
 


### PR DESCRIPTION
Based this off other Josh's work on https://decomp.me/scratch/ncrbI

Noticed there was already a define in `libgte.h` for Vector0 which I've used, but also filled out the other two.

Hope this is ok for a first PR 😄 
Let me know if anything needs changing.