### PR TITLE
Decompile for ServantDesc data for tt_001

### DIFF
--- a/config/splat.us.tt_001.yaml
+++ b/config/splat.us.tt_001.yaml
@@ -37,7 +37,8 @@ segments:
     align: 4
     subalign: 4
     subsegments:
-      - [0x0, data]
+      - [0x0, .data, F84]
+      - [0x40, data]
       - [0xEFC, .rodata, F84]
       - [0xF84, c, F84]
       - [0x35B0, sbss]

--- a/config/symbols.us.tt_001.txt
+++ b/config/symbols.us.tt_001.txt
@@ -1,5 +1,5 @@
-Unk28 = 0x80170028;
-Unk2C = 0x8017002C;
+Unk28 = 0x80170028; // type:func
+Unk2C = 0x8017002C; // type:func
 g_EntityRanges = 0x80170EE4;
 CheckEntityValid = 0x801714F4;
 DestroyEntity = 0x80172AE4;

--- a/config/symbols.us.tt_001.txt
+++ b/config/symbols.us.tt_001.txt
@@ -1,5 +1,6 @@
+g_ServantDesc_Brk2 = 0x80170028;
+g_ServantDesc_Brk3 = 0x8017002C;
 g_EntityRanges = 0x80170EE4;
 CheckEntityValid = 0x801714F4;
-DestroyServantEntity = 0x80172904;
 DestroyEntity = 0x80172AE4;
 g_IsServantDestroyed = 0x8017381C;

--- a/config/symbols.us.tt_001.txt
+++ b/config/symbols.us.tt_001.txt
@@ -1,5 +1,5 @@
-g_ServantDesc_Brk2 = 0x80170028;
-g_ServantDesc_Brk3 = 0x8017002C;
+Unk28 = 0x80170028;
+Unk2C = 0x8017002C;
 g_EntityRanges = 0x80170EE4;
 CheckEntityValid = 0x801714F4;
 DestroyEntity = 0x80172AE4;

--- a/src/servant/tt_001/F84.c
+++ b/src/servant/tt_001/F84.c
@@ -23,16 +23,12 @@ typedef struct {
 } ServantDesc_Brk1;
 
 typedef struct {
-    void (*Unk28)(Entity* self);
-} ServantDesc_Brk2;
-
-typedef struct {
-    void (*Unk2C)(/*?*/);
+    
     void (*Unk30)(/*?*/);
     void (*Unk34)(/*?*/);
     void (*Unk38)(/*?*/);
     void (*Unk3C)(Entity* self);
-} ServantDesc_Brk3;
+} ServantDesc_Brk2;
 
 void func_us_80171624(s32 arg0);
 void func_us_80171864(Entity* self);
@@ -55,9 +51,12 @@ ServantDesc_Brk1 g_ServantDesc_Brk1 = {
     func_us_80171624, func_us_80171864, func_us_801720A4, func_us_801720AC,
     func_us_801720B4, func_us_801720BC, func_us_801720C4, func_us_801720CC,
     func_us_801720D4, func_us_801720DC};
-ServantDesc_Brk2 g_ServantDesc_Brk2 = {func_us_801720E4};
-ServantDesc_Brk3 g_ServantDesc_Brk3 = {
-    func_us_8017246C, func_us_801728EC, func_us_801728F4, func_us_801728FC,
+
+void (*Unk28)(Entity* self) = &func_us_801720E4;
+void (*Unk2C)(/*?*/) = &func_us_8017246C;
+
+ServantDesc_Brk2 g_ServantDesc_Brk2 = {
+    func_us_801728EC, func_us_801728F4, func_us_801728FC,
     DestroyServantEntity};
 #endif
 

--- a/src/servant/tt_001/F84.c
+++ b/src/servant/tt_001/F84.c
@@ -4,6 +4,63 @@
 
 extern s32 g_IsServantDestroyed;
 
+#ifndef VERSION_PSP
+/* func_us_80171864 uses pointers by a different naming scheme forcing
+ * a breakout of ServantDesc.  Once that function is decompiled,
+ * these structs should be able to be removed and the declaration
+ * set to a  ServantDesc */
+typedef struct {
+    void (*Init)(s32 arg0);
+    void (*Update)(Entity* self);
+    void (*Unk08)(Entity* self);
+    void (*Unk0C)(/*?*/);
+    void (*Unk10)(/*?*/);
+    void (*Unk14)(/*?*/);
+    void (*Unk18)(/*?*/);
+    void (*Unk1C)(/*?*/);
+    void (*Unk20)(/*?*/);
+    void (*Unk24)(/*?*/);
+} ServantDesc_Brk1;
+
+typedef struct {
+    void (*Unk28)(Entity* self);
+} ServantDesc_Brk2;
+
+typedef struct {
+    void (*Unk2C)(/*?*/);
+    void (*Unk30)(/*?*/);
+    void (*Unk34)(/*?*/);
+    void (*Unk38)(/*?*/);
+    void (*Unk3C)(Entity* self);
+} ServantDesc_Brk3;
+
+void func_us_80171624(s32 arg0);
+void func_us_80171864(Entity* self);
+void func_us_801720A4(Entity* self);
+void func_us_801720AC(void);
+void func_us_801720B4(void);
+void func_us_801720BC(void);
+void func_us_801720C4(void);
+void func_us_801720CC(void);
+void func_us_801720D4(void);
+void func_us_801720DC(void);
+void func_us_801720E4(Entity* self);
+void func_us_8017246C(void);
+void func_us_801728EC(void);
+void func_us_801728F4(void);
+void func_us_801728FC(void);
+void DestroyServantEntity(Entity* self);
+
+ServantDesc_Brk1 g_ServantDesc_Brk1 = {
+    func_us_80171624, func_us_80171864, func_us_801720A4, func_us_801720AC,
+    func_us_801720B4, func_us_801720BC, func_us_801720C4, func_us_801720CC,
+    func_us_801720D4, func_us_801720DC};
+ServantDesc_Brk2 g_ServantDesc_Brk2 = {func_us_801720E4};
+ServantDesc_Brk3 g_ServantDesc_Brk3 = {
+    func_us_8017246C, func_us_801728EC, func_us_801728F4, func_us_801728FC,
+    DestroyServantEntity};
+#endif
+
 INCLUDE_ASM("servant/tt_001/nonmatchings/F84", func_us_80170F84);
 
 INCLUDE_ASM("servant/tt_001/nonmatchings/F84", func_us_80171284);
@@ -18,7 +75,7 @@ INCLUDE_ASM("servant/tt_001/nonmatchings/F84", func_us_80171624);
 
 INCLUDE_ASM("servant/tt_001/nonmatchings/F84", func_us_80171864);
 
-void func_us_801720A4(void) {}
+void func_us_801720A4(Entity* self) {}
 
 void func_us_801720AC(void) {}
 


### PR DESCRIPTION
There are 2 symbols that are pointed at functions in the ServantDesc struct.  I wasn't sure how to get those symbols to point into fields of that struct, but breaking it apart works.  Maybe there is a better way to do it.