### PR TITLE
Make config stage fixes

### DIFF
--- a/tools/make-config.py
+++ b/tools/make-config.py
@@ -790,6 +790,10 @@ def add_symbol_unique(symbol_file_name: str, name: str, offset: int):
 def add_symbol(splat_config, version: str, name: str, offset: int):
     if offset == 0:
         return
+    # do not add symbols that belongs to the shared area
+    base_addr = splat_config["segments"][0]["vram"]
+    if offset < base_addr:
+        return
 
     # add symbol to the overlay symbol list
     symbol_file_name = splat_config["options"]["symbol_addrs_path"][1]


### PR DESCRIPTION
Fixes a few issues found by @bismurphy where certain symbols that were not supposed to be added, were added.

The major fix is when the second pass found a meaningful symbol name like `MakeExplosion`, the third pass could add a new symbol with the same offset but with the default splat name `func_8019055C`. With the new `add_symbol_unique` the symbol table will stay unique. On top of that when adding a new symbol `func_8019055C` can be replaced by `MakeExplosion` but not the other way around. This will ensure only meaningful names will be resolved.