### PR TITLE
Fix issues with running under MSVC

### DIFF
--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -255,7 +255,11 @@ void PlayAnimation(s8* frameProps, AnimationFrame** frames) {
 
 u32 UpdateAnim(s8* frameProps, AnimationFrame** anims) {
     AnimationFrame* animFrame;
+#if defined(VERSION_PC)
+    s32 ret = 0;
+#else
     s32 ret;
+#endif
 
     if (g_CurrentEntity->animFrameDuration == -1) {
         ret = -1;

--- a/src/dra/953A0.c
+++ b/src/dra/953A0.c
@@ -1474,7 +1474,11 @@ void func_80136010(void) {
 
     s8 sum;
     s8* new_var;
+#if defined(VERSION_PC)
+    s16* fakeptr = 0;
+#else
     s16* fakeptr;
+#endif
 
     SpuGetAllKeysStatus(g_KeyStatus);
     if (g_SeqIsPlaying == 0) {

--- a/src/pc/psxsdk/libsnd.c
+++ b/src/pc/psxsdk/libsnd.c
@@ -93,7 +93,7 @@ u16* D_80032F10;
 
 struct SpuVoice _svm_voice[NUM_SPU_CHANNELS];
 
-void WaitEvent(s32) {}
+void WaitEvent(s32 arg0) {}
 
 union RegBuf _svm_sreg_buf;
 
@@ -268,7 +268,7 @@ struct _ss_spu_vm_rec_struct _ss_spu_vm_rec;
 s16 _svm_orev1;
 s16 _svm_orev2;
 
-void SpuVmKeyOn(s16, s16, u8, s32, s32, s32) { assert(0); }
+void SpuVmKeyOn(s16 arg0, s16 arg1, u8 arg2, s32 arg3, s32 arg4, s32 arg5) { assert(0); }
 
 s32 _svm_envx_hist[32];
 s32 D_8003BD08 = 0;
@@ -586,7 +586,7 @@ long SpuSetReverbModeParam(SpuReverbAttr* attr) {
 
 long ResetRCnt(long spec) { return 1; }
 
-void* InterruptCallback(u8, void (*)()) { return 0; }
+void* InterruptCallback(u8 arg0, void (*arg1)()) { return 0; }
 
 long GetVideoMode(void) { return 0; }
 
@@ -1151,7 +1151,7 @@ s32 _spu_addrMode;
 
 void (* volatile _spu_IRQCallback)();
 
-void DeliverEvent(unsigned long, unsigned long) {}
+void DeliverEvent(unsigned long arg0, unsigned long arg1) {}
 
 s32 D_800330F8[256] = {0};
 s32 D_80033558;
@@ -1200,14 +1200,14 @@ int _spu_t(int mode, ...) {
     return 0;
 }
 
-void _SsSndCrescendo(s16, s16) { assert(false); }
-void _SsSndDecrescendo(s16, s16) { assert(false); }
+void _SsSndCrescendo(s16 arg0, s16 arg1) { assert(false); }
+void _SsSndDecrescendo(s16 arg0, s16 arg1) { assert(false); }
 
 void SpuVmSetVol(
     short seq_sep_no, short vabId, short program, short voll, short volr) {
     assert(false);
 }
 
-void _SsContDataEntry(s16, s16, u8) { assert(false); }
+void _SsContDataEntry(s16 arg0, s16 arg1, u8 arg2) { assert(false); }
 
 #endif

--- a/src/pc/psxsdk/libspu.c
+++ b/src/pc/psxsdk/libspu.c
@@ -301,5 +301,5 @@ long SpuMallocWithStartAddr(unsigned long addr, long size) {
     return var_v0;
 }
 #include <assert.h>
-void _SpuSetVoiceAttr(SpuVoiceAttr* arg, s32, s32, s32) { NOT_IMPLEMENTED; }
+void _SpuSetVoiceAttr(SpuVoiceAttr* arg0, s32 arg1, s32 arg2, s32 arg3) { NOT_IMPLEMENTED; }
 #endif

--- a/src/pc/render_soft.c
+++ b/src/pc/render_soft.c
@@ -428,8 +428,7 @@ void SoftDrawOTag(OT_TYPE* p) {
             num_updates = 2;
             break;
         default:
-            assert(false);
-            WARNF("code %02X not supported", code);
+            WARNF("SoftDrawOTag: code %02X not supported", code);
             break;
         }
         for (int i = 0; i < num_updates; i++) {

--- a/src/st/no0/e_breakable.c
+++ b/src/st/no0/e_breakable.c
@@ -50,4 +50,4 @@ static u8 g_eBreakableDrawModes[] = {
     DRAW_DEFAULT,
     DRAW_DEFAULT};
 
-#include "../e_breakable.h";
+#include "../e_breakable.h"


### PR DESCRIPTION
Fixed some uninitialised pointers / return types which affected a few things at runtime - down on main menu and leaving through door.

Fixed some build errors with WANT_LIBSND_LLE due to unnamed parameters in implemented functions. Still working on getting it building locally with this flag enabled but this gets a little further.