### PR TITLE
Remove redundant header comments

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/**
- * Custom Entity Subtypes
- */
-
 #include "common.h"
 
 struct Entity;

--- a/src/st/dre/11A64.c
+++ b/src/st/dre/11A64.c
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * File: 11A64.c
- * Overlay: DRE
- * Description: Nightmare
- */
-
 #include "dre.h"
 #include "sfx.h"
 

--- a/src/st/dre/succubus.c
+++ b/src/st/dre/succubus.c
@@ -1,11 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: DRE
- * Enemy: Succubus Boss
- * ID: 0x19
- * BOSS ID: 9
- */
-
 #include "dre.h"
 #include "sfx.h"
 

--- a/src/st/e_merman.h
+++ b/src/st/e_merman.h
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Entity: Merman
- * Stages: NO3, NP3
- */
-
 typedef enum {
     MERMAN_INIT,
     MERMAN_SWIMMING_UP,

--- a/src/st/e_merman2.h
+++ b/src/st/e_merman2.h
@@ -1,11 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Entity: Merman2
- * Stages: NO3, NP3
- *
- * Another merman variant
- */
-
 typedef enum {
     MERMAN2_INIT,
     MERMAN2_SWIMMING_UP,

--- a/src/st/no3/377D4.c
+++ b/src/st/no3/377D4.c
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * File: 377D4.c
- * Overlay: NO3
- * Description: Castle Entrance
- */
-
 #include "no3.h"
 #include "sfx.h"
 

--- a/src/st/np3/44DCC.c
+++ b/src/st/np3/44DCC.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NP3
- * Description: Merman Room
- */
-
 #include "np3.h"
 #include "sfx.h"
 #include "../e_merman2.h"

--- a/src/st/np3/48238.c
+++ b/src/st/np3/48238.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NP3
- * Description: Merman Room (2)
- */
-
 #include "np3.h"
 #include "sfx.h"
 #include "../e_merman.h"

--- a/src/st/np3/49F98.c
+++ b/src/st/np3/49F98.c
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NP3
- * Enemy: Bloody Zombie
- */
 
 // NOTE: There is an nz0/e_bloody_zombie.c which is almost exactly the same as
 // this file. Would maybe be smart to try to de-duplicate. Could be marked as

--- a/src/st/np3/slogra.c
+++ b/src/st/np3/slogra.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NP3
- * Enemy: Slogra & Gaibon Boss
- */
-
 #include "np3.h"
 #include "sfx.h"
 

--- a/src/st/nz0/30958.c
+++ b/src/st/nz0/30958.c
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * File: 394D4.c
- * Overlay: NZ0
- * Description: Alchemy Laboratory
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/nz0/e_axe_knight.c
+++ b/src/st/nz0/e_axe_knight.c
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Enemy: Axe Knight
- * Description: Low level Axe Knight
- */
-
 #include "nz0.h"
 
 #include "../entity_axe_knight.h"

--- a/src/st/nz0/e_bloody_skeleton.c
+++ b/src/st/nz0/e_bloody_skeleton.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Enemy: Blood Skeleton
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/nz0/e_bloody_zombie.c
+++ b/src/st/nz0/e_bloody_zombie.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Enemy: Bloody Zombie
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/nz0/e_skeleton.c
+++ b/src/st/nz0/e_skeleton.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Enemy: Skeleton
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/nz0/e_spittle_bone.c
+++ b/src/st/nz0/e_spittle_bone.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Enemy: Spittle Bone
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/nz0/e_subweapon_container.c
+++ b/src/st/nz0/e_subweapon_container.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: NZ0
- * Entity: SubWeapon container
- */
-
 #include "nz0.h"
 #include "sfx.h"
 

--- a/src/st/sel/2C048.c
+++ b/src/st/sel/2C048.c
@@ -1,10 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * File: 2C048.c
- * Overlay: SEL
- * Description: Title & loading screen
- */
-
 #include "sel.h"
 #include "memcard.h"
 #include "sfx.h"

--- a/src/st/st0/2A8DC.c
+++ b/src/st/st0/2A8DC.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: ST0
- * Entity: Secret Stairs
- */
-
 #include "st0.h"
 #include "sfx.h"
 

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-/*
- * Overlay: ST0
- * Enemy: Dracula Boss
- */
-
 #include "st0.h"
 #include "sfx.h"
 


### PR DESCRIPTION
There are various C files that have this three-lines comments with file name, overlay name and description. It is redundant because the file name is in... the file name. The overlay name is in the file path and the description is implied in the source file name once we find a suitable name.

I wanted to get rid of those because they might mislead new contributors as if it is a requirement or not. And it is better to have a code base that is compact and self-descriptive enough.