### PR TITLE
Tweak the handling of the LayoutEntity files created by sotn-assets

### DIFF
--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -9,7 +9,7 @@
 
 #define CASTLE_FLAG_BANK 0x00
 
-typedef enum {
+typedef enum EntityIDs{
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_ID_01,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -9,7 +9,7 @@
 
 #define CASTLE_FLAG_BANK 0x00
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_ID_01,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/cen/cen.h
+++ b/src/st/cen/cen.h
@@ -32,7 +32,7 @@ typedef enum EntityIDs{
     /* 0x13 */ E_ID_13,
     /* 0x14 */ E_ID_14,
     /* 0x15 */ E_GREY_PUFF,
-    /* 0x16 */ E_ID_16,
+    /* 0x16 */ E_CUTSCENE,
     /* 0x17 */ E_PLATFORM,
     /* 0x18 */ E_MARIA,
     /* 0x19 */ E_ROOM_DARKNESS,

--- a/src/st/dre/dre.h
+++ b/src/st/dre/dre.h
@@ -6,7 +6,7 @@
 
 #define CASTLE_FLAG_BANK 0xD3
 
-typedef enum {
+typedef enum EntityIDs{
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/dre/dre.h
+++ b/src/st/dre/dre.h
@@ -6,7 +6,7 @@
 
 #define CASTLE_FLAG_BANK 0xD3
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/entrance_stage_entities.h
+++ b/src/st/entrance_stage_entities.h
@@ -6,6 +6,8 @@
 // helpful for understanding the overall layouts of stages in the game.
 // If enemies are always in their own area, that would be good to know.
 
+// This seems like a totally unused entity. Not created in any way, not in
+// e_layout.c.
 void EntityUnkId16(Entity* self) {
     switch (self->step) {
     case 0:

--- a/src/st/no3/no3.h
+++ b/src/st/no3/no3.h
@@ -41,7 +41,6 @@ typedef enum EntityIDs {
     /* 0x0E */ E_SAVE_GAME_POPUP,
     /* 0x0F */ E_DUMMY_0F,
     /* 0x10 */ E_DUMMY_10,
-
     /* 0x11 */ E_ID_11 = 0x11,
     /* 0x14 */ E_ID_14 = 0x14,
     /* 0x15 */ E_GREY_PUFF,

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -5,7 +5,7 @@
 
 #define CASTLE_FLAG_BANK 0x34
 
-typedef enum {
+typedef enum EntityIDs{
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/np3/np3.h
+++ b/src/st/np3/np3.h
@@ -5,7 +5,7 @@
 
 #define CASTLE_FLAG_BANK 0x34
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/nz0/nz0.h
+++ b/src/st/nz0/nz0.h
@@ -7,7 +7,7 @@
 
 #define CASTLE_FLAG_BANK 0x7E
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/nz0/nz0.h
+++ b/src/st/nz0/nz0.h
@@ -7,7 +7,7 @@
 
 #define CASTLE_FLAG_BANK 0x7E
 
-typedef enum {
+typedef enum EntityIDs{
     /* 0x00 */ E_NONE,
     /* 0x01 */ E_BREAKABLE,
     /* 0x02 */ E_EXPLOSION,

--- a/src/st/rwrp/rwrp.h
+++ b/src/st/rwrp/rwrp.h
@@ -9,7 +9,7 @@
 
 #define CASTLE_FLAG_BANK 0x1E0
 
-typedef enum {
+typedef enum EntityIDs{
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/src/st/rwrp/rwrp.h
+++ b/src/st/rwrp/rwrp.h
@@ -9,7 +9,7 @@
 
 #define CASTLE_FLAG_BANK 0x1E0
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/src/st/st0/st0.h
+++ b/src/st/st0/st0.h
@@ -6,7 +6,7 @@
 
 #define OVL_EXPORT(x) ST0_##x
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/src/st/st0/st0.h
+++ b/src/st/st0/st0.h
@@ -6,7 +6,7 @@
 
 #define OVL_EXPORT(x) ST0_##x
 
-typedef enum {
+typedef enum EntityIDs{
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/src/st/wrp/wrp.h
+++ b/src/st/wrp/wrp.h
@@ -5,7 +5,7 @@
 
 #define CASTLE_FLAG_BANK 0x00
 
-typedef enum EntityIDs{
+typedef enum EntityIDs {
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/src/st/wrp/wrp.h
+++ b/src/st/wrp/wrp.h
@@ -5,7 +5,7 @@
 
 #define CASTLE_FLAG_BANK 0x00
 
-typedef enum {
+typedef enum EntityIDs{
     E_NONE,
     E_BREAKABLE,
     E_EXPLOSION,

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -395,6 +395,53 @@ func buildSprites(fileName string, outputDir string) error {
 
 func buildEntityLayouts(fileName string, outputDir string) error {
 	ovlName := path.Base(outputDir)
+
+	// Get the EntityIDs enum from the .h file and invert it to get a lookup table
+	// Keys are integers, values are the names from the enum.
+	hFile, err := os.ReadFile(outputDir + ovlName + ".h")
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(hFile), "\n")
+	// Extract all the lines that are part of the enum.
+	// Do this by searching for the first "EntityIDs" (in typedef enum EntityIDs {)
+	// and the last "EntityIDs" (in } EntityIDs;)
+	enumData := []string{}
+	inEnum := false
+	for _,line := range lines {
+		if strings.Contains(line, "EntityIDs"){
+			if inEnum{
+				break
+			} else {
+				inEnum = true
+			}
+		} else if inEnum {
+			enumData = append(enumData, line)
+		}
+	}
+	// Now we have the enum's lines loaded. Iterate through populating a map.
+	entityNames := make(map[int]string, 255)
+	// Increments in the enum, updates if enum has a direct assign
+	index := -1 // start at -1 so first increment takes it to 0 to begin
+	for _,line := range enumData {
+		line = strings.Split(line, ",")[0] // go up to the comma
+		parts := strings.Split(line, " = ")
+		if len(parts) > 1 {
+			hexVal := strings.Replace(parts[1], "0x", "", -1)
+			parsed, err := strconv.ParseInt(hexVal, 16, 16)
+			if err != nil {
+				return err
+			}
+			index = int(parsed)
+		} else {
+			index ++
+		}
+		parts = strings.Split(parts[0], " ")
+		name := parts[len(parts) - 1]
+		entityNames[index] = name
+	}
+	// Done loading entities from EntityIDs now!
+
 	writeLayoutEntries := func(sb *strings.Builder, banks [][]layoutEntry, align4 bool) error {
 		nWritten := 0
 		for i, entries := range banks {
@@ -415,7 +462,11 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 				} else {
 				// TODO: See if we can make this pull from the overlay's EntityIDs enum
 				// Should be a separate function call
-					entityIDStr = fmt.Sprintf("0x%02X", int(e.ID))
+					entityIDStr = entityNames[int(e.ID)]
+					// If not in enum, then just use the hex value.
+					if entityIDStr == "" {
+						entityIDStr = fmt.Sprintf("0x%02X", int(e.ID))
+					}
 				}
 				sb.WriteString(fmt.Sprintf("    0x%04X, 0x%04X, %s, 0x%04X, 0x%04X,\n",
 					uint16(e.X), uint16(e.Y), entityIDStr, int(e.Slot)|(int(e.SpawnID)<<8), e.Params))

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -460,8 +460,6 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 					// This will only ever be 0xA001.
 					entityIDStr = fmt.Sprintf("0x%04X", (int(e.Flags) << 8) | int(e.ID))
 				} else {
-				// TODO: See if we can make this pull from the overlay's EntityIDs enum
-				// Should be a separate function call
 					entityIDStr = entityNames[int(e.ID)]
 					// If not in enum, then just use the hex value.
 					if entityIDStr == "" {

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -406,7 +406,7 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 			if lastEntry.X != -1 || lastEntry.Y != -1 {
 				return fmt.Errorf("layout entity bank %d needs to have a X:-1 and Y:-1 entry at the end", i)
 			}
-
+			sb.WriteString(fmt.Sprintf("//%d\n", nWritten)) //label each block with offsets
 			for _, e := range entries {
 				sb.WriteString(fmt.Sprintf("    0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X,\n",
 					uint16(e.X), uint16(e.Y), int(e.ID)|(int(e.Flags)<<8), int(e.Slot)|(int(e.SpawnID)<<8), e.Params))
@@ -480,16 +480,16 @@ func buildEntityLayouts(fileName string, outputDir string) error {
 	sbHeader.WriteString("#include <stage.h>\n\n")
 	sbHeader.WriteString("#include \"common.h\"\n\n")
 	sbHeader.WriteString("// clang-format off\n")
-	sbHeader.WriteString(fmt.Sprintf("extern u16 %s_x[];\n", symbolName))
+	sbHeader.WriteString(fmt.Sprintf("extern LayoutEntity %s_x[];\n", symbolName))
 	sbHeader.WriteString(fmt.Sprintf("LayoutEntity* %s_pStObjLayoutHorizontal[] = {\n", strings.ToUpper(ovlName)))
 	for _, i := range el.Indices {
-		sbHeader.WriteString(fmt.Sprintf("    (LayoutEntity*)&%s_x[%d],\n", symbolName, offsets[i]))
+		sbHeader.WriteString(fmt.Sprintf("    &%s_x[%d],\n", symbolName, offsets[i] / 5))
 	}
 	sbHeader.WriteString(fmt.Sprintf("};\n"))
-	sbHeader.WriteString(fmt.Sprintf("extern u16 %s_y[];\n", symbolName))
+	sbHeader.WriteString(fmt.Sprintf("extern LayoutEntity %s_y[];\n", symbolName))
 	sbHeader.WriteString(fmt.Sprintf("LayoutEntity* %s_pStObjLayoutVertical[] = {\n", strings.ToUpper(ovlName)))
 	for _, i := range el.Indices {
-		sbHeader.WriteString(fmt.Sprintf("    (LayoutEntity*)&%s_y[%d],\n", symbolName, offsets[i]))
+		sbHeader.WriteString(fmt.Sprintf("    &%s_y[%d],\n", symbolName, offsets[i] / 5))
 	}
 	sbHeader.WriteString(fmt.Sprintf("};\n"))
 


### PR DESCRIPTION
This changes the formatting of the generated layout entities in order to make the files (in my opinion) more readable. We do the following:

1. change the types in e_laydef to make the offsets make more sense and reduce casts
2. Break up e_layout into blocks to more easily see where the boundaries between each room's data are
3. Add comments between those boundaries with the offsets, to easily cross-reference e_laydef and e_layout
4. Implement reading of the EntityIDs enum so that entities are listed by ID in e_layout.c to make it easier to identify them
5. Include the overlay's .h file rather than common.h, to allow access to the EntityIDs enum.

Sounds like we want to make changes here to move this stuff up to the JSON, so I'll mark this as a draft while we determine the long-term desired functionality.

Also, just a heads-up that this is my first time working with Go, so I might have done some bad code practices.