### PR TITLE
Remove the function calls chart from CI workflow

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -76,12 +76,6 @@ jobs:
         run: make -j build
       - name: Check if they match
         run: make check
-      - name: Analyze calls dry run
-        if: matrix.version == 'us'
-        run: |
-          make force_symbols
-          make force_extract
-          .venv/bin/python3 ./tools/analyze_calls.py --ultradry
       - name: Remove clutter from build folder
         run: rm -rf build/${{ matrix.version }}/asm build/${{ matrix.version }}/src build/${{ matrix.version }}/assets
       - name: Export build folder
@@ -185,16 +179,8 @@ jobs:
             make python-dependencies & \
             (sudo apt-get update && sudo apt-get install graphviz) & \
             wait
-      - name: Generate function calls chart
-        run: |
-            make force_symbols
-            make force_extract
-            rm -rf gh-duplicates/function_calls/ || true
-            .venv/bin/python3 tools/analyze_calls.py --output_dir=gh-duplicates/function_calls
-            git clean -fdx asm/
       - name: Generate duplicates report
         run: |
-          make clean
           make force_symbols
           make -j extract
           cd tools/dups
@@ -205,7 +191,7 @@ jobs:
             rm -rf build/us/main.ld
             rm -rf build/us/weapon.ld
             make -j extract
-            .venv/bin/python3 tools/function_finder/function_finder_psx.py --use-call-trees > gh-duplicates/functions.md
+            .venv/bin/python3 tools/function_finder/function_finder_psx.py > gh-duplicates/functions.md
       - name: Commit all reports
         run: |
             git config --global user.name 'GitHub Action'


### PR DESCRIPTION
Should fix issues with symbols in subsequent steps related to the use of `force_extract`