### PR TITLE
Rewrite EntityHolyWater

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -77,7 +77,7 @@ typedef struct ET_Generic {
     /* 0xAE */ s8 unkAE;
     /* 0xAF */ s8 : 8;
     /* 0xB0 */ s16 unkB0;
-    /* 0xB2 */ s16 unkB2;
+    /* 0xB2 */ s16 : 16;
     /* 0xB4 */ s32 : 32;
     union {
         /* 0xB8 */ void (*unkFuncB8)(struct Entity*);
@@ -1311,6 +1311,7 @@ typedef struct {
     /* 0xA8 */ s32 : 32;
     /* 0xAC */ s32 : 32;
     /* 0xB0 */ s16 subweaponId;
+    /* 0xB2 */ s16 unkB2;
 } ET_Subweapon;
 typedef struct {
     s16 timer;
@@ -1330,6 +1331,7 @@ typedef struct {
     /* 0xA8 */ s32 : 32;
     /* 0xAC */ s32 : 32;
     /* 0xB0 */ s16 subweaponId;
+    /* 0xB2 */ s16 unkB2;
 } ET_HolyWater;
 typedef struct {
     u16 unk7C;

--- a/src/dra/78D0C.c
+++ b/src/dra/78D0C.c
@@ -708,7 +708,7 @@ void func_80119F70(Entity* entity) {
 void func_8011A290(Entity* entity) {
     SubweaponDef subwpn;
 
-    func_800FE3C4(&subwpn, entity->ext.generic.unkB0, 0);
+    func_800FE3C4(&subwpn, entity->ext.subweapon.subweaponId, 0);
     entity->attack = subwpn.attack;
     entity->attackElement = subwpn.attackElement;
     entity->hitboxState = subwpn.hitboxState;
@@ -716,7 +716,7 @@ void func_8011A290(Entity* entity) {
     entity->stunFrames = subwpn.stunFrames;
     entity->hitEffect = subwpn.hitEffect;
     entity->entityRoomIndex = subwpn.entityRoomIndex;
-    entity->ext.generic.unkB2 = subwpn.crashId;
+    entity->ext.subweapon.unkB2 = subwpn.crashId;
     func_80118894(entity);
 }
 


### PR DESCRIPTION
Main motivation here was to eliminate `ext.generic.unkB2`, which no longer exists and has been removed from the struct. While I was at it, I modernized the holy water function.

The argument is "self" instead of "entity"

We use FIX() where relevant

Function is adjusted to match on PSP

Variables are renamed

Factory calls are commented

I think those are the main highlights. Mostly small stuff, but everything comes step by step.