### PR TITLE
Try fixing duplicate report symbols by cleaning .ld files first

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -179,19 +179,17 @@ jobs:
             make python-dependencies & \
             (sudo apt-get update && sudo apt-get install graphviz) & \
             wait
+      - name: Clean ld files
+        run: |
+            find ./build -type f -name "*.ld" -delete
       - name: Generate duplicates report
         run: |
-          make clean
           make force_symbols
           make -j extract
           cd tools/dups
           cargo run --release -- --threshold .90 --output-file ../../gh-duplicates/duplicates.txt
       - name: Generate function report
         run: |
-            git checkout config/
-            rm -rf build/us/main.ld
-            rm -rf build/us/weapon.ld
-            make -j extract
             .venv/bin/python3 tools/function_finder/function_finder_psx.py > gh-duplicates/functions.md
       - name: Commit all reports
         run: |


### PR DESCRIPTION
I still can't reproduce the prior CI issue locally.

Steps:
* Clone repo fresh
* Follow steps from `generate-duplicates-report`
    *  `make update-dependencies`
    * `make extract_disk`
    * `Obtain built binaries` extracting `build_us.zip` from failing job to `build/us/*`
    * `make force_symbols`
    * `make -j extract`
    * `cd tools/dups`
    * `cargo run --release -- --threshold .90 --output-file ../../gh-duplicates/duplicates.txt`

Given the suspicion is the `.ld` files I've added a step to remove those from the `build_us.zip` output before running.

After doing so and running the workflow steps from this PR, output is
duplicates.txt: https://gist.github.com/JoshSchreuder/4725784aa12ab97e37ae31d6035c0ade