### PR TITLE
Decompile NO3 EntityBackgroundLightning

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -1796,6 +1796,13 @@ typedef struct {
     /* 0x8C */ struct Entity* parent;
 } ET_GhostEvent;
 
+typedef struct {
+    s32 : 32;
+    s16 unk80;
+    s16 : 16;
+    u8 unk84;
+} ET_BackgroundLightning;
+
 // ====== RIC ENTITIES ======
 
 // ==========================
@@ -1948,6 +1955,7 @@ typedef union { // offset=0x7C
     ET_DisableAfterImage disableAfterImage;
     ET_EntityExplosion3 entityExplosion3;
     ET_GhostEvent ghostEvent;
+    ET_BackgroundLightning backgroundLightning;
 } Ext;
 
 #define SYNC_FIELD(struct1, struct2, field_name)                               \

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -54,6 +54,7 @@ enum SfxModes {
 #define SET_UNK_10 0x10
 #define SET_UNK_11 0x11
 #define SET_UNK_12 0x12
+#define SET_UNK_90 0x90
 #define SET_RELEASE_RATE_LOW_20_21 0xa3
 #define SET_RELEASE_RATE_LOW_22_23 0xa7
 #define SET_KEY_ON_20_21 0xa4

--- a/src/dra/5087C.c
+++ b/src/dra/5087C.c
@@ -1203,7 +1203,7 @@ void RunMainEngine(void) {
 #if defined(VERSION_US)
             D_80097910 = SE_INTRO_WIND;
 #elif defined(VERSION_HD)
-            D_80097910 = 0x327;
+            D_80097910 = MU_METAMORPHOSIS;
 #endif
         }
         if ((D_8003C730 == 0) && !(D_8003C708.flags & 0x20)) {

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -135,8 +135,183 @@ void EntityUnkId16(Entity* self) {
     }
 }
 
+extern u8 D_80180EA0[];
+extern u8 D_80180F60;
+
+extern u16 D_80180FAC[];
+extern u16 D_80180FBC[];
+
+extern u8 D_80180FDC[][2];
+
 // lightning and sound for background
-INCLUDE_ASM("st/no3/nonmatchings/377D4", EntityBackgroundLightning);
+void EntityBackgroundLightning(Entity* self) {
+    Entity* otherEnt;
+    s32 playerRealX;
+    s32 randOf3;
+    s32 clutDest;
+    s32 i;
+    s32 clutSrc;
+    u8* var_s3;
+    u8* var_s1;
+
+    switch (self->step) {
+    case 0:
+        InitializeEntity(g_EInitGeneric);
+
+        self->ext.backgroundLightning.unk80 = 0x80;
+        self->animCurFrame = 0xF;
+        var_s1 = &D_80180EA0[0];
+        for (i = 0; i < 12; i++) {
+            clutDest = var_s1[0];
+            clutSrc = 15;
+            clutSrc = var_s1[clutSrc];
+            g_ClutIds[clutDest] = g_ClutIds[clutSrc + 0x200];
+            var_s1 += 16;
+        }
+        if (self->params & 256) {
+            self->step = 4;
+            break;
+        }
+        if (g_CastleFlags[CASTLE_FLAG_55]) {
+            self->params = 0;
+        }
+    case 1:
+        switch (self->step_s) {
+        case 0:
+            otherEnt = AllocEntity(&g_Entities[224], &g_Entities[256]);
+            if (otherEnt != NULL) {
+                CreateEntityFromCurrentEntity(E_ID_29, otherEnt);
+                randOf3 = (Random() & 3);
+                otherEnt->posX.i.hi = D_80180FDC[randOf3][0];
+                otherEnt->posY.i.hi = D_80180FDC[randOf3][1];
+            }
+            otherEnt = AllocEntity(&g_Entities[224], &g_Entities[256]);
+            if (otherEnt != NULL) {
+                CreateEntityFromCurrentEntity(E_ID_2A, otherEnt);
+                if (randOf3 > 2) {
+                    randOf3 = 0;
+                }
+                otherEnt->params = randOf3;
+            }
+            self->step_s += 1;
+
+        case 1:
+            if (AnimateEntity(D_80180FAC, self) == 0) {
+                self->ext.backgroundLightning.unk80 = (Random() & 0x7F) + 0x40;
+                self->step_s += 1;
+            }
+            var_s3 = &D_80180F60;
+            if (!self->params) {
+                var_s3 += 0x30;
+            }
+            for (clutSrc = self->animCurFrame; *var_s3 != 0xFF; var_s3 += 4) {
+                i = var_s3[0];
+                g_ClutIds[i] = g_ClutIds[(var_s3 + clutSrc)[1] + 0x200];
+            }
+
+            if (clutSrc == 1) {
+                g_GpuBuffers[0].draw.r0 = 0x30;
+                g_GpuBuffers[0].draw.g0 = 0x30;
+                g_GpuBuffers[0].draw.b0 = 0x48;
+                g_GpuBuffers[1].draw.r0 = 0x30;
+                g_GpuBuffers[1].draw.g0 = 0x30;
+                g_GpuBuffers[1].draw.b0 = 0x48;
+            } else {
+                g_GpuBuffers[0].draw.r0 = 0x10;
+                g_GpuBuffers[0].draw.g0 = 8;
+                g_GpuBuffers[0].draw.b0 = 0x38;
+                g_GpuBuffers[1].draw.r0 = 0x10;
+                g_GpuBuffers[1].draw.g0 = 8;
+                g_GpuBuffers[1].draw.b0 = 0x38;
+            }
+            break;
+        case 2:
+            g_GpuBuffers[0].draw.r0 = 0x10;
+            g_GpuBuffers[0].draw.g0 = 8;
+            g_GpuBuffers[0].draw.b0 = 0x38;
+            g_GpuBuffers[1].draw.r0 = 0x10;
+            g_GpuBuffers[1].draw.g0 = 8;
+            g_GpuBuffers[1].draw.b0 = 0x38;
+            if (!--self->ext.backgroundLightning.unk80) {
+                SetSubStep(0);
+            }
+            break;
+        }
+        if (self->params != 1) {
+            break;
+        }
+        otherEnt = &PLAYER;
+        playerRealX = g_Tilemap.scrollX.i.hi + otherEnt->posX.i.hi;
+        if (playerRealX > 0x300) {
+            g_CastleFlags[CASTLE_FLAG_55] = 1;
+            SetStep(2);
+        }
+        break;
+
+    case 2:
+        if (AnimateEntity(D_80180FBC, self) == 0) {
+            self->params = 0;
+            SetStep(1);
+        }
+        g_GpuBuffers[0].draw.r0 = 16;
+        g_GpuBuffers[0].draw.g0 = 8;
+        g_GpuBuffers[0].draw.b0 = 56;
+        g_GpuBuffers[1].draw.r0 = 16;
+        g_GpuBuffers[1].draw.g0 = 8;
+        g_GpuBuffers[1].draw.b0 = 56;
+        var_s1 = &D_80180EA0[0];
+        for (i = 0; i < 12; i++) {
+            clutDest = var_s1[0];
+            clutSrc = self->animCurFrame;
+            clutSrc = var_s1[clutSrc];
+            g_ClutIds[clutDest] = g_ClutIds[clutSrc + 0x200];
+            var_s1 += 16;
+        }
+        break;
+
+    case 4:
+        g_GpuBuffers[0].draw.r0 = 16;
+        g_GpuBuffers[0].draw.g0 = 8;
+        g_GpuBuffers[0].draw.b0 = 56;
+        g_GpuBuffers[1].draw.r0 = 16;
+        g_GpuBuffers[1].draw.g0 = 8;
+        g_GpuBuffers[1].draw.b0 = 56;
+    }
+    if (self->params == 1) {
+        switch (self->ext.backgroundLightning.unk84) {
+        case 0:
+            g_api.PlaySfx(SET_UNK_90);
+            self->ext.backgroundLightning.unk84++;
+            D_80097928 = 1;
+            D_80097910 = SE_INTRO_WIND_QUIET;
+            break;
+        case 1:
+            if (g_api.func_80131F68() == false) {
+                D_80097928 = 0;
+                g_api.PlaySfx(D_80097910);
+                self->ext.backgroundLightning.unk84++;
+            }
+            break;
+        case 2:
+            otherEnt = &PLAYER;
+            playerRealX = g_Tilemap.scrollX.i.hi + otherEnt->posX.i.hi;
+            if (playerRealX > 0x300) {
+                g_api.PlaySfx(SET_UNK_90);
+                D_80097928 = 1;
+                D_80097910 = MU_DRACULAS_CASTLE;
+                self->ext.backgroundLightning.unk84++;
+            }
+            break;
+        case 3:
+            if (g_api.func_80131F68() == false) {
+                D_80097928 = 0;
+                g_api.PlaySfx(D_80097910);
+                self->ext.backgroundLightning.unk84++;
+            }
+            break;
+        }
+    }
+}
 
 // window that opens and shuts in the background
 void EntityShuttingWindow(Entity* self) {

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -48,6 +48,8 @@ typedef enum EntityIDs {
     /* 0x17 */ E_BG_LIGHTNING = 0x17,
     /* 0x1E */ E_CAVERN_DOOR_LEVER_UNK0 = 0x1E,
     /* 0x27 */ E_FALLING_ROCK_2 = 0x27,
+    /* 0x29 */ E_ID_29 = 0x29,
+    /* 0x2A */ E_ID_2A,
     /* 0x2E */ E_ID_2E = 0x2E,
     /* 0x30 */ E_ID_30 = 0x30,
     /* 0x31 */ E_ID_31,

--- a/src/st/nz0/bossfight.c
+++ b/src/st/nz0/bossfight.c
@@ -65,7 +65,7 @@ void EntityBossFightManager(Entity* self) {
             g_api.TimeAttackController(
                 TIMEATTACK_EVENT_SLOGRA_GAIBON_DEFEAT, TIMEATTACK_SET_VISITED);
             D_80097928 = 1;
-            D_80097910 = 0x31D;
+            D_80097910 = MU_FESTIVAL_OF_SERVANTS;
             self->step++;
         }
         break;
@@ -83,9 +83,9 @@ void EntityBossFightManager(Entity* self) {
             g_api.TimeAttackController(
                 TIMEATTACK_EVENT_SLOGRA_GAIBON_DEFEAT, TIMEATTACK_SET_RECORD);
             if (g_api.func_80131F68() != false) {
-                g_api.PlaySfx(0x90);
+                g_api.PlaySfx(SET_UNK_90);
             }
-            D_80097910 = 0x32E;
+            D_80097910 = MU_DANCE_OF_GOLD;
             self->step++;
         }
         return;
@@ -103,7 +103,7 @@ void EntityBossFightManager(Entity* self) {
         g_BossFlag |= BOSS_FLAG_DOORS_OPEN; // Reopen the door
         g_CastleFlags[SG_KILL_ALCH] = 1;
         D_80097928 = 1;
-        D_80097910 = 0x32E;
+        D_80097910 = MU_DANCE_OF_GOLD;
         self->step++;
         return;
     case 6:


### PR DESCRIPTION
Nice to get more progress in our "old" stages on those last few difficult functions.

At the end of this function there is a little switch block which switches around some SFX; this informed me that D_80097910 holds SFX, so I went back through the repo for other uses of this variable and made it use SFX enums. This variable appears to hold the SFX ID for the current background music. Maybe it deserves a name, but I don't want to turn this PR into too much of a mess of doing different things.