### PR TITLE
 Create enum for g_CastleFlags 

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1810,34 +1810,38 @@ extern u8 g_CastleFlags[0x300]; // starts at 0x8003BDEC
 typedef enum {
     CLOCK_ROOM_DOORS, // opened by gold and silver ring; drops down to CEN
     CASTLE_FLAG_2 = 2,
-    CASTLE_FLAG_19 = 19,
+    CASTLE_FLAG_19 = 19, // Randomized by g_RandomizeCastleFlag13; unused
+    // Start NO3/NP3 flags
     CASTLE_FLAG_48 = 48,
     CASTLE_FLAG_49,
     CASTLE_FLAG_50,
     JEWEL_SWORD_ROOM,
     CASTLE_FLAG_52,
     CASTLE_FLAG_53,
-    CASTLE_FLAG_54,
+    CASTLE_FLAG_54, // Unused
     CASTLE_FLAG_55,
     DEATH_STAIRWAY_BROKEN, // Piece of stairs right before Death room
-    SG_RETR_ENTR,        // Slogra/Gaibon retreated from Entrance encounter
+    SG_RETR_ENTR,          // Slogra/Gaibon retreated from Entrance encounter
     CASTLE_FLAG_58,
-    CASTLE_FLAG_98 = 98,
-    CASTLE_FLAG_99,
+    CASTLE_FLAG_98 = 98, // Set in DRA, unused
+    CASTLE_FLAG_99,      // Set in DRA, unused
+    // Start NZ0 flags
     CASTLE_FLAG_129 = 129,
     CASTLE_FLAG_130,
     CASTLE_FLAG_131,
-    SG_KILL_ALCH,  // Slogra & Gaibon were killed in Alchemy Lab
+    SG_KILL_ALCH, // Slogra & Gaibon were killed in Alchemy Lab
     CASTLE_FLAG_133,
     CASTLE_FLAG_149 = 149,
     CASTLE_FLAG_150,
     CASTLE_FLAG_155 = 155,
     CASTLE_FLAG_185 = 185,
+    // WRP
     CASTLE_FLAG_208 = 208,
+    // RWRP
     CASTLE_FLAG_209,
     // Cutscenes the player has finished seeing
     SUCC_CS_DONE = 212, // Succubus cutscene (as Lisa)
-    HG_CS_DONE = 216, // Holy Glasses cutscene (in CEN)
+    HG_CS_DONE = 216,   // Holy Glasses cutscene (in CEN)
     HEART_FLAGS_START = 256,
     MAD_COLLISION_FLAGS_START = 288,
     MAD_RAREDROP_FLAGS_START = 320,

--- a/include/game.h
+++ b/include/game.h
@@ -1807,6 +1807,44 @@ extern s32 g_IsTimeAttackUnlocked;
 // prevents the player to enter in the warp room. When g_CastleFlags[0x32] the
 // column will disappear.
 extern u8 g_CastleFlags[0x300]; // starts at 0x8003BDEC
+typedef enum {
+    CLOCK_ROOM_DOORS, // opened by gold and silver ring; drops down to CEN
+    CASTLE_FLAG_2 = 2,
+    CASTLE_FLAG_19 = 19,
+    CASTLE_FLAG_48 = 48,
+    CASTLE_FLAG_49,
+    CASTLE_FLAG_50,
+    JEWEL_SWORD_ROOM,
+    CASTLE_FLAG_52,
+    CASTLE_FLAG_53,
+    CASTLE_FLAG_54,
+    CASTLE_FLAG_55,
+    DEATH_STAIRWAY_BROKEN, // Piece of stairs right before Death room
+    SG_RETR_ENTR,        // Slogra/Gaibon retreated from Entrance encounter
+    CASTLE_FLAG_58,
+    CASTLE_FLAG_98 = 98,
+    CASTLE_FLAG_99,
+    CASTLE_FLAG_129 = 129,
+    CASTLE_FLAG_130,
+    CASTLE_FLAG_131,
+    SG_KILL_ALCH,  // Slogra & Gaibon were killed in Alchemy Lab
+    CASTLE_FLAG_133,
+    CASTLE_FLAG_149 = 149,
+    CASTLE_FLAG_150,
+    CASTLE_FLAG_155 = 155,
+    CASTLE_FLAG_185 = 185,
+    CASTLE_FLAG_208 = 208,
+    CASTLE_FLAG_209,
+    // Cutscenes the player has finished seeing
+    SUCC_CS_DONE = 212, // Succubus cutscene (as Lisa)
+    HG_CS_DONE = 216, // Holy Glasses cutscene (in CEN)
+    HEART_FLAGS_START = 256,
+    MAD_COLLISION_FLAGS_START = 288,
+    MAD_RAREDROP_FLAGS_START = 320,
+    COLLISION_FLAGS_START = 400,
+    COLLECT_FLAGS_START = 432,
+} CastleFlagOffsets;
+
 extern s32 D_8003C0EC[4];
 extern s32 D_8003C0F8;
 extern s32 D_8003C100;

--- a/src/boss/mar/17FEC.c
+++ b/src/boss/mar/17FEC.c
@@ -499,7 +499,6 @@ extern s16 D_us_80181298[];
 // Stone doors on the floor leading to CEN Entity ID 0x1B
 void EntityStoneDoor(Entity* self) {
     u16 params = self->params;
-    const int centerCubeDoor = 0;
 
     switch (self->step) {
     case 0:
@@ -507,7 +506,7 @@ void EntityStoneDoor(Entity* self) {
         self->animSet = ANIMSET_OVL(1);
         self->animCurFrame = params + 27;
         self->zPriority = 0x40;
-        if (g_CastleFlags[centerCubeDoor] == 0) {
+        if (g_CastleFlags[CLOCK_ROOM_DOORS] == 0) {
             self->posX.i.hi += D_us_80181294[params];
             UpdateStoneDoorTiles(true);
         } else {
@@ -515,17 +514,17 @@ void EntityStoneDoor(Entity* self) {
             UpdateStoneDoorTiles(false);
         }
         self->posY.i.hi += 88;
-        self->ext.stoneDoor.flag = g_CastleFlags[centerCubeDoor];
+        self->ext.stoneDoor.flag = g_CastleFlags[CLOCK_ROOM_DOORS];
         break;
 
     case 1:
         if (self->ext.stoneDoor.flag == NULL) {
-            if (g_CastleFlags[centerCubeDoor]) {
+            if (g_CastleFlags[CLOCK_ROOM_DOORS]) {
                 self->ext.stoneDoor.unk80 = 0;
                 self->step++;
             }
         }
-        self->ext.stoneDoor.flag = g_CastleFlags[centerCubeDoor];
+        self->ext.stoneDoor.flag = g_CastleFlags[CLOCK_ROOM_DOORS];
         break;
 
     case 2:

--- a/src/dra/loading.c
+++ b/src/dra/loading.c
@@ -493,7 +493,7 @@ void HandleNowLoading(void) {
         }
         if (g_StageId == STAGE_NO3 && g_PlayableCharacter != PLAYER_ALUCARD) {
             D_8006C374 = 0x11;
-            g_CastleFlags[0x34] = 1;
+            g_CastleFlags[CASTLE_FLAG_52] = 1;
         }
         D_800978C4 = 1;
         SetGameState(Game_Play);

--- a/src/dra/play.c
+++ b/src/dra/play.c
@@ -93,15 +93,15 @@ void HandlePlay(void) {
             for (i = 0; i < LEN(g_CastleFlags); i++) {
                 g_CastleFlags[i] = 0;
             }
-            g_CastleFlags[0xB9] = 1;
-            g_CastleFlags[0x9B] = 1;
+            g_CastleFlags[CASTLE_FLAG_185] = 1;
+            g_CastleFlags[CASTLE_FLAG_155] = 1;
             if (g_PlayableCharacter != 0) {
-                g_CastleFlags[0x35] = 1;
-                g_CastleFlags[0x62] = 1;
-                g_CastleFlags[0x63] = 1;
-                g_CastleFlags[0x85] = 1;
-                g_CastleFlags[0x95] = 1;
-                g_CastleFlags[0x96] = 1;
+                g_CastleFlags[CASTLE_FLAG_53] = 1;
+                g_CastleFlags[CASTLE_FLAG_98] = 1;
+                g_CastleFlags[CASTLE_FLAG_99] = 1;
+                g_CastleFlags[CASTLE_FLAG_133] = 1;
+                g_CastleFlags[CASTLE_FLAG_149] = 1;
+                g_CastleFlags[CASTLE_FLAG_150] = 1;
             }
 
             for (i = 0, ptr = &g_MenuNavigation; i < sizeof(MenuNavigation);
@@ -179,8 +179,8 @@ void HandlePlay(void) {
         DestroyAllPrimitives();
         func_800EDAE4();
         func_801024DC();
-        if (g_CastleFlags[0x13] & 0x80) {
-            g_CastleFlags[0x13] = g_RandomizeCastleFlag13[rand() & 0xF] + 0x80;
+        if (g_CastleFlags[CASTLE_FLAG_19] & 0x80) {
+            g_CastleFlags[CASTLE_FLAG_19] = g_RandomizeCastleFlag13[rand() & 0xF] + 0x80;
         }
         g_GameStep++;
         break;

--- a/src/dra/play.c
+++ b/src/dra/play.c
@@ -180,7 +180,8 @@ void HandlePlay(void) {
         func_800EDAE4();
         func_801024DC();
         if (g_CastleFlags[CASTLE_FLAG_19] & 0x80) {
-            g_CastleFlags[CASTLE_FLAG_19] = g_RandomizeCastleFlag13[rand() & 0xF] + 0x80;
+            g_CastleFlags[CASTLE_FLAG_19] =
+                g_RandomizeCastleFlag13[rand() & 0xF] + 0x80;
         }
         g_GameStep++;
         break;

--- a/src/st/cen/F890.c
+++ b/src/st/cen/F890.c
@@ -91,7 +91,7 @@ void EntityPlatform(Entity* self) {
             self->animCurFrame = 9;
             self->zPriority = 0x80;
 
-            if (g_CastleFlags[216] != 0) {
+            if (g_CastleFlags[HG_CS_DONE] != 0) {
                 self->step = 9;
             }
 
@@ -276,7 +276,7 @@ void EntityRoomDarkness(Entity* self) {
     switch (self->step) {
     case 0:
         /* Has player seen Maria Holy Glasses Cutscene? */
-        if (g_CastleFlags[216] != 0) {
+        if (g_CastleFlags[HG_CS_DONE] != 0) {
             DestroyEntity(self);
             return;
         }
@@ -348,7 +348,7 @@ void EntityRoomDarkness(Entity* self) {
 void EntityMaria(Entity* self) {
     if (self->step == 0) {
         /* Has player seen Maria Holy Glasses Cutscene? */
-        if (g_CastleFlags[216] != 0) {
+        if (g_CastleFlags[HG_CS_DONE] != 0) {
             DestroyEntity(self);
             return;
         }

--- a/src/st/cen/entity_heart_drop.c
+++ b/src/st/cen/entity_heart_drop.c
@@ -10,7 +10,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0xC0;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -29,7 +29,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/cen/entity_heart_drop.c
+++ b/src/st/cen/entity_heart_drop.c
@@ -29,7 +29,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/cen/holyglassescutscene.c
+++ b/src/st/cen/holyglassescutscene.c
@@ -232,7 +232,7 @@ void EntityHolyGlassesCutscene(Entity* self) {
     }
     switch (self->step) {
     case 0:
-        if (g_CastleFlags[216] != 0) {
+        if (g_CastleFlags[HG_CS_DONE] != 0) {
             DestroyEntity(self);
             return;
         }
@@ -667,7 +667,7 @@ void EntityHolyGlassesCutscene(Entity* self) {
 
     case 7:
         DestroyEntity(self);
-        g_CastleFlags[216] = 1;
+        g_CastleFlags[HG_CS_DONE] = 1;
         g_api.TimeAttackController(
             TIMEATTACK_EVENT_GET_HOLYGLASSES, TIMEATTACK_SET_RECORD);
         D_8003C704 = 0;

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -349,7 +349,7 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + 0x190] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |= miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -349,7 +349,8 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |=
+                        miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {

--- a/src/st/dre/entity_heart_drop.c
+++ b/src/st/dre/entity_heart_drop.c
@@ -9,7 +9,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0x118;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -28,7 +28,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/dre/entity_heart_drop.c
+++ b/src/st/dre/entity_heart_drop.c
@@ -28,7 +28,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -81,7 +81,6 @@ typedef enum {
 extern s32 D_80180660; // clones counter
 
 void EntitySuccubus(Entity* self) {
-    const int SeenCutscene = 212;
     u8* clonesShootOrder;
     s32 sideToPlayer;
     Entity* entity;
@@ -113,7 +112,7 @@ void EntitySuccubus(Entity* self) {
         CreateEntityFromCurrentEntity(E_SUCCUBUS_WING_OVERLAY, &self[1]);
 
     case SUCCUBUS_CS_1: // Disguised as Lisa
-        if (g_CastleFlags[SeenCutscene] || (g_DemoMode != Demo_None)) {
+        if (g_CastleFlags[SUCC_CS_DONE] || (g_DemoMode != Demo_None)) {
             self->facingLeft = 0;
             self->posX.i.hi = 416 - g_Tilemap.scrollX.i.hi;
             self->posY.i.hi = 175 - g_Tilemap.scrollY.i.hi;

--- a/src/st/dre/succubuscutscene.c
+++ b/src/st/dre/succubuscutscene.c
@@ -206,7 +206,8 @@ void EntitySuccubusCutscene(Entity* self) {
     }
     switch (self->step) {
     case 0:
-        if ((g_CastleFlags[SUCC_CS_DONE]) || (g_PlayableCharacter != PLAYER_ALUCARD) ||
+        if ((g_CastleFlags[SUCC_CS_DONE]) ||
+            (g_PlayableCharacter != PLAYER_ALUCARD) ||
             (g_DemoMode != Demo_None)) {
             if (!self->params) {
                 DestroyEntity(self);

--- a/src/st/dre/succubuscutscene.c
+++ b/src/st/dre/succubuscutscene.c
@@ -206,7 +206,7 @@ void EntitySuccubusCutscene(Entity* self) {
     }
     switch (self->step) {
     case 0:
-        if ((g_CastleFlags[212]) || (g_PlayableCharacter != PLAYER_ALUCARD) ||
+        if ((g_CastleFlags[SUCC_CS_DONE]) || (g_PlayableCharacter != PLAYER_ALUCARD) ||
             (g_DemoMode != Demo_None)) {
             if (!self->params) {
                 DestroyEntity(self);
@@ -227,7 +227,7 @@ void EntitySuccubusCutscene(Entity* self) {
             self->primIndex = g_Dialogue.primIndex[2];
             self->step++;
         }
-        if ((g_CastleFlags[212] != 0) ||
+        if ((g_CastleFlags[SUCC_CS_DONE] != 0) ||
             (g_PlayableCharacter != PLAYER_ALUCARD) ||
             (g_DemoMode != Demo_None)) {
             D_801A3ED4 = 1;
@@ -654,7 +654,7 @@ void EntitySuccubusCutscene(Entity* self) {
 
     case 7:
         if (self->params) {
-            g_CastleFlags[212] = 1;
+            g_CastleFlags[SUCC_CS_DONE] = 1;
             g_Settings.D_8003CB04 |= 0x2000;
         } else {
             g_Settings.D_8003CB04 |= 0x1000;

--- a/src/st/e_collect.h
+++ b/src/st/e_collect.h
@@ -373,7 +373,7 @@ void EntityPrizeDrop(Entity* self) {
             index = self->ext.equipItemDrop.castleFlag;
             if (index) {
                 index--;
-                g_CastleFlags[(index >> 3) + 0x1b0] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
             }
 #endif
         }
@@ -669,7 +669,7 @@ void EntityEquipItemDrop(Entity* self) {
         index = self->ext.equipItemDrop.castleFlag;
         if (index) {
             index--;
-            g_CastleFlags[(index >> 3) + 0x1b0] |= 1 << (index & 7);
+            g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
         }
 #endif
         primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);

--- a/src/st/e_collect.h
+++ b/src/st/e_collect.h
@@ -373,7 +373,8 @@ void EntityPrizeDrop(Entity* self) {
             index = self->ext.equipItemDrop.castleFlag;
             if (index) {
                 index--;
-                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |=
+                    1 << (index & 7);
             }
 #endif
         }
@@ -669,7 +670,8 @@ void EntityEquipItemDrop(Entity* self) {
         index = self->ext.equipItemDrop.castleFlag;
         if (index) {
             index--;
-            g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
+            g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |=
+                1 << (index & 7);
         }
 #endif
         primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);

--- a/src/st/e_misc.h
+++ b/src/st/e_misc.h
@@ -36,7 +36,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/e_misc.h
+++ b/src/st/e_misc.h
@@ -17,7 +17,7 @@ void EntityHeartDrop(Entity* self) {
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 =
             self->params + 0x118 + CASTLE_FLAG_BANK;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -36,7 +36,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -7,7 +7,8 @@ void EntityHeartDrop(Entity* self) {
 
     if (self->step == 0) {
         index = self->ext.heartDrop.unkB4 = self->params;
-        if ((g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7)) & 1) {
+        if ((g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7)) &
+            1) {
             DestroyEntity(self);
             return;
         }
@@ -24,7 +25,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/mad/15520.c
+++ b/src/st/mad/15520.c
@@ -7,7 +7,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (self->step == 0) {
         index = self->ext.heartDrop.unkB4 = self->params;
-        if ((g_CastleFlags[(index >> 3) + 0x100] >> (index & 7)) & 1) {
+        if ((g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7)) & 1) {
             DestroyEntity(self);
             return;
         }
@@ -24,7 +24,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -286,7 +286,7 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + 0x120] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) + MAD_COLLISION_FLAGS_START] |= miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {
@@ -494,7 +494,7 @@ void HitDetection(void) {
                                         miscVar1--;
                                         flaggy_flags = (1 << (miscVar1 & 7));
                                         g_CastleFlags[(miscVar1 >> 3) +
-                                                      0x140] |= flaggy_flags;
+                                                      MAD_RAREDROP_FLAGS_START] |= flaggy_flags;
                                     }
                                 } else {
                                     miscVar3 -= sp3C->rareItemDropRate;

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -286,7 +286,8 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + MAD_COLLISION_FLAGS_START] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) +
+                                  MAD_COLLISION_FLAGS_START] |= miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {
@@ -493,8 +494,10 @@ void HitDetection(void) {
                                     if (miscVar1) {
                                         miscVar1--;
                                         flaggy_flags = (1 << (miscVar1 & 7));
-                                        g_CastleFlags[(miscVar1 >> 3) +
-                                                      MAD_RAREDROP_FLAGS_START] |= flaggy_flags;
+                                        g_CastleFlags
+                                            [(miscVar1 >> 3) +
+                                             MAD_RAREDROP_FLAGS_START] |=
+                                            flaggy_flags;
                                     }
                                 } else {
                                     miscVar3 -= sp3C->rareItemDropRate;

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -284,7 +284,7 @@ void EntityCastleDoor(Entity* self) {
             prim = prim->next;
             var_a0++;
         }
-        if (g_CastleFlags[52] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_52] != 0) {
             self->ext.castleDoor.rotZ = 0;
             self->step = 5;
         }
@@ -299,7 +299,7 @@ void EntityCastleDoor(Entity* self) {
         self->ext.castleDoor.rotZ = -0x380;
         self->ext.castleDoor.timer = 32;
         self->step = 4;
-        g_CastleFlags[52] = 1;
+        g_CastleFlags[CASTLE_FLAG_52] = 1;
         break;
 
     case 2:
@@ -748,7 +748,7 @@ void EntityCavernDoorLever(Entity* entity) {
         entity->rotZ = -0x200;
         entity->drawFlags |= FLAG_DRAW_ROTZ;
         CreateEntityFromEntity(0x1E, entity, &entity[1]);
-        if (g_CastleFlags[0x30] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_48] != 0) {
             entity->rotZ = 0;
         }
 
@@ -757,10 +757,10 @@ void EntityCavernDoorLever(Entity* entity) {
             entity->rotZ += 4;
             if (entity->rotZ > 0) {
                 entity->rotZ = 0;
-                if (g_CastleFlags[0x30] == 0) {
+                if (g_CastleFlags[CASTLE_FLAG_48] == 0) {
                     g_api.PlaySfx(SFX_LEVER_METAL_BANG);
                 }
-                g_CastleFlags[0x30] = 1;
+                g_CastleFlags[CASTLE_FLAG_48] = 1;
             } else if (!(g_Timer & 0xF)) {
                 g_api.PlaySfx(SFX_LEVER_METAL_BANG);
             }
@@ -821,7 +821,7 @@ void EntityCavernDoor(Entity* self) {
         self->zPriority = 0x9F;
 
         tileLayoutPtr = &D_80181230[0];
-        if (g_CastleFlags[48]) {
+        if (g_CastleFlags[CASTLE_FLAG_48]) {
             self->step = 128;
             self->animCurFrame = 0;
             tileLayoutPtr += 3;
@@ -854,7 +854,7 @@ void EntityCavernDoor(Entity* self) {
         break;
 
     case 1:
-        if (g_CastleFlags[48]) {
+        if (g_CastleFlags[CASTLE_FLAG_48]) {
             g_api.PlaySfx(SFX_SWITCH_CLICK);
             self->step++;
         }
@@ -962,7 +962,7 @@ void EntityClickSwitch(Entity* entity) {
         InitializeEntity(D_80180B18);
         entity->animCurFrame = 9;
         entity->zPriority = 0x5E;
-        if (g_CastleFlags[0x31] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             entity->step = 2;
             entity->posY.i.hi += 4;
         }
@@ -975,7 +975,7 @@ void EntityClickSwitch(Entity* entity) {
             if ((g_Tilemap.scrollY.i.hi + entity->posY.i.hi) > 160) {
                 entity->posY.i.hi = 160 - g_Tilemap.scrollY.i.hi;
                 g_api.PlaySfx(SFX_SWITCH_CLICK);
-                g_CastleFlags[0x31] = 1;
+                g_CastleFlags[CASTLE_FLAG_49] = 1;
                 entity->step++;
             }
         }
@@ -1019,14 +1019,14 @@ void EntityPathBlockSmallWeight(Entity* self) {
             poly = (POLY_GT4*)poly->tag;
         }
 
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step = 3;
             self->posY.i.hi += 111;
         }
         break;
 
     case 1:
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step++;
         }
         break;
@@ -1094,14 +1094,14 @@ void EntityPathBlockTallWeight(Entity* self) {
             poly = (POLY_GT4*)poly->tag;
         }
 
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step = 3;
             self->posY.i.hi -= 128;
         }
         break;
 
     case 1:
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step++;
         }
         break;
@@ -1180,7 +1180,6 @@ void EntityTrapDoor(Entity* entity) {
 
 // left side of the breakable rock, drops pot roast
 void EntityMermanRockLeftSide(Entity* self) {
-    const int jewelSwordRoomUnlock = 51;
     const int rockBroken = (1 << 0);
     const int wolfFlag = (1 << 2);
     u16* tileLayoutPtr;
@@ -1205,7 +1204,7 @@ void EntityMermanRockLeftSide(Entity* self) {
             tilePos += 0x30;
         }
 
-        if (g_CastleFlags[jewelSwordRoomUnlock] & rockBroken) {
+        if (g_CastleFlags[JEWEL_SWORD_ROOM] & rockBroken) {
             tileLayoutPtr = &D_80181264;
             tilePos = 0x1F1;
             for (i = 0; i < 3; i++) {
@@ -1262,7 +1261,7 @@ void EntityMermanRockLeftSide(Entity* self) {
                 CreateEntityFromEntity(E_EQUIP_ITEM_DROP, self, newEntity);
                 newEntity->params = ITEM_POT_ROAST;
             }
-            g_CastleFlags[jewelSwordRoomUnlock] |= rockBroken;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= rockBroken;
             self->hitboxState = 1;
             self->step++;
         }
@@ -1271,7 +1270,7 @@ void EntityMermanRockLeftSide(Entity* self) {
     case 2:
         if ((self->hitFlags != 0) &&
             (g_Player.unk0C & PLAYER_STATUS_WOLF_FORM)) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= wolfFlag;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= wolfFlag;
         }
         break;
     }
@@ -1279,7 +1278,6 @@ void EntityMermanRockLeftSide(Entity* self) {
 
 // right side of the merman room rock, breaks when hit
 void EntityMermanRockRightSide(Entity* self) {
-    const int jewelSwordRoomUnlock = 51;
     const int rockBroken = (1 << 1);
     const int batFlag = (1 << 3);
     u16* tileLayoutPtr;
@@ -1304,7 +1302,7 @@ void EntityMermanRockRightSide(Entity* self) {
             tilePos += 0x30;
         }
 
-        if (g_CastleFlags[jewelSwordRoomUnlock] & rockBroken) {
+        if (g_CastleFlags[JEWEL_SWORD_ROOM] & rockBroken) {
             tileLayoutPtr = &D_801812A0;
             tilePos = 0x1FD;
             for (i = 0; i < 3; i++) {
@@ -1357,7 +1355,7 @@ void EntityMermanRockRightSide(Entity* self) {
         }
 
         if (self->ext.generic.unk84.S16.unk0 >= 2) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= rockBroken;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= rockBroken;
             self->hitboxState = 1;
             self->step++;
         }
@@ -1366,7 +1364,7 @@ void EntityMermanRockRightSide(Entity* self) {
     case 2:
         if ((self->hitFlags != 0) &&
             (g_Player.unk0C & PLAYER_STATUS_BAT_FORM)) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= batFlag;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= batFlag;
         }
         break;
     }
@@ -1381,13 +1379,13 @@ void EntityUnkId26(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_EInitGeneric);
-        if (g_CastleFlags[58] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_58] != 0) {
             self->step = 2;
         }
         break;
 
     case 1:
-        if ((g_CastleFlags[51] & 12) == 12) {
+        if ((g_CastleFlags[JEWEL_SWORD_ROOM] & 12) == 12) {
             PlaySfxPositional(SFX_WALL_DEBRIS_B);
             self->step++;
         }
@@ -1409,7 +1407,7 @@ void EntityUnkId26(Entity* self) {
             }
         }
 
-        g_CastleFlags[58] |= 1;
+        g_CastleFlags[CASTLE_FLAG_58] |= 1;
         g_api.func_800F1FC4(0x3A);
         self->step++;
         break;
@@ -1472,7 +1470,6 @@ void EntityFallingRock2(Entity* self) {
 // ID 0x5C
 // Stairway piece you can break before Death encounter
 void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
-    const int stairwayPieceBroken = 56;
     Primitive *prim, *prim2, *prim3;
     Entity* newEntity;
     Collider collider;
@@ -1490,7 +1487,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         self->posX.i.hi = 1432 - g_Tilemap.scrollX.i.hi;
         self->posY.i.hi = 200 - g_Tilemap.scrollY.i.hi;
         self->hitPoints = 16;
-        if (g_CastleFlags[stairwayPieceBroken]) {
+        if (g_CastleFlags[DEATH_STAIRWAY_BROKEN]) {
             self->hitboxState = 0;
             g_Tilemap.fg[0x4D9] = 0x3EE;
             g_Tilemap.fg[0x539] = 0x3D2;
@@ -1516,7 +1513,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         g_api.PlaySfx(SFX_WALL_DEBRIS_B);
         g_Tilemap.fg[0x4D9] = 0x3EE;
         g_Tilemap.fg[0x539] = 0x3D2;
-        g_CastleFlags[stairwayPieceBroken] = true;
+        g_CastleFlags[DEATH_STAIRWAY_BROKEN] = true;
 
         newEntity = AllocEntity(&g_Entities[160], &g_Entities[192]);
         if (newEntity != NULL) {
@@ -1666,7 +1663,7 @@ void EntityDeathSkySwirl(Entity* self) {
     MATRIX mtx;
 
     if (self->step == 0) {
-        if (g_CastleFlags[53]) {
+        if (g_CastleFlags[CASTLE_FLAG_53]) {
             DestroyEntity(self);
             return;
         }
@@ -1757,7 +1754,7 @@ void EntitySwitch(Entity* entity) {
         InitializeEntity(D_80180B18);
         entity->animCurFrame = 9;
         entity->zPriority = 0x5E;
-        if (g_CastleFlags[0x32] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_50] != 0) {
             entity->step = 2;
             entity->posY.i.hi += 4;
         }
@@ -1769,7 +1766,7 @@ void EntitySwitch(Entity* entity) {
             entity->posY.val += FIX(0.25);
             if ((g_Tilemap.scrollY.i.hi + entity->posY.i.hi) > 193) {
                 entity->posY.i.hi = 193 - g_Tilemap.scrollY.i.hi;
-                g_CastleFlags[0x32] = 1;
+                g_CastleFlags[CASTLE_FLAG_50] = 1;
                 g_api.PlaySfx(SFX_STONE_MOVE_B);
                 entity->step++;
             }
@@ -1794,7 +1791,7 @@ void EntityHeartRoomGoldDoor(Entity* self) {
         self->animCurFrame = 37;
         self->zPriority = 0x5E;
 
-        if (g_CastleFlags[50] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_50] != 0) {
             for (
                 tilePos = 0x48, i = 7, self->step = 128, self->animCurFrame = 0;
                 i >= 0; tilePos += 0x10, i--) {
@@ -1832,7 +1829,7 @@ void EntityHeartRoomGoldDoor(Entity* self) {
         break;
 
     case 1:
-        if (g_CastleFlags[50] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_50] != 0) {
             g_api.PlaySfx(SFX_STONE_MOVE_A);
             self->step++;
         }

--- a/src/st/no3/3C4EC.c
+++ b/src/st/no3/3C4EC.c
@@ -88,7 +88,7 @@ void EntityCastleDoorTransition(Entity* entity) {
 
     switch (entity->step) {
     case 0:
-        if (g_CastleFlags[52]) {
+        if (g_CastleFlags[CASTLE_FLAG_52]) {
             DestroyEntity(entity);
             return;
         }

--- a/src/st/no3/564B0.c
+++ b/src/st/no3/564B0.c
@@ -95,7 +95,7 @@ void EntityZombieSpawner(Entity* self) {
         self->flags &= FLAG_UNK_2000;
     }
 
-    if (g_CastleFlags[0x37]) {
+    if (g_CastleFlags[CASTLE_FLAG_55]) {
         self->posX.i.hi = 128;
         if (--self->ext.zombieSpawner.spawnDelay == 0) {
             newEntity = AllocEntity(g_Entities + 160, g_Entities + 168);

--- a/src/st/no3/deathcutscene.c
+++ b/src/st/no3/deathcutscene.c
@@ -175,7 +175,8 @@ void EntityDeathCutscene(Entity* self) {
     switch (self->step) {
     case 0:
         CreateEntityFromCurrentEntity(E_BG_LIGHTNING, &g_Entities[192]);
-        if ((g_CastleFlags[CASTLE_FLAG_53]) || (g_PlayableCharacter != PLAYER_ALUCARD)) {
+        if ((g_CastleFlags[CASTLE_FLAG_53]) ||
+            (g_PlayableCharacter != PLAYER_ALUCARD)) {
             DestroyEntity(self);
             g_Entities[192].params = 0;
             return;

--- a/src/st/no3/deathcutscene.c
+++ b/src/st/no3/deathcutscene.c
@@ -175,7 +175,7 @@ void EntityDeathCutscene(Entity* self) {
     switch (self->step) {
     case 0:
         CreateEntityFromCurrentEntity(E_BG_LIGHTNING, &g_Entities[192]);
-        if ((g_CastleFlags[53]) || (g_PlayableCharacter != PLAYER_ALUCARD)) {
+        if ((g_CastleFlags[CASTLE_FLAG_53]) || (g_PlayableCharacter != PLAYER_ALUCARD)) {
             DestroyEntity(self);
             g_Entities[192].params = 0;
             return;
@@ -612,7 +612,7 @@ void EntityDeathCutscene(Entity* self) {
         break;
 
     case 7:
-        g_CastleFlags[53] = 1;
+        g_CastleFlags[CASTLE_FLAG_53] = 1;
         g_api.TimeAttackController(
             TIMEATTACK_EVENT_MEET_DEATH, TIMEATTACK_SET_RECORD);
         D_8003C704 = 0;

--- a/src/st/no3/entity_heart_drop.c
+++ b/src/st/no3/entity_heart_drop.c
@@ -27,7 +27,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/no3/entity_heart_drop.c
+++ b/src/st/no3/entity_heart_drop.c
@@ -8,7 +8,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0x30;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -27,7 +27,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/np3/32830.c
+++ b/src/st/np3/32830.c
@@ -32,7 +32,7 @@ void func_801B28E4(Entity* self) {
         InitializeEntity(g_EInitGeneric);
         self->ext.et_801B28E4.timer = 0x80;
         self->animCurFrame = 15;
-        g_CastleFlags[55] |= 1;
+        g_CastleFlags[CASTLE_FLAG_55] |= 1;
         if (self->params & FLAG_DEAD) {
             self->step = 4;
             return;
@@ -656,7 +656,7 @@ void EntityCavernDoorLever(Entity* entity) {
         entity->rotZ = -0x200;
         entity->drawFlags |= FLAG_DRAW_ROTZ;
         CreateEntityFromEntity(E_ID_1E, entity, &entity[1]);
-        if (g_CastleFlags[0x30] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_48] != 0) {
             entity->rotZ = 0;
         }
 
@@ -665,10 +665,10 @@ void EntityCavernDoorLever(Entity* entity) {
             entity->rotZ += 4;
             if (entity->rotZ > 0) {
                 entity->rotZ = 0;
-                if (g_CastleFlags[48] == 0) {
+                if (g_CastleFlags[CASTLE_FLAG_48] == 0) {
                     g_api.PlaySfx(SFX_LEVER_METAL_BANG);
                 }
-                g_CastleFlags[48] = 1;
+                g_CastleFlags[CASTLE_FLAG_48] = 1;
             } else if (!(g_Timer & 0xF)) {
                 g_api.PlaySfx(SFX_LEVER_METAL_BANG);
             }
@@ -732,7 +732,7 @@ void EntityCavernDoor(Entity* self) {
         self->zPriority = 0x9F;
 
         tileLayoutPtr = &D_801810F8[0];
-        if (g_CastleFlags[48]) {
+        if (g_CastleFlags[CASTLE_FLAG_48]) {
             self->step = 128;
             self->animCurFrame = 0;
             tileLayoutPtr += 3;
@@ -765,7 +765,7 @@ void EntityCavernDoor(Entity* self) {
         break;
 
     case 1:
-        if (g_CastleFlags[48]) {
+        if (g_CastleFlags[CASTLE_FLAG_48]) {
             // Missing line compared to NO3
             // g_api.PlaySfx(SFX_SWITCH_CLICK);
             self->step++;
@@ -879,7 +879,7 @@ void EntityClickSwitch(Entity* entity) {
         InitializeEntity(D_80180AA8);
         entity->animCurFrame = 9;
         entity->zPriority = 0x5E;
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             entity->step = 2;
             entity->posY.i.hi += 4;
         }
@@ -892,7 +892,7 @@ void EntityClickSwitch(Entity* entity) {
             if ((g_Tilemap.scrollY.i.hi + entity->posY.i.hi) > 160) {
                 entity->posY.i.hi = 160 - g_Tilemap.scrollY.i.hi;
                 g_api.PlaySfx(SFX_SWITCH_CLICK);
-                g_CastleFlags[49] = 1;
+                g_CastleFlags[CASTLE_FLAG_49] = 1;
                 entity->step++;
             }
         }
@@ -938,14 +938,14 @@ void EntityPathBlockSmallWeight(Entity* self) {
 
         self->posX.i.hi = 416 - g_Tilemap.scrollX.i.hi;
         self->posY.i.hi = 64 - g_Tilemap.scrollY.i.hi;
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->posY.i.hi += 111;
             self->step = 3;
         }
         break;
 
     case 1:
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step++;
         }
         break;
@@ -1015,14 +1015,14 @@ void EntityPathBlockTallWeight(Entity* self) {
             poly = (POLY_GT4*)poly->tag;
         }
 
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step = 3;
             self->posY.i.hi -= 128;
         }
         break;
 
     case 1:
-        if (g_CastleFlags[49] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_49] != 0) {
             self->step++;
         }
         break;
@@ -1100,7 +1100,6 @@ void EntityTrapDoor(Entity* entity) {
 
 // left side of the breakable rock, drops pot roast
 void EntityMermanRockLeftSide(Entity* self) {
-    const int jewelSwordRoomUnlock = 51;
     const int rockBroken = (1 << 0);
     const int wolfFlag = (1 << 2);
     u16* tileLayoutPtr;
@@ -1125,7 +1124,7 @@ void EntityMermanRockLeftSide(Entity* self) {
             tilePos += 0x30;
         }
 
-        if (g_CastleFlags[jewelSwordRoomUnlock] & rockBroken) {
+        if (g_CastleFlags[JEWEL_SWORD_ROOM] & rockBroken) {
             tileLayoutPtr = &D_8018112C;
             tilePos = 0x1F1;
             for (i = 0; i < 3; i++) {
@@ -1182,7 +1181,7 @@ void EntityMermanRockLeftSide(Entity* self) {
                 CreateEntityFromEntity(E_EQUIP_ITEM_DROP, self, newEntity);
                 newEntity->params = ITEM_POT_ROAST;
             }
-            g_CastleFlags[jewelSwordRoomUnlock] |= rockBroken;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= rockBroken;
             self->hitboxState = 1;
             self->step++;
         }
@@ -1191,7 +1190,7 @@ void EntityMermanRockLeftSide(Entity* self) {
     case 2:
         if ((self->hitFlags != 0) &&
             (g_Player.unk0C & PLAYER_STATUS_WOLF_FORM)) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= wolfFlag;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= wolfFlag;
         }
         break;
     }
@@ -1199,7 +1198,7 @@ void EntityMermanRockLeftSide(Entity* self) {
 
 // right side of the merman room rock, breaks when hit
 void EntityMermanRockRightSide(Entity* self) {
-    const int jewelSwordRoomUnlock = 51;
+    const int jewelSwordRoomUnlok = 51;
     const int rockBroken = (1 << 1);
     const int batFlag = (1 << 3);
     u16* tileLayoutPtr;
@@ -1224,7 +1223,7 @@ void EntityMermanRockRightSide(Entity* self) {
             tilePos += 0x30;
         }
 
-        if (g_CastleFlags[jewelSwordRoomUnlock] & rockBroken) {
+        if (g_CastleFlags[JEWEL_SWORD_ROOM] & rockBroken) {
             tileLayoutPtr = &D_80181168;
             tilePos = 0x1FD;
             for (i = 0; i < 3; i++) {
@@ -1277,7 +1276,7 @@ void EntityMermanRockRightSide(Entity* self) {
         }
 
         if (self->ext.generic.unk84.S16.unk0 >= 2) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= rockBroken;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= rockBroken;
             self->hitboxState = 1;
             self->step++;
         }
@@ -1286,7 +1285,7 @@ void EntityMermanRockRightSide(Entity* self) {
     case 2:
         if ((self->hitFlags != 0) &&
             (g_Player.unk0C & PLAYER_STATUS_BAT_FORM)) {
-            g_CastleFlags[jewelSwordRoomUnlock] |= batFlag;
+            g_CastleFlags[JEWEL_SWORD_ROOM] |= batFlag;
         }
         break;
     }
@@ -1301,13 +1300,13 @@ void func_801B5488(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_EInitGeneric);
-        if (g_CastleFlags[58] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_58] != 0) {
             self->step = 2;
         }
         break;
 
     case 1:
-        if ((g_CastleFlags[51] & 12) == 12) {
+        if ((g_CastleFlags[JEWEL_SWORD_ROOM] & 12) == 12) {
             PlaySfxPositional(SFX_WALL_DEBRIS_B);
             self->step++;
         }
@@ -1329,7 +1328,7 @@ void func_801B5488(Entity* self) {
             }
         }
 
-        g_CastleFlags[58] |= 1;
+        g_CastleFlags[CASTLE_FLAG_58] |= 1;
         g_api.func_800F1FC4(0x3A);
         self->step++;
         break;
@@ -1391,7 +1390,6 @@ void EntityFallingRock2(Entity* self) {
 // ID 0x4B
 // Stairway piece you can break before Death encounter
 void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
-    const int stairwayPieceBroken = 56;
     Primitive *prim, *prim2, *prim3;
     Entity* newEntity;
     Collider collider;
@@ -1409,7 +1407,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         self->posX.i.hi = 1432 - g_Tilemap.scrollX.i.hi;
         self->posY.i.hi = 200 - g_Tilemap.scrollY.i.hi;
         self->hitPoints = 16;
-        if (g_CastleFlags[stairwayPieceBroken]) {
+        if (g_CastleFlags[DEATH_STAIRWAY_BROKEN]) {
             self->hitboxState = 0;
             g_Tilemap.fg[0x4D9] = 0x3EE;
             g_Tilemap.fg[0x539] = 0x3D2;
@@ -1435,7 +1433,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         g_api.PlaySfx(SFX_WALL_DEBRIS_B);
         g_Tilemap.fg[0x4D9] = 0x3EE;
         g_Tilemap.fg[0x539] = 0x3D2;
-        g_CastleFlags[stairwayPieceBroken] = true;
+        g_CastleFlags[DEATH_STAIRWAY_BROKEN] = true;
 
         newEntity = AllocEntity(&g_Entities[160], &g_Entities[192]);
         if (newEntity != NULL) {
@@ -1609,7 +1607,7 @@ void EntitySwitch(Entity* self) {
         InitializeEntity(D_80180AA8);
         self->animCurFrame = 9;
         self->zPriority = 0x5E;
-        if (g_CastleFlags[50]) {
+        if (g_CastleFlags[CASTLE_FLAG_50]) {
             self->step = 2;
             self->posY.i.hi += 4;
         }
@@ -1621,7 +1619,7 @@ void EntitySwitch(Entity* self) {
             self->posY.val += FIX(0.25);
             if ((g_Tilemap.scrollY.i.hi + self->posY.i.hi) > 193) {
                 self->posY.i.hi = 193 - g_Tilemap.scrollY.i.hi;
-                g_CastleFlags[50] = true;
+                g_CastleFlags[CASTLE_FLAG_50] = true;
                 g_api.PlaySfx(SFX_SWITCH_CLICK);
                 self->step++;
             }
@@ -1645,7 +1643,7 @@ void EntityHeartRoomGoldDoor(Entity* self) {
         self->animCurFrame = 0x25;
         self->zPriority = 0x5E;
 
-        if (g_CastleFlags[50] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_50] != 0) {
             for (
                 tilePos = 0x48, i = 7, self->step = 128, self->animCurFrame = 0;
                 i >= 0; tilePos += 0x10, i--) {
@@ -1683,7 +1681,7 @@ void EntityHeartRoomGoldDoor(Entity* self) {
         break;
 
     case 1:
-        if (g_CastleFlags[50]) {
+        if (g_CastleFlags[CASTLE_FLAG_50]) {
             g_api.PlaySfx(SFX_STONE_MOVE_A);
             self->step++;
         }

--- a/src/st/np3/49BC8.c
+++ b/src/st/np3/49BC8.c
@@ -95,7 +95,7 @@ void EntityZombieSpawner(Entity* self) {
         self->flags &= FLAG_UNK_2000;
     }
 
-    if (g_CastleFlags[0x37]) {
+    if (g_CastleFlags[CASTLE_FLAG_55]) {
         self->posX.i.hi = 128;
         if (--self->ext.zombieSpawner.spawnDelay == 0) {
             newEntity = AllocEntity(g_Entities + 160, g_Entities + 168);

--- a/src/st/np3/e_misc.c
+++ b/src/st/np3/e_misc.c
@@ -29,7 +29,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/np3/e_misc.c
+++ b/src/st/np3/e_misc.c
@@ -10,7 +10,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0x30;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -29,7 +29,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/np3/gaibon.c
+++ b/src/st/np3/gaibon.c
@@ -166,7 +166,7 @@ void EntityGaibon(Entity* self) {
     }
     switch (self->step) {
     case 0x0:
-        if ((g_CastleFlags[132] == 0) && (*(&g_CastleFlags[56] + 1) == 0)) {
+        if ((g_CastleFlags[SG_KILL_ALCH] == 0) && (g_CastleFlags[SG_RETR_ENTR] == 0)) {
             InitializeEntity(D_80180B68);
             self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             CreateEntityFromCurrentEntity(E_801B8CC0, self + 1);
@@ -591,7 +591,7 @@ void EntityGaibon(Entity* self) {
                 self->facingLeft = 0;
             }
             self->ext.GS_Props.speed = 0;
-            g_CastleFlags[57] |= 1;
+            g_CastleFlags[SG_RETR_ENTR] |= 1;
             self->step_s++;
             /* fallthrough */
         case 1:

--- a/src/st/np3/gaibon.c
+++ b/src/st/np3/gaibon.c
@@ -166,7 +166,8 @@ void EntityGaibon(Entity* self) {
     }
     switch (self->step) {
     case 0x0:
-        if ((g_CastleFlags[SG_KILL_ALCH] == 0) && (g_CastleFlags[SG_RETR_ENTR] == 0)) {
+        if ((g_CastleFlags[SG_KILL_ALCH] == 0) &&
+            (g_CastleFlags[SG_RETR_ENTR] == 0)) {
             InitializeEntity(D_80180B68);
             self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             CreateEntityFromCurrentEntity(E_801B8CC0, self + 1);

--- a/src/st/np3/slogra.c
+++ b/src/st/np3/slogra.c
@@ -48,8 +48,6 @@ typedef enum {
 } SlograDyingSubSteps;
 
 void EntitySlogra(Entity* self) {
-    const int RetreatedInEntrance = 57;
-    const int KilledInAlchLab = 132;
     Entity* newEntity;
     s32 hitPoints;
     u8* animation;
@@ -89,8 +87,8 @@ void EntitySlogra(Entity* self) {
 
     switch (self->step) {
     case SLOGRA_INIT:
-        if (g_CastleFlags[KilledInAlchLab] ||
-            g_CastleFlags[RetreatedInEntrance]) {
+        if (g_CastleFlags[SG_KILL_ALCH] ||
+            g_CastleFlags[SG_RETR_ENTR]) {
             DestroyEntity(self);
             return;
         }
@@ -357,7 +355,7 @@ void EntitySlogra(Entity* self) {
             }
             self->ext.GS_Props.timer = 64;
             PlaySfxPositional(NA_SE_EN_SLOGRA_DEATH_EXPLOSION);
-            g_CastleFlags[RetreatedInEntrance] |= 1;
+            g_CastleFlags[SG_RETR_ENTR] |= 1;
             self->step_s++;
 
         case SLOGRA_DYING_EXPLODING:

--- a/src/st/np3/slogra.c
+++ b/src/st/np3/slogra.c
@@ -87,8 +87,7 @@ void EntitySlogra(Entity* self) {
 
     switch (self->step) {
     case SLOGRA_INIT:
-        if (g_CastleFlags[SG_KILL_ALCH] ||
-            g_CastleFlags[SG_RETR_ENTR]) {
+        if (g_CastleFlags[SG_KILL_ALCH] || g_CastleFlags[SG_RETR_ENTR]) {
             DestroyEntity(self);
             return;
         }

--- a/src/st/nz0/311C0.c
+++ b/src/st/nz0/311C0.c
@@ -112,7 +112,7 @@ void EntityLeftSecretRoomWall(Entity* self, u16* tileLayoutPtr, s32 tilePos) {
         self->hitboxHeight = 32;
         self->hitboxState = 2;
 
-        cond = g_CastleFlags[129] != 0;
+        cond = g_CastleFlags[CASTLE_FLAG_129] != 0;
         tileLayoutPtr = &D_80180E54 + (-cond & 0xC);
 
         tilePos = 0x260;
@@ -123,7 +123,7 @@ void EntityLeftSecretRoomWall(Entity* self, u16* tileLayoutPtr, s32 tilePos) {
             tileLayoutPtr += 2;
         }
 
-        if (g_CastleFlags[129] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_129] != 0) {
             DestroyEntity(self);
             break;
         }
@@ -156,7 +156,7 @@ void EntityLeftSecretRoomWall(Entity* self, u16* tileLayoutPtr, s32 tilePos) {
         self->step++;
 
         if (self->ext.nz0311c0.unk84 == 3) {
-            g_CastleFlags[129] = 1;
+            g_CastleFlags[CASTLE_FLAG_129] = 1;
             g_api.func_800F1FC4(0x81);
 
             for (i = 0; i < 8; i++) {
@@ -191,7 +191,7 @@ void EntityBottomSecretRoomFloor(
         self->hitboxWidth = 16;
         self->hitboxHeight = 16;
         self->hitboxState = 2;
-        flag = (g_CastleFlags[130] != 0);
+        flag = (g_CastleFlags[CASTLE_FLAG_130] != 0);
         tileLayoutPtr = &D_80180E94 + (-flag & 0x6);
 
         tilePos = 0x2E7;
@@ -202,7 +202,7 @@ void EntityBottomSecretRoomFloor(
             tilePos += 0x10;
         }
 
-        if (g_CastleFlags[130] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_130] != 0) {
             DestroyEntity(self);
             break;
         }
@@ -235,7 +235,7 @@ void EntityBottomSecretRoomFloor(
         self->step++;
 
         if (self->ext.nz0311c0.unk84 == 3) {
-            g_CastleFlags[130] = 1;
+            g_CastleFlags[CASTLE_FLAG_130] = 1;
             g_api.func_800F1FC4(0x82);
             DestroyEntity(self);
         }
@@ -751,20 +751,20 @@ void EntityCannonWall(Entity* self) {
     case 0:
         InitializeEntity(g_EInitGeneric);
 
-        cond = g_CastleFlags[131] != 0;
+        cond = g_CastleFlags[CASTLE_FLAG_131] != 0;
         tileLayoutPtr = (-cond & 6) + &D_80180ED4[0];
         for (tilePos = 0x46, i = 0; i < 6; i++, tileLayoutPtr++) {
             g_Tilemap.fg[tilePos] = *tileLayoutPtr;
             tilePos += 0x10;
         }
 
-        if (g_CastleFlags[131] != 0) {
+        if (g_CastleFlags[CASTLE_FLAG_131] != 0) {
             DestroyEntity(self);
         }
         break;
 
     case 1:
-        i = g_CastleFlags[131] != 0; // TODO: !FAKE:
+        i = g_CastleFlags[CASTLE_FLAG_131] != 0; // TODO: !FAKE:
         if (i) {
             self->step++;
         }

--- a/src/st/nz0/bossfight.c
+++ b/src/st/nz0/bossfight.c
@@ -101,7 +101,7 @@ void EntityBossFightManager(Entity* self) {
         newEnt->posY.i.hi = newEntY;
         newEnt->params = 5;
         g_BossFlag |= BOSS_FLAG_DOORS_OPEN; // Reopen the door
-        g_CastleFlags[132] = 1;
+        g_CastleFlags[SG_KILL_ALCH] = 1;
         D_80097928 = 1;
         D_80097910 = 0x32E;
         self->step++;

--- a/src/st/nz0/entity_heart_drop.c
+++ b/src/st/nz0/entity_heart_drop.c
@@ -27,7 +27,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/nz0/entity_heart_drop.c
+++ b/src/st/nz0/entity_heart_drop.c
@@ -8,7 +8,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0xF8;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -27,7 +27,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/nz0/mariacutscene.c
+++ b/src/st/nz0/mariacutscene.c
@@ -142,7 +142,7 @@ void EntityMariaCutscene(Entity* self) {
     }
     switch (self->step) {
     case 0:
-        if ((g_CastleFlags[133] != 0) ||
+        if ((g_CastleFlags[CASTLE_FLAG_133] != 0) ||
             (g_PlayableCharacter != PLAYER_ALUCARD)) {
             DestroyEntity(self);
             return;
@@ -578,7 +578,7 @@ void EntityMariaCutscene(Entity* self) {
 
     case 7:
         DestroyEntity(self);
-        g_CastleFlags[133] = 1;
+        g_CastleFlags[CASTLE_FLAG_133] = 1;
         D_8003C704 = 0;
         g_Settings.D_8003CB04 |= 0x100;
         break;

--- a/src/st/rwrp/warp.c
+++ b/src/st/rwrp/warp.c
@@ -152,7 +152,7 @@ void EntityRWarpRoom(Entity* self) {
         prim->drawMode = DRAW_HIDE;
 
         WarpBackgroundAmplitiude = 0x100;
-        g_CastleFlags[0xD1] |= 1 << self->params;
+        g_CastleFlags[CASTLE_FLAG_209] |= 1 << self->params;
         D_80180648 = 0;
         moveX = PLAYER.posX.i.hi + g_Tilemap.scrollX.i.hi;
         if (moveX > 0x60 && moveX < 0xA0) {
@@ -234,7 +234,7 @@ void EntityRWarpRoom(Entity* self) {
             if (temp > LEN(WarpRoomCoords) - 1) {
                 temp = 0;
             }
-            if (g_CastleFlags[0xD1] & (1 << temp)) {
+            if (g_CastleFlags[CASTLE_FLAG_209] & (1 << temp)) {
                 break;
             }
         }

--- a/src/st/st0/collision.c
+++ b/src/st/st0/collision.c
@@ -251,7 +251,7 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + 0x190] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |= miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {

--- a/src/st/st0/collision.c
+++ b/src/st/st0/collision.c
@@ -251,7 +251,8 @@ void HitDetection(void) {
                 if (miscVar1) {
                     miscVar1--;
                     miscVar3 = 1 << (miscVar1 & 7);
-                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |= miscVar3;
+                    g_CastleFlags[(miscVar1 >> 3) + COLLISION_FLAGS_START] |=
+                        miscVar3;
                 }
                 if ((g_Status.relics[RELIC_FAERIE_SCROLL] & 2) &&
                     !(entFrom5C->flags & FLAG_NOT_AN_ENEMY)) {

--- a/src/st/wrp/e_stage_name.c
+++ b/src/st/wrp/e_stage_name.c
@@ -17,7 +17,7 @@ void EntityStageNamePopup(Entity* self) {
 
     switch (self->step) {
     case 0:
-        if (g_CastleFlags[2]) {
+        if (g_CastleFlags[CASTLE_FLAG_2]) {
             DestroyEntity(self);
             return;
         }
@@ -238,7 +238,7 @@ void EntityStageNamePopup(Entity* self) {
         break;
     case 32:
         if (!--self->ext.stpopupj.unk80) {
-            g_CastleFlags[2] = 1;
+            g_CastleFlags[CASTLE_FLAG_2] = 1;
             self->step_s = 0;
             self->step = 0x12;
         }

--- a/src/st/wrp/warp.c
+++ b/src/st/wrp/warp.c
@@ -162,8 +162,8 @@ void EntityWarpRoom(Entity* self) {
         self->hitboxOffY += 16;
         self->hitboxWidth = 2;
         self->hitboxHeight = 16;
-        g_CastleFlags[0xD0] |= 1;
-        g_CastleFlags[0xD0] |= 1 << self->params;
+        g_CastleFlags[CASTLE_FLAG_208] |= 1;
+        g_CastleFlags[CASTLE_FLAG_208] |= 1 << self->params;
         D_80180648 = 0;
         entity = &PLAYER;
         moveX = entity->posX.i.hi + g_Tilemap.scrollX.i.hi;
@@ -235,7 +235,7 @@ void EntityWarpRoom(Entity* self) {
             if (move_room > LEN(WarpRoomCoords) - 1) {
                 move_room = 0;
             }
-            if (g_CastleFlags[0xD0] & (1 << move_room)) {
+            if (g_CastleFlags[CASTLE_FLAG_208] & (1 << move_room)) {
                 break;
             }
         }

--- a/src/st/wrp_psp/e_collect.c
+++ b/src/st/wrp_psp/e_collect.c
@@ -314,7 +314,8 @@ void EntityPrizeDrop(Entity* self) {
             index = self->ext.equipItemDrop.castleFlag;
             if (index) {
                 index--;
-                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |=
+                    1 << (index & 7);
             }
         }
         if (!itemId) {

--- a/src/st/wrp_psp/e_collect.c
+++ b/src/st/wrp_psp/e_collect.c
@@ -314,7 +314,7 @@ void EntityPrizeDrop(Entity* self) {
             index = self->ext.equipItemDrop.castleFlag;
             if (index) {
                 index--;
-                g_CastleFlags[(index >> 3) + 0x1b0] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + COLLECT_FLAGS_START] |= 1 << (index & 7);
             }
         }
         if (!itemId) {

--- a/src/st/wrp_psp/e_misc.c
+++ b/src/st/wrp_psp/e_misc.c
@@ -31,7 +31,8 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |=
+                    1 << (index & 7);
                 self->step = 5;
             }
         }

--- a/src/st/wrp_psp/e_misc.c
+++ b/src/st/wrp_psp/e_misc.c
@@ -12,7 +12,7 @@ void EntityHeartDrop(Entity* self) {
 
     if (!self->step) {
         index = self->ext.heartDrop.unkB4 = self->params + 0x118;
-        value = g_CastleFlags[(index >> 3) + 0x100] >> (index & 7);
+        value = g_CastleFlags[(index >> 3) + HEART_FLAGS_START] >> (index & 7);
         if (value & 1) {
             DestroyEntity(self);
             return;
@@ -31,7 +31,7 @@ void EntityHeartDrop(Entity* self) {
         index = self->ext.heartDrop.unkB4;
         if (self->step < 5) {
             if (self->hitFlags) {
-                g_CastleFlags[(index >> 3) + 0x100] |= 1 << (index & 7);
+                g_CastleFlags[(index >> 3) + HEART_FLAGS_START] |= 1 << (index & 7);
                 self->step = 5;
             }
         }


### PR DESCRIPTION
I went through every use of g_CastleFlags and created enum members for the different flags. This will allow us to better keep track of what flags exist and how they are used. This will also aid in tracking the arrangement of the overlays in the flags, as there seems to be some level of organization. As we add more gameplay overlays we can hopefully learn how these all work together.

Some functions were using local `const int` declarations to give names to flags. For example, there was `const int jewelSwordRoomUnlock = 51;`. For these ones, which had flag purposes identified in code, I went ahead and gave their global castle flag a similar name (in this case, `JEWEL_SWORD_ROOM`). For all other flags, I kept the name as a placeholder of `CASTLE_FLAG_###`; later someone else can identify what the individual flags are.

This should be a good step in making the castle flags more understandable, as well as to connect the different functions across the game and properly see which ones are touching the same flags. When a castle flag is written as 0x32 in some places, and 50 in others, it makes it harder to search. Now that we can use CASTLE_FLAG_50, hopefully we will have better understanding of all the uses of the flag.