### PR TITLE
Rework sotn-assets animation pointers

### DIFF
--- a/src/boss/mar/header.c
+++ b/src/boss/mar/header.c
@@ -2,7 +2,7 @@
 #include "mar.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 static GfxBank* gfxBanks[];

--- a/src/st/cen/header.c
+++ b/src/st/cen/header.c
@@ -2,7 +2,7 @@
 #include "cen.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-static signed short* spriteBanks[];
+static s16** spriteBanks[];
 static void* Cluts[];
 static MyRoomDef rooms_layers[];
 static GfxBank* gfxBanks[];

--- a/src/st/dre/header.c
+++ b/src/st/dre/header.c
@@ -2,7 +2,7 @@
 #include "dre.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 extern GfxBank* g_GfxBanks[];

--- a/src/st/no3/header.c
+++ b/src/st/no3/header.c
@@ -2,7 +2,7 @@
 #include "no3.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 extern GfxBank* g_GfxBanks[];

--- a/src/st/np3/header.c
+++ b/src/st/np3/header.c
@@ -2,7 +2,7 @@
 #include "np3.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 extern GfxBank* g_GfxBanks[];

--- a/src/st/nz0/header.c
+++ b/src/st/nz0/header.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "nz0.h"
 
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* g_Cluts[];
 extern void* g_EntityGfxs[];
 extern MyRoomDef rooms_layers[];

--- a/src/st/rwrp/header.c
+++ b/src/st/rwrp/header.c
@@ -2,7 +2,7 @@
 #include "rwrp.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 extern void* OVL_EXPORT(g_EntityGfxs)[];

--- a/src/st/st0/header.c
+++ b/src/st/st0/header.c
@@ -2,7 +2,7 @@
 #include "st0.h"
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-extern signed short* spriteBanks[];
+extern s16** spriteBanks[];
 extern void* Cluts[];
 extern MyRoomDef rooms_layers[];
 extern GfxBank* g_EntityGfxs[];

--- a/src/st/wrp/header.c
+++ b/src/st/wrp/header.c
@@ -14,7 +14,7 @@ void BottomCornerText(u8*, u8);
 extern MyRoomDef rooms_layers[];
 
 extern RoomHeader OVL_EXPORT(rooms)[];
-static signed short* spriteBanks[];
+static s16** spriteBanks[];
 extern void* g_Cluts[];
 extern RoomDef g_TileLayers[];
 extern void* OVL_EXPORT(g_EntityGfxs)[];

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -373,15 +373,15 @@ func buildSprites(fileName string, outputDir string) error {
 			continue
 		}
 		symbol := fmt.Sprintf("sprites_%s_%d", ovlName, i)
-		sbHeader.WriteString(fmt.Sprintf("extern s16* %s;\n", symbol))
+		sbHeader.WriteString(fmt.Sprintf("extern s16* %s[];\n", symbol))
 		buildSpriteGroup(&sbData, sprites, symbol, r)
 		symbols = append(symbols, symbol)
 	}
 
-	sbHeader.WriteString("static s16* spriteBanks[] = {\n")
+	sbHeader.WriteString("static s16** spriteBanks[] = {\n")
 	for _, index := range spritesBanks.Indices {
 		if index >= 0 {
-			sbHeader.WriteString(fmt.Sprintf("    &%s,\n", symbols[index]))
+			sbHeader.WriteString(fmt.Sprintf("    %s,\n", symbols[index]))
 		} else {
 			sbHeader.WriteString(fmt.Sprintf("    0,\n"))
 		}


### PR DESCRIPTION
I was reviewing some of the animations pulled out by sotn-assets. Speicfically, I found that in `src/st/no3/sprite_banks.h` (a file created by sotn-assets locally, which does not exist directly in this repo), we have:

```
extern s16* sprites_no3_0;
extern s16* sprites_no3_1;
extern s16* sprites_no3_2;
extern s16* sprites_no3_3;
extern s16* sprites_no3_4;
extern s16* sprites_no3_5;
extern s16* sprites_no3_6;
extern s16* sprites_no3_7;
extern s16* sprites_no3_8;
static s16* spriteBanks[] = {
    0,
    &sprites_no3_0,
    &sprites_no3_3,
    &sprites_no3_1,
    &sprites_no3_2,
    &sprites_no3_4,
    &sprites_no3_5,
    &sprites_no3_6,
    &sprites_no3_7,
    &sprites_no3_8,
```

However, those are not the right pointer types. `sprites_no3_#` should have a type of `s16* []`, so I reworked the sotn-assets tool to use the right pointers for each of these things. Now the sprite_banks.h file looks like: 
```
extern s16* sprites_no3_0[];
extern s16* sprites_no3_1[];
extern s16* sprites_no3_2[];
extern s16* sprites_no3_3[];
extern s16* sprites_no3_4[];
extern s16* sprites_no3_5[];
extern s16* sprites_no3_6[];
extern s16* sprites_no3_7[];
extern s16* sprites_no3_8[];
static s16** spriteBanks[] = {
    0,
    sprites_no3_0,
    sprites_no3_3,
    sprites_no3_1,
    sprites_no3_2,
    sprites_no3_4,
    sprites_no3_5,
    sprites_no3_6,
    sprites_no3_7,
    sprites_no3_8,
```

Which more accurately represents the data within.

Naturally, since this PR mostly just changes the tool, the real changes are in the tool's output, so feel free to clone this branch and investigate the sprite_banks.h file if you want to see anything further about it.

DRA's equivalent of the SpriteBanks array is `D_800A3B70`, and is currently in the repo as extracted data, without using `sotn-assets`; this PR makes it so the types in the overlays (which do use `sotn-assets`) will match the types in DRA.