### PR TITLE
Fix symbols cross command

### DIFF
--- a/tools/symbols.py
+++ b/tools/symbols.py
@@ -136,39 +136,39 @@ re_func = r"(?P<FUNC>\%(hi|lo))"
 # all the regex patterns supported by the MIPS assembly parser
 patterns = [
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_func}\({re_ident('SYM')}\)\({re_reg('IMM')}\)",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_func}\({re_ident('SYM')}\)\({re_reg('IMM')}\)",
         ["LOC", "VRAM", "VAL", "OP", "DST", "FUNC", "SYM", "IMM"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_func}\({re_ident('SYM')}\)",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_func}\({re_ident('SYM')}\)",
         ["LOC", "VRAM", "VAL", "OP", "DST", "FUNC", "SYM"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_reg('LEFT')},\\s+{re_reg('RIGHT')}",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_reg('LEFT')},\s+{re_reg('RIGHT')}",
         ["LOC", "VRAM", "VAL", "OP", "DST", "LEFT", "RIGHT"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_reg('LEFT')},\\s+{re_func}\({re_ident('SYM')}\)\({re_reg('IMM')}\)",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_reg('LEFT')},\s+{re_func}\({re_ident('SYM')}\)\({re_reg('IMM')}\)",
         ["LOC", "VRAM", "VAL", "OP", "DST", "LEFT", "FUNC", "SYM", "IMM"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_reg('LEFT')},\\s+{re_func}\({re_ident('SYM')}\)",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_reg('LEFT')},\s+{re_func}\({re_ident('SYM')}\)",
         ["LOC", "VRAM", "VAL", "OP", "DST", "LEFT", "FUNC", "SYM"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+{re_reg('LEFT')}",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+{re_reg('LEFT')}",
         ["LOC", "VRAM", "VAL", "OP", "DST", "LEFT"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+\.{re_ident('LABEL')}",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+\.{re_ident('LABEL')}",
         ["LOC", "VRAM", "VAL", "OP", "LABEL"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}\\s+{re_reg('DST')},\\s+\.{re_ident('LABEL')}",
+        rf"{re_splat_line()}\s+{re_ident('OP')}\s+{re_reg('DST')},\s+\.{re_ident('LABEL')}",
         ["LOC", "VRAM", "VAL", "OP", "DST", "LABEL"],
     ),
     (
-        rf"{re_splat_line()}\\s+{re_ident('OP')}$",
+        rf"{re_splat_line()}\s+{re_ident('OP')}$",
         ["LOC", "VRAM", "VAL", "OP"],
     ),
     (r"glabel (?P<FUNC_NAME>\w+)", ["FUNC_NAME"]),


### PR DESCRIPTION
I was experimenting with `python3 tools/symbols.py cross asm/us/ric/matchings/1AC60/RicInit.s asm/hd/ric/nonmatchings/hd/RicInit.s` and I found the tool was giving no matches.

With this fix the output produced is now:
```
PLAYER_rotY = 0x800733F4;
PLAYER_rotX = 0x800733F2;
ric_anim_stand_relax = 0x80155480;
g_IsPrologueStage = 0x80154570;
D_80175958 = 0x801758AC;
D_801759D8 = 0x8017592C;
D_801530AC = 0x801530AC;
D_80153AA0 = 0x80153AA0;
D_80153D24 = 0x80153D24;
D_801541A8 = 0x801541A8;  
```
