### PR TITLE
Decompile remaining functions in `libgte` `reg03.c`

### DIFF
--- a/include/psxsdk/libgte.h
+++ b/include/psxsdk/libgte.h
@@ -116,6 +116,17 @@ extern long ratan2(long y, long x);
                      :                                                         \
                      : "r"(r0))
 
+#define gte_ldv3(r0, r1, r2)                                                   \
+    __asm__ volatile(                                                          \
+        "lwc2	$0, 0( %0 );"                                                    \
+        "lwc2	$1, 4( %0 );"                                                    \
+        "lwc2	$2, 0( %1 );"                                                    \
+        "lwc2	$3, 4( %1 );"                                                    \
+        "lwc2	$4, 0( %2 );"                                                    \
+        "lwc2	$5, 4( %2 )"                                                     \
+        :                                                                      \
+        : "r"(r0), "r"(r1), "r"(r2))
+
 // NOTE: These are not the official defines in the SDK.
 // They were identified by looking at functions which used them.
 #define gte_rtps()                                                             \
@@ -142,17 +153,6 @@ extern long ratan2(long y, long x);
         :                                                                      \
         : "r"(r0)                                                              \
         : "$12", "memory")
-
-#define gte_ldv3(r0, r1, r2)                                                   \
-    __asm__ volatile(                                                          \
-        "lwc2	$0, 0( %0 );"                                                    \
-        "lwc2	$1, 4( %0 );"                                                    \
-        "lwc2	$2, 0( %1 );"                                                    \
-        "lwc2	$3, 4( %1 );"                                                    \
-        "lwc2	$4, 0( %2 );"                                                    \
-        "lwc2	$5, 4( %2 )"                                                     \
-        :                                                                      \
-        : "r"(r0), "r"(r1), "r"(r2))
 
 #define gte_stopz(r0)                                                          \
     __asm__ volatile("swc2	$24, 0( %0 )" : : "r"(r0) : "memory")
@@ -201,6 +201,59 @@ extern long ratan2(long y, long x);
         : "$12", "$13", "$14")
 
 #define gte_SetGeomScreen(r0) __asm__ volatile("ctc2	%0, $26" : : "r"(r0))
+
+#define gte_SetRGBfifo(r, g, b)                                                \
+    __asm__ volatile("lwc2   $20, 0( %0 );"                                    \
+                     "lwc2   $21, 0( %1 );"                                    \
+                     "lwc2   $22, 0( %2 )"                                     \
+                     :                                                         \
+                     : "r"(r), "r"(g), "r"(b))
+
+#define gte_lddp(r0) __asm__ volatile("mtc2	%0, $8" : : "r"(r0))
+
+#define gte_SetIR123(r0, r1, r2)                                               \
+    __asm__ volatile("mtc2	%0, $9;"                                            \
+                     "mtc2	%1, $10;"                                           \
+                     "mtc2	%2, $11"                                            \
+                     :                                                         \
+                     : "r"(r0), "r"(r1), "r"(r2))
+
+#define gte_ldsz3(r0, r1, r2)                                                  \
+    __asm__ volatile("mtc2	%0, $17;"                                           \
+                     "mtc2	%1, $18;"                                           \
+                     "mtc2	%2, $19"                                            \
+                     :                                                         \
+                     : "r"(r0), "r"(r1), "r"(r2))
+
+#define gte_ldsz4(r0, r1, r2, r3)                                              \
+    __asm__ volatile(                                                          \
+        "mtc2	%0, $16;"                                                        \
+        "mtc2	%1, $17;"                                                        \
+        "mtc2	%2, $18;"                                                        \
+        "mtc2	%3, $19"                                                         \
+        :                                                                      \
+        : "r"(r0), "r"(r1), "r"(r2), "r"(r3))
+
+#define gte_ldsxy3(r0, r1, r2)                                                 \
+    __asm__ volatile("mtc2	%0, $12;"                                           \
+                     "mtc2	%1, $13;"                                           \
+                     "mtc2	%2, $14"                                            \
+                     :                                                         \
+                     : "r"(r0), "r"(r1), "r"(r2))
+
+#define gte_SetRii(r0, r1, r2)                                                 \
+    __asm__ volatile("ctc2	%0, $0;"                                            \
+                     "ctc2	%1, $2;"                                            \
+                     "ctc2	%2, $4"                                             \
+                     :                                                         \
+                     : "r"(r0), "r"(r1), "r"(r2))
+
+#define gte_SetMAC123(r0, r1, r2)                                              \
+    __asm__ volatile("mtc2	%0, $25;"                                           \
+                     "mtc2	%1, $26;"                                           \
+                     "mtc2	%2, $27"                                            \
+                     :                                                         \
+                     : "r"(r0), "r"(r1), "r"(r2))
 
 #else
 

