### PR TITLE
Move unkB8 out of Ext and into Entity

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -75,9 +75,6 @@ typedef struct ET_Generic {
     /* 0xA8 */ s32 : 32;
     /* 0xAC */ s16 : 16;
     /* 0xAE */ s8 unkAE;
-    /* 0xAF */ s8 : 8;
-    /* 0xB0 */ s32 : 32;
-    /* 0xB4 */ s32 : 32;
 } ET_Generic;
 
 typedef struct {

--- a/include/entity.h
+++ b/include/entity.h
@@ -78,16 +78,6 @@ typedef struct ET_Generic {
     /* 0xAF */ s8 : 8;
     /* 0xB0 */ s32 : 32;
     /* 0xB4 */ s32 : 32;
-    union {
-        /* 0xB8 */ void (*unkFuncB8)(struct Entity*);
-        /* 0xB8 */ struct Entity* entityPtr;
-        struct {
-            /* 0xB8 */ u8 unk0;
-            /* 0xB9 */ u8 unk1;
-            /* 0xBA */ u8 unk2;
-            /* 0xBB */ u8 unk3;
-        } modeU8;
-    } unkB8;
 } ET_Generic;
 
 typedef struct {
@@ -110,7 +100,6 @@ typedef struct {
     /* 0x7C */ u32 unk[14];
     /* 0xB4 */ u16 unkB4;
     /* 0xB6 */ s16 unkB6;
-    /* 0xB8 */ PfnEntityUpdate update;
 } ET_HeartDrop;
 
 typedef struct {
@@ -241,7 +230,6 @@ typedef struct PACKED {
     /* 0xAE */ s16 equipId;
     /* 0xB0 */ s16 unkB0;
     /* 0xB4 */ s32 unkB4;
-    /* 0xB8 */ s32 unkB8;
 } ET_WeaponUnk030;
 
 typedef struct PACKED {
@@ -854,7 +842,8 @@ typedef struct {
     /* 0xA6 */ s16 unkA6;
     /* 0xA8 */ u8 unkA8;
     /* 0xA9 */ char pad_A9[0x7];
-    /* 0xB0 */ u16 unkB0[0x6];
+    /* 0xB0 */ u16 unkB0[2];
+    /* 0xB4 */ u16 unkB4[2];
 } ET_GurkhaHammer;
 
 typedef struct {
@@ -940,8 +929,6 @@ typedef struct PACKED {
     s16 unkA6;
     void* unkA8;
     u8 anim;
-    char pad2[0x8];
-    struct Entity* unkB8;
 } ET_Player;
 
 typedef struct {
@@ -1106,10 +1093,6 @@ typedef struct {
     s32 : 32;
     s32 : 32;
     s16 subweaponId;
-#ifndef VERSION_PC
-    s32 pad2;
-#endif
-    struct Entity* parent2;
 } ET_Agunea;
 typedef struct {
     s16 unk7C;
@@ -1507,7 +1490,6 @@ typedef struct {
     s32 unkAC;
     s16 unkB0;
     s32 unkB4;
-    s32 unkB8;
 } ET_Whip;
 
 typedef struct {
@@ -1830,7 +1812,7 @@ typedef struct {
 
 typedef union { // offset=0x7C
     struct Primitive* prim;
-    char stub[0x40];
+    char stub[0x3C];
     ET_TimerOnly timer;
     ET_EntFactory factory;
     ET_Generic generic;

--- a/include/game.h
+++ b/include/game.h
@@ -852,6 +852,7 @@ typedef struct Entity {
     /* 0x6D */ u8 unk6D[11];
     /* 0x78 */ s32 unk78;
     /* 0x7C */ Ext ext;
+    /* 0xB8 */ struct Entity* unkB8;
 } Entity; // size = 0xBC
 
 typedef struct {

--- a/src/dra/72BB0.c
+++ b/src/dra/72BB0.c
@@ -606,7 +606,7 @@ void func_80113EE0(void) {
 }
 
 void func_80113F7C(void) {
-    Entity* entity = PLAYER.ext.player.unkB8;
+    Entity* entity = PLAYER.unkB8;
     s16 posX;
     s32 var_a0;
     s32 var_a2;

--- a/src/dra/843B0.c
+++ b/src/dra/843B0.c
@@ -2203,7 +2203,7 @@ void EntitySubwpnAgunea(Entity* self) {
         }
         if (self->hitFlags != 0) {
             self->step = 3;
-            self->ext.agunea.parent = self->ext.agunea.parent2;
+            self->ext.agunea.parent = self->unkB8;
         }
         break;
     case 4:

--- a/src/pc/sdl2_macros.c
+++ b/src/pc/sdl2_macros.c
@@ -173,7 +173,7 @@ void handle_macros(const u8* keyb, u_long* pressed) {
         Entity* temp = g_Entities + STAGE_ENTITY_START + 11;
         temp->posX.i.hi = 128;
         temp->posY.i.hi = 128;
-        PLAYER.ext.player.unkB8 = temp;
+        PLAYER.unkB8 = temp;
         PLAYER.hitParams = 3;
     }
 
@@ -182,7 +182,7 @@ void handle_macros(const u8* keyb, u_long* pressed) {
         Entity* temp = g_Entities + STAGE_ENTITY_START + 11;
         temp->posX.i.hi = 128;
         temp->posY.i.hi = 128;
-        PLAYER.ext.player.unkB8 = temp;
+        PLAYER.unkB8 = temp;
         PLAYER.hitParams = 0x20;
         PLAYER.hitPoints = g_Status.hp;
     }
@@ -192,7 +192,7 @@ void handle_macros(const u8* keyb, u_long* pressed) {
         Entity* temp = g_Entities + STAGE_ENTITY_START + 11;
         temp->posX.i.hi = 128;
         temp->posY.i.hi = 128;
-        PLAYER.ext.player.unkB8 = temp;
+        PLAYER.unkB8 = temp;
         PLAYER.hitParams = 0x20;
         PLAYER.hitPoints = g_Status.hp;
         g_Player.unk5C = 1;

--- a/src/ric/1CB04.c
+++ b/src/ric/1CB04.c
@@ -445,7 +445,7 @@ void func_80159BC8(void) {
 }
 
 void func_80159C04(void) {
-    Entity* entity = PLAYER.ext.player.unkB8;
+    Entity* entity = PLAYER.unkB8;
     s16 temp_v0;
     s32 var_a0;
     s32 var_a2;

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -2033,7 +2033,7 @@ void RicEntitySubwpnAgunea(Entity* self) {
         }
         if (self->hitFlags != 0) {
             self->step = 3;
-            self->ext.agunea.parent = self->ext.agunea.parent2;
+            self->ext.agunea.parent = self->unkB8;
         }
         break;
     case 4:

--- a/src/st/collision.h
+++ b/src/st/collision.h
@@ -252,8 +252,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
-                                        iterEnt1;
+                                    iterEnt2->unkB8 = iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {
                                         iterEnt2->hitFlags = 3;
@@ -310,7 +309,7 @@ void HitDetection(void) {
                     if (hitboxCheck1 >= hitboxCheck2) {
                         if ((iterEnt1->attack) &&
                             (iterEnt2->hitPoints < iterEnt1->attack)) {
-                            iterEnt2->ext.player.unkB8 = iterEnt1;
+                            iterEnt2->unkB8 = iterEnt1;
                             if (miscVar1 & 8) {
                                 iterEnt2->hitFlags = 3;
                             } else {

--- a/src/st/entity_heart_drop.h
+++ b/src/st/entity_heart_drop.h
@@ -27,9 +27,9 @@ void EntityHeartDrop(Entity* self) {
         index -= HEART_DROP_CASTLE_FLAG;
         index = g_HeartDropArray[index];
         if (index < 128) {
-            self->ext.heartDrop.update = EntityPrizeDrop;
+            self->unkB8 = EntityPrizeDrop;
         } else {
-            self->ext.heartDrop.update = EntityEquipItemDrop;
+            self->unkB8 = EntityEquipItemDrop;
             index -= 128;
         }
         self->params = index + 0x8000;
@@ -43,6 +43,6 @@ void EntityHeartDrop(Entity* self) {
             }
         }
     }
-    update = self->ext.heartDrop.update;
+    update = self->unkB8;
     update(self);
 }

--- a/src/st/mad/collision.c
+++ b/src/st/mad/collision.c
@@ -190,8 +190,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
-                                        iterEnt1;
+                                    iterEnt2->unkB8 = iterEnt1;
                                     // reminder: iterEnt1->hitboxState
                                     if (miscVar1 & 8) {
                                         iterEnt2->hitFlags = 3;
@@ -247,7 +246,7 @@ void HitDetection(void) {
                     hitboxCheck1 *= 2;
                     if (hitboxCheck1 >= hitboxCheck2) {
                         if (iterEnt1->attack) {
-                            iterEnt2->ext.player.unkB8 = iterEnt1;
+                            iterEnt2->unkB8 = iterEnt1;
                             if (miscVar1 & 8) {
                                 iterEnt2->hitFlags = 3;
                             } else {

--- a/src/st/np3/4D540.c
+++ b/src/st/np3/4D540.c
@@ -248,12 +248,11 @@ void func_801CDF1C(s16 entIndices[], s16 arg1[][4], s32 arg2) {
 
     arg1 += (u16)g_CurrentEntity->ext.GH_Props.unkB0[arg2];
 
-    if (g_CurrentEntity->ext.GH_Props.unkB0[arg2 + 2] == 0) {
+    if (g_CurrentEntity->ext.GH_Props.unkB4[arg2] == 0) {
         func_801CDD80(entIndices, arg1);
-        *(arg2 + 2 + g_CurrentEntity->ext.GH_Props.unkB0) = arg1[0][0];
+        g_CurrentEntity->ext.GH_Props.unkB4[arg2] = arg1[0][0];
     }
-    // I don't know why the reverse array indexing is needed, but it is. Darn.
-    if (!(--((arg2 + 2)[g_CurrentEntity->ext.GH_Props.unkB0]))) {
+    if (!(--g_CurrentEntity->ext.GH_Props.unkB4[arg2])) {
         if (arg1[1][0] == 0) {
             g_CurrentEntity->ext.GH_Props.unkB0[arg2] = 0;
         } else {
@@ -331,19 +330,27 @@ void func_801CE1E8(s16 step) {
     g_CurrentEntity->step_s = 0;
     g_CurrentEntity->animFrameIdx = 0;
     g_CurrentEntity->animFrameDuration = 0;
-
+    // BUG: See below.
     for (i = 0; i < 4; i++) {
         g_CurrentEntity->ext.GH_Props.unkB0[i] = 0;
-        g_CurrentEntity->ext.GH_Props.unkB0[i + 2] = 0;
+        g_CurrentEntity->ext.GH_Props.unkB4[i] = 0;
     }
 }
 
-void func_801CE228(s16 step) {
+void func_801CE228() {
     s32 i;
-
+    // BUG: Array out of bounds writing. Possible explanation:
+    // unkB0 was originally a 4-element array. This loop would iterate
+    // through the 4 elements and write each to zero.
+    // At some point, unkB0 got split to two arrays, unkB0 and unkB4.
+    // Now we zero out both arrays. But since each one is only 2 elements,
+    // the loop should only be `i < 2`. They forgot to change it. This means
+    // that for i = 2 and i = 3, the unkB0 writes are writing into unkB4,
+    // and the unkB4 is writing totally out of bounds.
+    // As far as we know, this bug does not have any consequences.
     for (i = 0; i < 4; i++) {
         g_CurrentEntity->ext.GH_Props.unkB0[i] = 0;
-        g_CurrentEntity->ext.GH_Props.unkB0[i + 2] = 0;
+        g_CurrentEntity->ext.GH_Props.unkB4[i] = 0;
     }
 }
 

--- a/src/st/np3/4E69C.c
+++ b/src/st/np3/4E69C.c
@@ -81,7 +81,7 @@ void EntityHammer(Entity* self) {
                 func_801CE228();
                 func_801CE4CC(otherEnt);
             } else if (self->ext.GH_Props.unkB0[0] == 2 &&
-                       self->ext.GH_Props.unkB0[2] == 1) {
+                       self->ext.GH_Props.unkB4[0] == 1) {
                 func_801CE1E8(8);
             }
         }
@@ -129,7 +129,7 @@ void EntityHammer(Entity* self) {
             func_801CDE10(var_s2);
             func_801CE2CC(var_s2);
             if (self->ext.GH_Props.unkB0[0] == 0 &&
-                self->ext.GH_Props.unkB0[2] == 0) {
+                self->ext.GH_Props.unkB4[0] == 0) {
                 self->step_s++;
             }
             break;
@@ -137,7 +137,7 @@ void EntityHammer(Entity* self) {
             func_801CDF1C(var_s2, &D_80182C9C, 0);
             func_801CDE10(var_s2);
             func_801CE2CC(var_s2);
-            if (self->ext.GH_Props.unkB0[2] == 0 &&
+            if (self->ext.GH_Props.unkB4[0] == 0 &&
                 self->ext.GH_Props.unkB0[0] == 0) {
                 self->step_s++;
             }
@@ -195,7 +195,7 @@ void EntityHammer(Entity* self) {
             func_801CDFD8(var_s3_2, 0x10);
             func_801CE258(&D_80182A20);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(0x743);
                 self->step_s++;
             }
@@ -218,16 +218,16 @@ void EntityHammer(Entity* self) {
             func_801CDFD8(var_s3_2, 2);
             func_801CE258(&D_80182A20);
             if ((self->ext.GH_Props.unkB0[0] == 4) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 self->ext.GH_Props.unk84 ^= 1;
             }
             if ((self->ext.GH_Props.unkB0[0] == 6) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(SFX_FM_EXPLODE_D);
                 g_api_func_80102CD8(1);
             }
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 self->ext.GH_Props.unk84 ^= 1;
                 self->step_s++;
             }
@@ -243,7 +243,7 @@ void EntityHammer(Entity* self) {
             func_801CE2CC(var_s2);
             func_801CE258(&D_80182A20);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 self->step_s++;
             }
             break;
@@ -262,7 +262,7 @@ void EntityHammer(Entity* self) {
         func_801CDE10(var_s2);
         func_801CE2CC(var_s2);
         func_801CE258(&D_80182A20);
-        if (self->ext.GH_Props.unkB0[2] == 0) {
+        if (self->ext.GH_Props.unkB4[0] == 0) {
             self->facingLeft ^= 1;
             func_801CE4CC(self);
         }
@@ -282,7 +282,7 @@ void EntityHammer(Entity* self) {
         func_801CE2CC(var_s2);
         func_801CE258(&D_80182A20);
         if (self->ext.GH_Props.unkB0[0] == 0 &&
-            self->ext.GH_Props.unkB0[2] == 0) {
+            self->ext.GH_Props.unkB4[0] == 0) {
             func_801CE4CC(self);
         }
         break;
@@ -320,7 +320,7 @@ void EntityHammer(Entity* self) {
         otherEnt->ext.GH_Props.unkA8 = 0;
     }
     D_8006C384.y = self->ext.GH_Props.unkB0[0];
-    D_8006C38C.y = self->ext.GH_Props.unkB0[2];
+    D_8006C38C.y = self->ext.GH_Props.unkB4[0];
     return;
 }
 

--- a/src/st/np3/4F5B8.c
+++ b/src/st/np3/4F5B8.c
@@ -244,7 +244,7 @@ void EntityGurkha(Entity* self) {
             func_801CDE10(var_s2);
             func_801CE2CC(var_s2);
             if (self->ext.GH_Props.unkB0[0] == 0 &&
-                self->ext.GH_Props.unkB0[2] == 0) {
+                self->ext.GH_Props.unkB4[0] == 0) {
                 self->step_s++;
             }
             break;
@@ -253,7 +253,7 @@ void EntityGurkha(Entity* self) {
             func_801CDE10(var_s2);
             func_801CE2CC(var_s2);
             func_801CF778();
-            if (self->ext.GH_Props.unkB0[2] == 0 &&
+            if (self->ext.GH_Props.unkB4[0] == 0 &&
                 self->ext.GH_Props.unkB0[0] == 0) {
                 self->step_s++;
             }
@@ -303,7 +303,7 @@ void EntityGurkha(Entity* self) {
             func_801CE2CC(var_s2);
             func_801CE258(&D_80182F9C);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 self->ext.GH_Props.unk80 = 0;
                 self->step_s++;
             }
@@ -339,7 +339,7 @@ void EntityGurkha(Entity* self) {
             func_801CE2CC(var_s2);
             func_801CE258(&D_80182F9C);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(0x740);
                 // we appear to write 0x10 twice here, weird
                 self->ext.GH_Props.unk80 = 0x10;
@@ -380,7 +380,7 @@ void EntityGurkha(Entity* self) {
             func_801CE2CC(var_s2);
             func_801CE258(&D_80182F9C);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 if (self->facingLeft == 0) {
                     self->velocityX = FIX(-4);
                 } else {
@@ -410,7 +410,7 @@ void EntityGurkha(Entity* self) {
             func_801CE2CC(var_s2);
             func_801CE258(&D_80182F9C);
             if (self->ext.GH_Props.unkB0[0] == 0 &&
-                self->ext.GH_Props.unkB0[2] == 0) {
+                self->ext.GH_Props.unkB4[0] == 0) {
                 self->step_s++;
             }
             break;
@@ -435,7 +435,7 @@ void EntityGurkha(Entity* self) {
                 (self + 15)->ext.GH_Props.unkA6 / 16;
             func_801CE258(&D_80182F9C);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 SetStep(5);
             }
             break;
@@ -451,7 +451,7 @@ void EntityGurkha(Entity* self) {
         func_801CDE10(var_s2);
         func_801CE2CC(var_s2);
         func_801CE258(&D_80182F9C);
-        if (self->ext.GH_Props.unkB0[2] == 0) {
+        if (self->ext.GH_Props.unkB4[0] == 0) {
             self->facingLeft ^= 1;
             func_801CF7A0(self);
         }
@@ -471,7 +471,7 @@ void EntityGurkha(Entity* self) {
         func_801CE2CC(var_s2);
         func_801CE258(&D_80182F9C);
         if (self->ext.GH_Props.unkB0[0] == 0 &&
-            self->ext.GH_Props.unkB0[2] == 0) {
+            self->ext.GH_Props.unkB4[0] == 0) {
             func_801CF7A0(self);
         }
         break;
@@ -509,7 +509,7 @@ void EntityGurkha(Entity* self) {
         otherEnt->ext.GH_Props.unkA8 = 0;
     }
     D_8006C384.y = self->ext.GH_Props.unkB0[0];
-    D_8006C38C.y = self->ext.GH_Props.unkB0[2];
+    D_8006C38C.y = self->ext.GH_Props.unkB4[0];
     return;
 }
 

--- a/src/st/np3/blade.c
+++ b/src/st/np3/blade.c
@@ -251,7 +251,7 @@ void EntityBlade(Entity* self) {
             func_801D0A00(var_s2);
             func_801D0B40();
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 self->step_s++;
             }
             self->step_s++;
@@ -261,7 +261,7 @@ void EntityBlade(Entity* self) {
             func_801CDE10(var_s2);
             func_801D0A00(var_s2);
             func_801D0B40();
-            if ((self->ext.GH_Props.unkB0[2] == 0) &&
+            if ((self->ext.GH_Props.unkB4[0] == 0) &&
                 (self->ext.GH_Props.unkB0[0] == 0)) {
                 self->step_s++;
             }
@@ -326,7 +326,7 @@ void EntityBlade(Entity* self) {
                 self->ext.GH_Props.unk8D = 1;
             }
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 if (self->ext.GH_Props.unk8D != 0) {
                     self->step_s = 3;
                 } else {
@@ -339,12 +339,12 @@ void EntityBlade(Entity* self) {
             func_801CDE10(var_s2);
             func_801D0A00(var_s2);
             if ((self->ext.GH_Props.unkB0[0] == 1) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(SFX_BONE_SWORD_SWISH_C);
             }
             func_801CE258(&D_80183494);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 (self + 15)->ext.GH_Props.unk8D = 0;
                 (self + 16)->ext.GH_Props.unk8D = 0;
                 self->step_s++;
@@ -356,7 +356,7 @@ void EntityBlade(Entity* self) {
             func_801D0A00(var_s2);
             func_801CE258(&D_80183494);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 var_v0 = func_801D0B78(self);
                 if (var_v0 != 0) {
                     func_801CE1E8(var_v0);
@@ -385,7 +385,7 @@ void EntityBlade(Entity* self) {
         otherEnt = self + var_s2[5];
         otherEnt->ext.GH_Props.unk8D = 1;
         if ((self->ext.GH_Props.unkB0[0] == 0) &&
-            (self->ext.GH_Props.unkB0[2] == 0)) {
+            (self->ext.GH_Props.unkB4[0] == 0)) {
             otherEnt =
                 self + var_s2[5]; // repeated line, surprised it gets compiled
             otherEnt->ext.GH_Props.unk8D = 0;
@@ -408,7 +408,7 @@ void EntityBlade(Entity* self) {
         func_801D0A00(var_s2);
         func_801D0B40();
         func_801CE258(&D_80183494);
-        if (self->ext.GH_Props.unkB0[2] == 0) {
+        if (self->ext.GH_Props.unkB4[0] == 0) {
             self->ext.GH_Props.unk88 = 0;
             self->facingLeft ^= 1;
             var_v0 = func_801D0B78(self);
@@ -434,7 +434,7 @@ void EntityBlade(Entity* self) {
         func_801D0A00(var_s2);
         func_801CE258(&D_80183494);
         if ((self->ext.GH_Props.unkB0[0] == 0) &&
-            (self->ext.GH_Props.unkB0[2] == 0)) {
+            (self->ext.GH_Props.unkB4[0] == 0)) {
             var_v0 = func_801D0B78(self);
             if (var_v0 != 0) {
                 func_801CE1E8(var_v0);
@@ -464,11 +464,11 @@ void EntityBlade(Entity* self) {
             func_801D0A00(var_s2);
             func_801CE258(&D_80183494);
             if ((self->ext.GH_Props.unkB0[0] == 3) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(SFX_STOMP_HARD_A);
             }
             if (self->ext.GH_Props.unkB0[0] == 0 &&
-                self->ext.GH_Props.unkB0[2] == 0) {
+                self->ext.GH_Props.unkB4[0] == 0) {
                 self->step_s++;
             }
             break;
@@ -478,7 +478,7 @@ void EntityBlade(Entity* self) {
             func_801CDE88(var_s2);
             func_801CE258(&D_80183494);
             if ((self->ext.GH_Props.unkB0[0] == 0) &&
-                (self->ext.GH_Props.unkB0[2] == 0)) {
+                (self->ext.GH_Props.unkB4[0] == 0)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
                 (self + 15)->ext.GH_Props.unk8C = 1;
                 (self + 15)->ext.GH_Props.rotZ = 0x400;
@@ -522,7 +522,7 @@ void EntityBlade(Entity* self) {
         otherEnt->ext.GH_Props.unkA8 = 0;
     }
     D_8006C384.y = self->ext.GH_Props.unkB0[0];
-    D_8006C38C.y = self->ext.GH_Props.unkB0[2];
+    D_8006C38C.y = self->ext.GH_Props.unkB4[0];
 }
 
 void EntityBladeSword(Entity* self) {

--- a/src/st/st0/collision.c
+++ b/src/st/st0/collision.c
@@ -181,8 +181,7 @@ void HitDetection(void) {
                                       FLAG_UNK_100000)) {
                                     // Probably has to stay generic since
                                     // iterEnt2 could be any entity?
-                                    iterEnt2->ext.generic.unkB8.entityPtr =
-                                        iterEnt1;
+                                    iterEnt2->unkB8 = iterEnt1;
                                     iterEnt2->hitFlags = 1;
                                     if ((i == 12) &&
                                         (iterEnt1->flags & FLAG_UNK_8000)) {
@@ -229,7 +228,7 @@ void HitDetection(void) {
                     hitboxCheck2 += hitboxCheck1;
                     hitboxCheck1 *= 2;
                     if (hitboxCheck1 >= hitboxCheck2) {
-                        iterEnt2->ext.player.unkB8 = iterEnt1;
+                        iterEnt2->unkB8 = iterEnt1;
                         iterEnt2->hitFlags = 1;
                         iterEnt2->hitParams = iterEnt1->attackElement;
                         iterEnt2->hitPoints = iterEnt1->attack;


### PR DESCRIPTION
Improved PR compared to #1704 .

We decided that unkB8 shouldn't be part of the Ext since it appears to apply to all entities.

Also discovered some issues with the ET_GurkhaHammer struct, so resolved those as well.

Now all accesses to the unkB8 offset go directly to `self->unkB8`.