### PR TITLE
Eliminate ext.generic.modeS8

### DIFF
--- a/config/symbols.hd.stcen.txt
+++ b/config/symbols.hd.stcen.txt
@@ -1,7 +1,7 @@
 g_EInitObtainable = 0x80180410;
 g_EInitParticle = 0x8018041C;
 g_EInitMaria = 0x80180428;
-g_eElevatorInit = 0x8018047C;
+g_EInitElevator = 0x8018047C;
 CEN_PrizeDrops = 0x801805D8;
 D_801805DC = 0x801805DC;
 D_801805E0 = 0x801805E0;

--- a/config/symbols.us.stno0.txt
+++ b/config/symbols.us.stno0.txt
@@ -8,6 +8,7 @@ g_EInitInteractable = 0x80180A94;
 g_EInitUnkId13 = 0x80180AD0;
 g_EInitCommon = 0x80180AE8;
 g_EInitDamageNum = 0x80180B18;
+g_EInitElevator = 0x80180B60;
 D_80180C94 = 0x80180BC0;
 g_EInitAxeKnight = 0x80180BFC;
 D_80180C6A = 0x80180C02;

--- a/include/entity.h
+++ b/include/entity.h
@@ -33,26 +33,23 @@ typedef struct ET_Generic {
             /* 0x80 */ s16 unk0;
             /* 0x82 */ s16 unk2;
         } modeS16;
-        struct {
-            /* 0x80 */ u8 unk0;
-        } modeS8;
     } unk80; // size = 0x4
 } ET_Generic;
 
 typedef struct {
-    /* 0x00 */ u16 timer;
-    /* 0x02 */ s16 unk7E;
-    /* 0x04 */ u8 aliveTimer;
-    /* 0x05 */ s8 unk81;
-    /* 0x06 */ s16 unk82;
-    /* 0x08 */ s32 fallSpeed;
-    /* 0x0C */ s16 gravity;
-    /* 0x0E */ s16 unk8A;
-    /* 0x10 */ s16 iconSlot;
-    /* 0x12 */ s16 unk8E;
-    /* 0x14 */ s16 unk90;
-    /* 0x16 */ s16 unk92;
-    /* 0x18 */ s32 castleFlag;
+    /* 0x7C */ u16 timer;
+    /* 0x7E */ s16 unk7E;
+    /* 0x80 */ u8 aliveTimer;
+    /* 0x81 */ s8 unk81;
+    /* 0x82 */ s16 unk82;
+    /* 0x84 */ s32 fallSpeed;
+    /* 0x88 */ s16 gravity;
+    /* 0x8A */ s16 unk8A;
+    /* 0x8C */ s16 iconSlot;
+    /* 0x8E */ s16 unk8E;
+    /* 0x90 */ s16 unk90;
+    /* 0x92 */ s16 unk92;
+    /* 0x94 */ s32 castleFlag;
 } ET_EquipItemDrop;
 
 typedef struct {
@@ -1818,6 +1815,19 @@ typedef struct {
     /* 0x84 */ u16 timer;
 } ET_DeathScythe;
 
+typedef struct {
+    /* 0x7C */ u8 animframe;
+    /* 0x7D */ s32 : 24;
+    /* 0x80 */ u8 velIndex;
+} ET_Unused_MAD_ST0;
+
+// Elevator at the top of CEN.
+// Exists in both CEN and NO0 (lowers you into CEN)
+typedef struct {
+    /* 0x7C */ struct Primitve* prim;
+    /* 0x80 */ u8 unk80;
+} ET_CEN_Elevator;
+
 // ====== RIC ENTITIES ======
 
 // ==========================
@@ -1976,6 +1986,8 @@ typedef union { // offset=0x7C
     ET_MermanRock mermanRock;
     ET_Warg warg;
     ET_DeathScythe deathScythe;
+    ET_Unused_MAD_ST0 unusedMadST0;
+    ET_CEN_Elevator cenElevator;
 } Ext;
 
 #define SYNC_FIELD(struct1, struct2, field)                                    \

--- a/src/st/cen/F890.c
+++ b/src/st/cen/F890.c
@@ -127,7 +127,7 @@ void EntityPlatform(Entity* self) {
             } else {
                 g_Player.padSim = 0;
             }
-            g_Entities[1].ext.generic.unk7C.S8.unk0 = 0;
+            g_Entities[1].ext.entSlot1.unk0 = 0;
             g_Player.D_80072EFC = 1;
             self->step++;
         }
@@ -230,7 +230,7 @@ void EntityPlatform(Entity* self) {
             if (g_unkGraphicsStruct.pauseEnemies != 0) {
                 g_unkGraphicsStruct.pauseEnemies = 0;
             }
-            g_Entities[1].ext.generic.unk7C.S8.unk0 = 1;
+            g_Entities[1].ext.entSlot1.unk0 = 1;
             self->step++;
             g_api.PlaySfx(SFX_DOOR_CLOSE_A);
         }