--- a/src/main/psxsdk/libgte/reg03.c
+++ b/src/main/psxsdk/libgte/reg03.c
@@ -8,29 +8,31 @@ void SetVertex1(SVECTOR* vector) { gte_ldv1(vector); }
 void SetVertex2(SVECTOR* vector) { gte_ldv2(vector); }
 
 void SetVertexTri(SVECTOR* vector1, SVECTOR* vector2, SVECTOR* vector3) {
-    gte_ldv0(vector1);
-    gte_ldv1(vector2);
-    gte_ldv2(vector3);
+    gte_ldv3(vector1, vector2, vector3);
 }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetRGBfifo);
+void SetRGBfifo(u_char r, u_char g, u_char b) { gte_SetRGBfifo(r, g, b); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetIR123);
+void SetIR123(u32 arg0, u32 arg1, u32 arg3) { gte_SetIR123(arg0, arg1, arg3); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetIR0);
+void SetIR0(u32 arg0) { gte_lddp(arg0); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo3);
+void SetSZfifo3(u32 arg0, u32 arg1, u32 arg3) { gte_ldsz3(arg0, arg1, arg3); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSZfifo4);
+void SetSZfifo4(u32 arg0, u32 arg1, u32 arg3, u32 arg4) {
+    gte_ldsz4(arg0, arg1, arg3, arg4);
+}
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetSXSYfifo);
+void SetSXSYfifo(u32 arg0, u32 arg1, u32 arg3) { gte_ldsxy3(arg0, arg1, arg3); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetRii);
+void SetRii(u32 arg0, u32 arg1, u32 arg3) { gte_SetRii(arg0, arg1, arg3); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetMAC123);
+void SetMAC123(u32 arg0, u32 arg1, u32 arg3) {
+    gte_SetMAC123(arg0, arg1, arg3);
+}
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetData32);
+void SetData32(void) { __asm__("mtc2 $a0, $30"); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetDQA);
+void SetDQA(void) { __asm__("ctc2 $a0, $27"); }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgte/reg03", SetDQB);
+void SetDQB(void) { __asm__("ctc2 $a0, $28"); }


### PR DESCRIPTION
* SetRGBfifo
* SetIR123
* SetIR0
  * Named this what I think is the same function [gte_lddp](https://github.com/Xeeynamo/sotn-decomp/blob/20652c255c368a112ea9de6c09474b1a3be59e16/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h#L144) in Psycross
* SetSZfifo3
  * Named this what I think is the same function [gte_ldsz3](https://github.com/Xeeynamo/sotn-decomp/blob/20652c255c368a112ea9de6c09474b1a3be59e16/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h#L172) in Psycross
* SetSZfifo4
  * Named this what I think is the same function [gte_ldsz4](https://github.com/Xeeynamo/sotn-decomp/blob/20652c255c368a112ea9de6c09474b1a3be59e16/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h#L180) in Psycross
* SetSXSYfifo
  * Named this what I think is the same function [gte_ldsxy3](https://github.com/Xeeynamo/sotn-decomp/blob/20652c255c368a112ea9de6c09474b1a3be59e16/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h#L156) in Psycross
* SetRii
* SetMAC123
* SetData32
* SetDQA
* SetDQB

The others did not seem to have an obvious equivalent in Psycross