### PR TITLE
 Some small Entity.unkB8 cleanup 

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -2028,3 +2028,5 @@ SYNC_FIELD(ET_Subweapon, ET_Agunea, subweaponId);
 SYNC_FIELD(ET_Subweapon, ET_AguneaCrash, subweaponId);
 SYNC_FIELD(ET_Subweapon, ET_GiantSpinningCross, subweaponId);
 SYNC_FIELD(ET_Subweapon, ET_CrashCross, subweaponId);
+
+SYNC_FIELD(ET_Generic, ET_Player, unkB8)

--- a/include/entity.h
+++ b/include/entity.h
@@ -78,16 +78,7 @@ typedef struct ET_Generic {
     /* 0xAF */ s8 : 8;
     /* 0xB0 */ s32 : 32;
     /* 0xB4 */ s32 : 32;
-    union {
-        /* 0xB8 */ void (*unkFuncB8)(struct Entity*);
-        /* 0xB8 */ struct Entity* entityPtr;
-        struct {
-            /* 0xB8 */ u8 unk0;
-            /* 0xB9 */ u8 unk1;
-            /* 0xBA */ u8 unk2;
-            /* 0xBB */ u8 unk3;
-        } modeU8;
-    } unkB8;
+    /* 0xB8 */ struct Entity* unkB8;
 } ET_Generic;
 
 typedef struct {
@@ -241,7 +232,6 @@ typedef struct PACKED {
     /* 0xAE */ s16 equipId;
     /* 0xB0 */ s16 unkB0;
     /* 0xB4 */ s32 unkB4;
-    /* 0xB8 */ s32 unkB8;
 } ET_WeaponUnk030;
 
 typedef struct PACKED {
@@ -1507,7 +1497,6 @@ typedef struct {
     s32 unkAC;
     s16 unkB0;
     s32 unkB4;
-    s32 unkB8;
 } ET_Whip;
 
 typedef struct {

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -252,8 +252,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8 =
-                                        iterEnt1;
+                                    iterEnt2->ext.generic.unkB8 = iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {
                                         iterEnt2->hitFlags = 3;

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -252,7 +252,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
+                                    iterEnt2->ext.generic.unkB8 =
                                         iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -190,8 +190,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8 =
-                                        iterEnt1;
+                                    iterEnt2->ext.generic.unkB8 = iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {
                                         iterEnt2->hitFlags = 3;

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -190,7 +190,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
+                                    iterEnt2->ext.generic.unkB8 =
                                         iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {

--- a/src/st/st0/collision.c
+++ b/src/st/st0/collision.c
@@ -181,7 +181,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
+                                    iterEnt2->ext.generic.unkB8 =
                                         iterEnt1;
                                     iterEnt2->hitFlags = 1;
                                     if ((i == 12) &&

--- a/src/st/st0/collision.c
+++ b/src/st/st0/collision.c
@@ -181,8 +181,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8 =
-                                        iterEnt1;
+                                    iterEnt2->ext.generic.unkB8 = iterEnt1;
                                     iterEnt2->hitFlags = 1;
                                     if ((i == 12) &&
                                         (iterEnt1->flags & FLAG_UNK_8000)) {


### PR DESCRIPTION
This offset is interesting because the HitDetection function (in collision.h/collision.c) writes to it, regardless of what kind of entity we're looking at. I'm wondering if the main Ext region should end 4 bytes short, and if unkB8 should be its own member of the top-level Entity struct. It's possible that this unkB8 was a late addition to Entity, and this is why it is tacked on at the end, after Ext.

It will be tricky to change the size of Ext, since it has so many members. We have a few (but not many) entities that touch this last unkB8 region, so it will likely take at least a couple steps to clean this up.

For now, I've removed it being a Union in Generic (and instead it is only an entity pointer), and removed offset B8 from a couple of entities that had it in there, but unused. Future steps might involve officially removing 0xB8 from the Ext and pulling it out to the Entity. For now, this is a very small change.