@@ -416,13 +416,13 @@ void EntityElevatorStationary(Entity* self) {
 
     switch (self->step) {
     case 0:
-        InitializeEntity(g_eElevatorInit);
+        InitializeEntity(g_EInitElevator);
         self->animCurFrame = 3;
         self->zPriority = player->zPriority + 2;
         CreateEntityFromCurrentEntity(E_ELEVATOR_STATIONARY, &self[-1]);
-        self[-1].params = 1;
+        (self - 1)->params = 1;
         CreateEntityFromCurrentEntity(E_ELEVATOR_STATIONARY, &self[-2]);
-        self[-2].params = 2;
+        (self - 2)->params = 2;
         primIndex = g_api.AllocPrimitives(PRIM_GT4, 12);
         if (primIndex == -1) {
             DestroyEntity(self);
@@ -430,7 +430,7 @@ void EntityElevatorStationary(Entity* self) {
         }
         prim = &g_PrimBuf[primIndex];
         self->primIndex = primIndex;
-        self->ext.prim = prim;
+        self->ext.cenElevator.prim = prim;
         self->flags |= FLAG_HAS_PRIMS;
         prim->tpage = 0x12;
         prim->clut = 0x223;
@@ -453,17 +453,17 @@ void EntityElevatorStationary(Entity* self) {
             self->posY.i.hi = player->posY.i.hi;
             player->posX.i.hi = self->posX.i.hi;
             self->animCurFrame = 10;
-            g_Entities[1].ext.stub[0x00] = 1;
+            g_Entities[1].ext.entSlot1.unk0 = 1;
             SetStep(3);
         }
         break;
 
     case 1:
-        if (*(u8*)&self[-1].ext.stub[0x4]) {
+        if ((self - 1)->ext.cenElevator.unk80) {
             posX = self->posX.i.hi - player->posX.i.hi;
             if (g_pads[0].pressed & PAD_UP) {
                 if (abs(posX) < 8) {
-                    g_Entities[1].ext.stub[0x00] = 1;
+                    g_Entities[1].ext.entSlot1.unk0 = 1;
                     g_Player.D_80072EFC = 2;
                     g_Player.padSim = 0;
                     PLAYER.velocityX = 0;
@@ -494,7 +494,7 @@ void EntityElevatorStationary(Entity* self) {
             if (AnimateEntity(D_80180780, self) == 0) {
                 self->animFrameIdx = 0;
                 self->animFrameDuration = 0;
-                g_Entities[1].ext.stub[0x00] = 0;
+                g_Entities[1].ext.entSlot1.unk0 = 0;
                 self->step_s = 0;
                 self->step = 1;
             }
@@ -531,14 +531,14 @@ void EntityElevatorStationary(Entity* self) {
             if (AnimateEntity(D_80180780, self) == 0) {
                 self->animFrameIdx = 0;
                 self->animFrameDuration = 0;
-                g_Entities[1].ext.stub[0x00] = 0;
+                g_Entities[1].ext.entSlot1.unk0 = 0;
                 self->step_s = 0;
                 self->step = 1;
             }
             break;
         }
     }
-    prim = self->ext.prim;
+    prim = self->ext.cenElevator.prim;
     prim->x0 = prim->x2 = self->posX.i.hi - 8;
     prim->x1 = prim->x3 = self->posX.i.hi + 8;
     temp = self->posY.i.hi;
@@ -575,7 +575,7 @@ void EntityUnkId1B(Entity* self) {
 
     switch (self->step) {
     case 0:
-        InitializeEntity(g_eElevatorInit);
+        InitializeEntity(g_EInitElevator);
         if (self->params & 16) {
             self->animCurFrame = self->params & 15;
             self->zPriority = 0x6A;
@@ -587,13 +587,13 @@ void EntityUnkId1B(Entity* self) {
 
     case 1:
         self->posX.i.hi = entity->posX.i.hi;
-        if (self->params == step) {
+        if (self->params == 1) {
             self->posY.i.hi = entity->posY.i.hi + 35;
-            self->ext.generic.unk80.modeS8.unk0 =
+            self->ext.cenElevator.unk80 =
                 GetPlayerCollisionWith(self, 12, 8, 4);
         } else {
             self->posY.i.hi = entity->posY.i.hi - 24;
-            self->ext.generic.unk80.modeS8.unk0 =
+            self->ext.cenElevator.unk80 =
                 GetPlayerCollisionWith(self, 12, 8, 6);
         }
         break;
@@ -611,7 +611,7 @@ void EntityMovingElevator(Entity* self) {
 
     switch (self->step) {
     case 0:
-        InitializeEntity(g_eElevatorInit);
+        InitializeEntity(g_EInitElevator);
         self->animCurFrame = 3;
         self->zPriority = player->zPriority + 2;
         primIndex = g_api.AllocPrimitives(PRIM_GT4, 12);
@@ -621,7 +621,7 @@ void EntityMovingElevator(Entity* self) {
         }
         prim = &g_PrimBuf[primIndex];
         self->primIndex = primIndex;
-        self->ext.prim = prim;
+        self->ext.cenElevator.prim = prim;
         self->flags |= FLAG_HAS_PRIMS;
         while (prim != NULL) {
             prim->tpage = 0x12;
@@ -646,7 +646,7 @@ void EntityMovingElevator(Entity* self) {
         }
 
         self->animCurFrame = 10;
-        g_Entities[1].ext.stub[0x00] = 1;
+        g_Entities[1].ext.entSlot1.unk0 = 1;
         SetStep(step);
         break;
 
@@ -666,7 +666,7 @@ void EntityMovingElevator(Entity* self) {
         g_Player.pl_vram_flag = 0x41;
         break;
     }
-    prim = self->ext.prim;
+    prim = self->ext.cenElevator.prim;
     prim->x0 = prim->x2 = self->posX.i.hi - 8;
     prim->x1 = prim->x3 = self->posX.i.hi + 8;
     temp = self->posY.i.hi;

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -55,7 +55,7 @@ extern u16 g_EInitMaria[];
 extern u16 g_EInitInteractable[];
 extern u16 g_EInitCommon[];
 extern u16 g_EInitParticle[];
-extern u16 g_eElevatorInit[]; // EntityElevator
+extern u16 g_EInitElevator[]; // EntityElevator
 
 extern u16* D_80180574[];
 extern u8 D_80180594[];

--- a/src/st/cen/e_init.c
+++ b/src/st/cen/e_init.c
@@ -49,7 +49,7 @@ PfnEntityUpdate OVL_EXPORT(EntityUpdates)[] = {
 };
 
 #include "../e_init_common.h"
-EInit g_eElevatorInit = {ANIMSET_OVL(11), 1, 0x48, 0x223, 5};
+EInit g_EInitElevator = {ANIMSET_OVL(11), 1, 0x48, 0x223, 5};
 
 static u32 JUNK_80180488 = 0x00FF0140;
 static u32 D_8018048C = 0x00FF0740;

--- a/src/st/e_collect.h
+++ b/src/st/e_collect.h
@@ -197,10 +197,10 @@ extern u16 g_EInitParticle[];
 #include "blink_item.h"
 #else
 // Also, this function is never called.
-void func_80194314(Entity* entity) {
-    if (entity->step != 0) {
-        if (entity->posY.i.hi >= 0xF1) {
-            DestroyEntity(entity);
+void Unreferenced_MAD_ST0_func(Entity* self) {
+    if (self->step != 0) {
+        if (self->posY.i.hi >= 0xF1) {
+            DestroyEntity(self);
             return;
         }
         FallEntity();
@@ -209,14 +209,12 @@ void func_80194314(Entity* entity) {
     }
 
     InitializeEntity(g_EInitBreakable);
-    entity->animCurFrame = entity->ext.generic.unk7C.U8.unk0;
-    entity->velocityX =
-        g_collectXVelTable[entity->ext.generic.unk80.modeS8.unk0 * 2];
-    entity->velocityY =
-        g_collectYVelTable[entity->ext.generic.unk80.modeS8.unk0 * 2];
+    self->animCurFrame = self->ext.unusedMadST0.animframe;
+    self->velocityX = g_collectXVelTable[self->ext.unusedMadST0.velIndex * 2];
+    self->velocityY = g_collectYVelTable[self->ext.unusedMadST0.velIndex * 2];
 
-    if (entity->params != 0) {
-        entity->zPriority -= 1;
+    if (self->params != 0) {
+        self->zPriority -= 1;
     }
 }
 #endif

--- a/src/st/no0/41F98.c
+++ b/src/st/no0/41F98.c
@@ -61,14 +61,14 @@ s16 func_us_801C2044(Primitive* prim, s16 offset) {
 
 INCLUDE_ASM("st/no0/nonmatchings/41F98", func_us_801C2184);
 
-extern u16 D_us_80180B60[];
+extern u16 g_EInitElevator[];
 void func_us_801C26B8(Entity* self) {
     Entity* entity = &self[self->params];
     s32 step = self->step;
 
     switch (self->step) {
     case 0:
-        InitializeEntity(D_us_80180B60);
+        InitializeEntity(g_EInitElevator);
         if (self->params & 16) {
             self->animCurFrame = self->params & 15;
             self->zPriority = 0x6A;
@@ -80,13 +80,13 @@ void func_us_801C26B8(Entity* self) {
 
     case 1:
         self->posX.i.hi = entity->posX.i.hi;
-        if (self->params == step) {
+        if (self->params == 1) {
             self->posY.i.hi = entity->posY.i.hi + 35;
-            self->ext.generic.unk80.modeS8.unk0 =
+            self->ext.cenElevator.unk80 =
                 GetPlayerCollisionWith(self, 12, 8, 4);
         } else {
             self->posY.i.hi = entity->posY.i.hi - 24;
-            self->ext.generic.unk80.modeS8.unk0 =
+            self->ext.cenElevator.unk80 =
                 GetPlayerCollisionWith(self, 12, 8, 6);
         }
         break;


### PR DESCRIPTION
More cleanup of removing uses of particular members of `ET_Generic` in order to avoid using Generic in the long term.

We have some pretty obvious duplication between NO0 and CEN with the elevator that goes between the two stages (makes sense), but I think we will probably want to get NO0 decompiled through copy and pasting between the stages, and then see about proper dedupes.

This PR is pretty small, not too many existing uses of this member :)