### PR TITLE
Replace MSVC with MinGW GCC

### DIFF
--- a/.github/workflows/picci.yaml
+++ b/.github/workflows/picci.yaml
@@ -110,6 +110,7 @@ jobs:
         mkdir C:\temp-sdl2
         powershell Invoke-WebRequest 'https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-devel-2.28.5-VC.zip' -OutFile C:\temp-sdl2\SDL2-devel-2.28.5-VC.zip
         7z x C:\temp-sdl2\SDL2-devel-2.28.5-VC.zip -oC:\temp-sdl2
+        choco install ninja
     - name: Clone repo
       uses: actions/checkout@v4
       with:
@@ -130,7 +131,7 @@ jobs:
         & make -j build_assets SOTNASSETS=$SOTN_ASSETS
     - name: Build
       run: |
-        cmake -B ${{github.workspace}}/pc -DCMAKE_BUILD_TYPE=Release -DSDL2_PATH=C:\temp-sdl2\SDL2-2.28.5
+        cmake -B ${{github.workspace}}/pc -G "Ninja" -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE=Release -DSDL2_PATH=C:\temp-sdl2\SDL2-2.28.5
         cmake --build ${{github.workspace}}/pc --config Release
 
   build-linux-lle:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,12 @@ endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   set(CMAKE_BUILD_TYPE Debug)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fsanitize=address")
+  if (NOT WIN32)
+    # asan is not supported on Windows
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fsanitize=address")
+  endif()
 
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-function-declaration")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types")

--- a/include/types.h
+++ b/include/types.h
@@ -18,7 +18,7 @@ typedef unsigned int size_t;
 #include <sys/types.h>
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 typedef unsigned char u_char;
 typedef unsigned short u_short;
 typedef unsigned long long u_long;

--- a/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h
+++ b/src/pc/psxsdk/PsyCross/src/gte/psx/inline_c.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 typedef unsigned int uint;
 typedef unsigned short ushort;
 #endif

--- a/src/pc/psxsdk/libapi.c
+++ b/src/pc/psxsdk/libapi.c
@@ -27,7 +27,11 @@ long TestEvent(unsigned long event) {
     return 1;
 }
 
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
+// needs to be disabled on Windows as it overlaps with the kernel32 API:
+// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-entercriticalsection
 void EnterCriticalSection(void) { NOT_IMPLEMENTED; }
+#endif
 
 void ExitCriticalSection(void) { NOT_IMPLEMENTED; }
 

--- a/src/pc/render_gl.c
+++ b/src/pc/render_gl.c
@@ -3,7 +3,7 @@
 #include <log.h>
 #include <game.h>
 #include <stdlib.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 #else

--- a/src/pc/render_soft.c
+++ b/src/pc/render_soft.c
@@ -3,7 +3,7 @@
 #include <log.h>
 #include <game.h>
 #include <stdlib.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 #else

--- a/src/pc/sdl2.c
+++ b/src/pc/sdl2.c
@@ -3,7 +3,7 @@
 #include <log.h>
 #include <game.h>
 #include <stdlib.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 #else

--- a/src/pc/sdl2_macros.c
+++ b/src/pc/sdl2_macros.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include <game.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 #else


### PR DESCRIPTION
This is mainly done to put an end on the [C2133](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2133?view=msvc-170) error and other oddities caused by the Microsoft Visual C++ compiler. It will be much easier to just rely on what GCC, Clang and MW C accepts as right instead of adding a fourth element into the mix that caused us more problems than what was worth.

This is achieved by hinting cmake to use GCC with `DCMAKE_C_COMPILER=gcc`. The CI agents from GitHub comes with MinGW pre-installed, so let's take advantage of that.

This unlocks #1743, #1701 and any issue we were bound to encounter later on.