### PR TITLE
Fix RBO3 progress

### DIFF
--- a/tools/progress.py
+++ b/tools/progress.py
@@ -82,13 +82,12 @@ class DecompProgressStats:
         if not os.path.exists(nonmatchings):
             nonmatchings_psp = f"{asm_path}/psp"
             if not os.path.exists(nonmatchings_psp):
+                if not os.path.exists(f"{asm_path}/matchings"):
+                    print(f"error: {asm_path} not found")
+                    exit(1)
                 # nonmatchings path does not exist, the overlay is 100% decompiled
                 return ""
             nonmatchings = nonmatchings_psp
-
-        nonmatchings_subdir = os.path.join(nonmatchings, os.path.basename(asm_path))
-        if os.path.exists(nonmatchings_subdir):
-            nonmatchings = nonmatchings_subdir
 
         # hack to return 'asm/us/main/nonmatchings' instead of 'asm/us/main/nonmatchings/main'
         if nonmatchings.endswith("/main"):


### PR DESCRIPTION
The code path I deleted was pretty much dead with the exception of `BORBO3` where the bug was triggered. Essentially the tool was looking for `asm/us/boss/rbo3/nonmatchings/rbo3/nonmatchings`, which had no content and let the tool assume the overlay completion was 100%.

I also added a guard where if `nonmatchings` is not found but also `matchings` is not there, the tool will terminate immediately. This should prevent any future oddity.