### PR TITLE
Fix analyze_calls for boss stages

### DIFF
--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -348,7 +348,7 @@ class sotn_function:
 
         filepath_split = self.asm_filename.split("/")
         self.overlay = filepath_split[2]
-        if self.overlay == "st":
+        if self.overlay in ["st","boss"]:
             self.overlay = filepath_split[3]
         if self.overlay == "weapon":
             self.overlay = filepath_split[4]
@@ -417,7 +417,7 @@ if __name__ == "__main__":
     # 1: Create baseline function objects for every .s file
     functions = [
         sotn_function(s.stem, str(s))
-        for s in Path("asm").rglob("*.s")
+        for s in Path("asm/us").rglob("*.s")
         if "nonmatchings" in str(s)
     ]
     if len(functions) == 0:

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -348,7 +348,7 @@ class sotn_function:
 
         filepath_split = self.asm_filename.split("/")
         self.overlay = filepath_split[2]
-        if self.overlay in ["st","boss"]:
+        if self.overlay in ["st", "boss"]:
             self.overlay = filepath_split[3]
         if self.overlay == "weapon":
             self.overlay = filepath_split[4]


### PR DESCRIPTION
In analyze_calls, we need to analyze a function's calls, and be able to track where they go. Given that a `jal` call only has a function name, it's possible for it to go to a function in any overlay. Therefore, we need to disambiguate across overlays.

We do this by identifying what overlay every function is in. This comes from the filename of the assembly file.

Since the overlay might be in, for example, asm/us/dra (a "level 3 overlay" because it has 3 directory names) or asm/us/st/cen (a "level 4 overlay") we had special logic for testing for "st".

Now that we can also have level 4 overlays in "boss" (with Maria and BO3 coming up) we need to test for those too.

While we're at it, we also only run on the "us" version's assembly files.