### PR TITLE
Use collider values to map to enum

### DIFF
--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -1586,7 +1586,7 @@ void func_8010C9F4(void) {
         if (g_Player.colliders2[i].effects & EFFECT_SOLID_FROM_ABOVE) {
             continue;
         }
-        if ((g_Player.unk0C & 2) && (collider.effects & 0x10)) {
+        if ((g_Player.unk0C & 2) && (collider.effects & EFFECT_MIST_ONLY)) {
             collider.effects &= ~3;
         }
         temp_s0 = g_Player.colliders2[i].effects &
@@ -1683,7 +1683,7 @@ void func_8010C9F4(void) {
     argX = *xPosPtr + D_800ACEC0[0].x;
     argY = (*yPosPtr + D_800ACEC0[0].y) - 10;
     CheckCollision(argX, argY, &collider, 0);
-    if ((collider.effects & 1) != 0) {
+    if ((collider.effects & EFFECT_SOLID) != 0) {
         return;
     }
     for (i = 2; i < 4; i++) {
@@ -1709,7 +1709,7 @@ void func_8010C9F4(void) {
                 argX = var_a1 + (*xPosPtr + D_800ACEC0[i].x);
                 argY = *yPosPtr + D_800ACEC0[i].y;
                 CheckCollision(argX, argY, &collider, 0);
-                if (collider.effects & 1) {
+                if (collider.effects & EFFECT_SOLID) {
                     *vram_ptr |= temp_fp;
                     if (!(*vram_ptr & 1)) {
                         *yPosPtr += collider.unk20;
@@ -1720,7 +1720,7 @@ void func_8010C9F4(void) {
                 argX = var_a1 + (*xPosPtr + D_800ACEC0[i].x);
                 argY = *yPosPtr + D_800ACEC0[i].y + g_Player.colliders2[i].unk8;
                 CheckCollision(argX, argY, &collider, 0);
-                if (collider.effects & 1) {
+                if (collider.effects & EFFECT_SOLID) {
                     if (!(*vram_ptr & 1)) {
                         *yPosPtr +=
                             collider.unk20 + g_Player.colliders2[i].unk8;
@@ -1783,7 +1783,7 @@ void func_8010D010(void) {
             argX = *xPosPtr + D_800ACEE0[i].x + g_Player.colliders3[i].unk4 - 1;
             argY = *yPosPtr + D_800ACEE0[i].y;
             CheckCollision(argX, argY, &collider, 0);
-            if ((collider.effects & 1) == 0) {
+            if ((collider.effects & EFFECT_SOLID) == 0) {
                 *vram_ptr |= 4;
                 *xPosPtr += g_Player.colliders3[i].unk4;
                 return;
@@ -1865,7 +1865,7 @@ void func_8010D2C8(void) {
             argX = *xPosPtr + D_800ACEE0[i].x + g_Player.colliders3[i].unkC + 1;
             argY = *yPosPtr + D_800ACEE0[i].y;
             CheckCollision(argX, argY, &collider, 0);
-            if ((collider.effects & 1) == 0) {
+            if ((collider.effects & EFFECT_SOLID) == 0) {
                 *vram_ptr |= 8;
                 *xPosPtr += g_Player.colliders3[i].unkC;
                 return;

--- a/src/dra/692E8.c
+++ b/src/dra/692E8.c
@@ -1587,7 +1587,7 @@ void func_8010C9F4(void) {
             continue;
         }
         if ((g_Player.unk0C & 2) && (collider.effects & EFFECT_MIST_ONLY)) {
-            collider.effects &= ~3;
+            collider.effects &= ~(EFFECT_UNK_0002 | EFFECT_SOLID);
         }
         temp_s0 = g_Player.colliders2[i].effects &
                   (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_SOLID);

--- a/src/dra/843B0.c
+++ b/src/dra/843B0.c
@@ -347,7 +347,8 @@ void EntitySubwpnThrownDagger(Entity* self) {
             }
             CheckCollision(
                 self->posX.i.hi + var_s5, self->posY.i.hi, &collider, 0);
-            if (self->hitFlags == 2 || collider.effects & 3) {
+            if (self->hitFlags == 2 ||
+                collider.effects & (EFFECT_SOLID | EFFECT_UNK_0002)) {
                 self->ext.timer.t = 64;
                 self->velocityX = -(self->velocityX >> 3);
                 self->velocityY = FIX(-2.5);

--- a/src/ric/21250.c
+++ b/src/ric/21250.c
@@ -863,7 +863,7 @@ void func_8015EE28(void) {
     argX = *xPosPtr + D_801545E4[0].x;
     argY = (*yPosPtr + D_801545E4[0].y) - 10;
     g_api.CheckCollision(argX, argY, &collider, 0);
-    if ((collider.effects & 1) != 0) {
+    if ((collider.effects & EFFECT_SOLID) != 0) {
         return;
     }
     for (i = 2; i < 4; i++) {
@@ -891,7 +891,7 @@ void func_8015EE28(void) {
                 argX = var_a1 + (*xPosPtr + D_801545E4[i].x);
                 argY = *yPosPtr + D_801545E4[i].y;
                 g_api.CheckCollision(argX, argY, &collider, 0);
-                if (collider.effects & 1) {
+                if (collider.effects & EFFECT_SOLID) {
                     *vram_ptr |= temp_fp;
                     if (!(*vram_ptr & 1)) {
                         *yPosPtr += collider.unk20;
@@ -902,7 +902,7 @@ void func_8015EE28(void) {
                 argX = var_a1 + (*xPosPtr + D_801545E4[i].x);
                 argY = *yPosPtr + D_801545E4[i].y + g_Player.colliders2[i].unk8;
                 g_api.CheckCollision(argX, argY, &collider, 0);
-                if (collider.effects & 1) {
+                if (collider.effects & EFFECT_SOLID) {
                     if (!(*vram_ptr & 1)) {
                         *yPosPtr +=
                             collider.unk20 + g_Player.colliders2[i].unk8;
@@ -956,7 +956,7 @@ void func_8015F414(void) {
             argX = *xPosPtr + D_80154604[i].x + g_Player.colliders3[i].unk4 - 1;
             argY = *yPosPtr + D_80154604[i].y;
             g_api.CheckCollision(argX, argY, &collider, 0);
-            if ((collider.effects & 1) == 0) {
+            if ((collider.effects & EFFECT_SOLID) == 0) {
                 *vram_ptr |= 4;
                 *xPosPtr += g_Player.colliders3[i].unk4;
                 return;
@@ -1030,7 +1030,7 @@ void func_8015F680(void) {
             argX = *xPosPtr + D_80154604[i].x + g_Player.colliders3[i].unkC + 1;
             argY = *yPosPtr + D_80154604[i].y;
             g_api.CheckCollision(argX, argY, &collider, 0);
-            if ((collider.effects & 1) == 0) {
+            if ((collider.effects & EFFECT_SOLID) == 0) {
                 *vram_ptr |= 8;
                 *xPosPtr += g_Player.colliders3[i].unkC;
                 return;

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -1386,7 +1386,8 @@ void RicEntitySubwpnDagger(Entity* self) {
             }
             g_api.CheckCollision(
                 self->posX.i.hi + var_s1, self->posY.i.hi, &collider, 0);
-            if ((self->hitFlags == 2) || (collider.effects & 3)) {
+            if ((self->hitFlags == 2) ||
+                (collider.effects & (EFFECT_SOLID | EFFECT_UNK_0002))) {
                 self->ext.subweapon.timer = 64;
                 self->velocityY = FIX(-2.5);
                 self->hitboxState = 0;

--- a/src/st/cen/DB18.c
+++ b/src/st/cen/DB18.c
@@ -80,7 +80,7 @@ void func_8018DB18(Entity* self) {
         self->velocityY += FIX(0.25);
         g_api.CheckCollision(
             self->posX.i.hi, self->posY.i.hi + 6, &collider, 0);
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             self->posY.i.hi += collider.unk18;
             self->velocityY = -self->velocityY / 2;
             self->velocityX -= self->velocityX / 3;

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -1574,7 +1574,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         x = prim3->x1;
         y = prim3->y0;
         g_api.CheckCollision(x, (s16)(y + 8), &collider, 0);
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             self->posX.i.hi = x;
             self->posY.i.hi = y - 4;
             self->step++;

--- a/src/st/np3/32830.c
+++ b/src/st/np3/32830.c
@@ -1495,7 +1495,7 @@ void EntityStairwayPiece(Entity* self, u8 arg1, u8 arg2, u8 arg3) {
         x = prim3->x1;
         y = prim3->y0;
         g_api.CheckCollision(x, (s16)(y + 8), &collider, 0);
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             self->posX.i.hi = x;
             self->posY.i.hi = y - 4;
             self->step++;

--- a/src/st/np3/4B018.c
+++ b/src/st/np3/4B018.c
@@ -334,7 +334,7 @@ void EntityOwl(Entity* self) {
                 xVar = self->posX.i.hi;
                 yVar = self->posY.i.hi + 0x10;
                 g_api.CheckCollision(xVar, yVar, &collider, 0);
-                if (collider.effects & 1) {
+                if (collider.effects & EFFECT_SOLID) {
                     self->posY.i.hi = self->posY.i.hi + collider.unk18;
                     self->step_s++;
                     if (KNIGHT->posX.i.hi > self->posX.i.hi) {

--- a/src/st/np3/4D540.c
+++ b/src/st/np3/4D540.c
@@ -312,12 +312,12 @@ s32 func_801CE120(Entity* self, s32 facing) {
     }
 
     g_api.CheckCollision(x, y - 6, &collider, 0);
-    if (collider.effects & 1) {
+    if (collider.effects & EFFECT_SOLID) {
         ret |= 2;
     }
 
     g_api.CheckCollision(x, y + 6, &collider, 0);
-    if (!(collider.effects & 1)) {
+    if (!(collider.effects & EFFECT_SOLID)) {
         ret |= 4;
     }
 

--- a/src/weapon/w_015.c
+++ b/src/weapon/w_015.c
@@ -267,7 +267,7 @@ void func_ptr_8017000C(Entity* self) {
         x = self->posX.i.hi + xOffset;
         y = self->posY.i.hi + yOffset;
         g_api.CheckCollision(x, y, &collider, 0);
-        if (collider.effects & 2) {
+        if (collider.effects & EFFECT_UNK_0002) {
             if (xOffset < 0) {
                 self->posX.i.hi += collider.unkC;
             } else {
@@ -282,7 +282,7 @@ void func_ptr_8017000C(Entity* self) {
         y = self->posY.i.hi + yOffset;
         g_api.CheckCollision(x, y, &collider, 0);
 
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             self->posY.i.hi += 1 + collider.unk20;
             self->velocityY = FIX(1);
             self->velocityX = self->velocityX / 2;
@@ -294,7 +294,7 @@ void func_ptr_8017000C(Entity* self) {
         y = self->posY.i.hi + yOffset;
         g_api.CheckCollision(x, y, &collider, 0);
 
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             e = g_api.CreateEntFactoryFromEntity(self, WFACTORY(76, 0), 0);
             e = g_api.CreateEntFactoryFromEntity(self, WFACTORY(78, 16), 0);
             g_api.func_80102CD8(3);

--- a/src/weapon/w_030.c
+++ b/src/weapon/w_030.c
@@ -315,7 +315,7 @@ void func_ptr_80170008(Entity* self) {
         g_api.CheckCollision(
             self->posX.i.hi, (s16)(self->posY.i.hi + 0x19), &collider, 0);
 
-        if (collider.effects & 1) {
+        if (collider.effects & EFFECT_SOLID) {
             self->ext.weapon_030.unk7E = 0x18;
             self->step = 3;
         }
@@ -330,12 +330,12 @@ void func_ptr_80170008(Entity* self) {
         posY = self->posY.i.hi;
 
         g_api.CheckCollision(posX, (s16)(posY + 10), &collider, 0);
-        if (collider.effects & 2) {
+        if (collider.effects & EFFECT_UNK_0002) {
             self->ext.weapon_030.unk7E = 0x18;
             self->step = 7;
         }
         g_api.CheckCollision(posX, (s16)(posY - 6), &collider, 0);
-        if (collider.effects & 2) {
+        if (collider.effects & EFFECT_UNK_0002) {
             self->ext.weapon_030.unk7E = 0x18;
             self->step = 7;
         }


### PR DESCRIPTION
Minor fixes to use the enum values in `dra`, `ric`, `cen`, `no3`, `np3`, `weapon`