### PR TITLE
Decompile libgpu SetDrawEnv

### DIFF
--- a/src/main/psxsdk/libgpu/sys.c
+++ b/src/main/psxsdk/libgpu/sys.c
@@ -306,13 +306,13 @@ extern void SetDrawMode(DR_MODE* p, int dfe, int dtd, int tpage, RECT* tw) {
     p->code[1] = get_tw(tw);
 }
 
-extern void SetDrawEnv(DR_ENV* dr_env0, DRAWENV* env) {
-    RECT temp;
-    s32 var_t0;
-    u16 var_v1;
+extern void SetDrawEnv(DR_ENV* dr_env_in, DRAWENV* env) {
+    RECT clip_rect;
+    s32 offset;
+    u16 calc_clip_height;
     DR_ENV* dr_env;
     
-    dr_env = dr_env0;
+    dr_env = dr_env_in;
 
     dr_env->code[0] = get_cs(env->clip.x, env->clip.y);
     dr_env->code[1] = get_ce(env->clip.w + env->clip.x - 1, env->clip.y + env->clip.h - 1);
@@ -321,46 +321,46 @@ extern void SetDrawEnv(DR_ENV* dr_env0, DRAWENV* env) {
     dr_env->code[4] = get_tw(&env->tw);
     dr_env->code[5] = 0xE6000000;
     
-    var_t0 = 7;
+    offset = 7;
     if (env->isbg != 0) {
-        temp.x = env->clip.x;
-        temp.y = env->clip.y;
-        temp.w = env->clip.w;
-        temp.h = env->clip.h;
-        temp.w = CLAMP(temp.w, 0, 1023);
+        clip_rect.x = env->clip.x;
+        clip_rect.y = env->clip.y;
+        clip_rect.w = env->clip.w;
+        clip_rect.h = env->clip.h;
+        clip_rect.w = CLAMP(clip_rect.w, 0, 1023);
         
-        if (temp.h >= 0) {
-            if ((D_8002C26C != 0 && temp.h >= 1024) ||
-                (D_8002C26C == 0 && temp.h >= 512)) {
+        if (clip_rect.h >= 0) {
+            if ((D_8002C26C != 0 && clip_rect.h >= 1024) ||
+                (D_8002C26C == 0 && clip_rect.h >= 512)) {
                 if (D_8002C26C != 0) {
-                    var_v1 = 1023;
+                    calc_clip_height = 1023;
                 } else {
-                    var_v1 = 511;
+                    calc_clip_height = 511;
                 }
             } else {
-                var_v1 = temp.h;
+                calc_clip_height = clip_rect.h;
             }
         } else {
-            var_v1 = 0;
+            calc_clip_height = 0;
         }
             
-        temp.h = var_v1;
-        if ((temp.x & 0x3F) || (temp.w & 0x3F)) {
-            temp.x -= env->ofs[0];
-            temp.y -= env->ofs[1];
-            *((s32*)dr_env + var_t0++) = 0x60000000 | env->b0 << 0x10 | env->g0 << 8 | env->r0 ;
-            *((s32*)dr_env + var_t0++) = *(s32*)&temp.x;
-            *((s32*)dr_env + var_t0++) = *(s32*)&temp.w;
-            temp.x += env->ofs[0];
-            temp.y += env->ofs[1];
+        clip_rect.h = calc_clip_height;
+        if ((clip_rect.x & 0x3F) || (clip_rect.w & 0x3F)) {
+            clip_rect.x -= env->ofs[0];
+            clip_rect.y -= env->ofs[1];
+            *((s32*)dr_env + offset++) = 0x60000000 | env->b0 << 0x10 | env->g0 << 8 | env->r0 ;
+            *((s32*)dr_env + offset++) = *(s32*)&clip_rect.x;
+            *((s32*)dr_env + offset++) = *(s32*)&clip_rect.w;
+            clip_rect.x += env->ofs[0];
+            clip_rect.y += env->ofs[1];
         } else {
-            *((s32*)dr_env + var_t0++) = 0x02000000 | env->b0 << 0x10 | env->g0 << 8 | env->r0;
-            *((s32*)dr_env + var_t0++) = *(s32*)&temp.x;
-            *((s32*)dr_env + var_t0++) = *(s32*)&temp.w;
+            *((s32*)dr_env + offset++) = 0x02000000 | env->b0 << 0x10 | env->g0 << 8 | env->r0;
+            *((s32*)dr_env + offset++) = *(s32*)&clip_rect.x;
+            *((s32*)dr_env + offset++) = *(s32*)&clip_rect.w;
         }
     }
 
-    setlen(dr_env, var_t0 - 1);
+    setlen(dr_env, offset - 1);
 }
 
 int get_mode(int dfe, int dtd, int tpage) {


### PR DESCRIPTION
Decompiled libgpu SetDrawEnv

This function actually packs some of the short length fields from a DRAWENV struct into DR_ENV struct code fields, which are longs.  

IE dr_env->code[7] gets packed with env->clip.x in the hi 2 bytes and env->clip.y in the low 2 bytes.

Perhaps DR_ENV should actually be PACKED_DRAWENV.

Decompilation by sozud <sozud@users.noreply.github.com> 
and brought to the finish line by dezgeg <dezgeg@users.noreply.github.com> 