### PR TITLE
Eliminate generic.unk7E with other cleanups

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -19,13 +19,6 @@ struct Entity;
 
 typedef struct ET_Generic {
     /* 0x7C */ Multi16 unk7C; // posX
-    union {
-        /* 0x7E */ u16 modeU16;
-        struct {
-            /* 0x7E */ u8 unk0;
-            /* 0x7F */ u8 unk1;
-        } modeU8;
-    } unk7E; // posY
 } ET_Generic;
 
 typedef struct {
@@ -1065,7 +1058,7 @@ typedef struct {
 #ifdef PLATFORM_64BIT
     s32 _align_parent[2];
 #endif
-    s16 unk7C;
+    s16 t;
     s16 unk7E;
     s16 unk80;
     s16 unk82;
@@ -1074,7 +1067,7 @@ typedef struct {
     /* 0x8C */ struct Entity* parent;
     s16 unk90;
     s16 unk92;
-    s16 unk94;
+    s16 crashIndex;
     s16 unk96;
     struct Entity* unk98;
     s32 : 32;
@@ -1085,7 +1078,12 @@ typedef struct {
     s32 : 32;
 #endif
     s16 subweaponId;
-} ET_StopWatch;
+} ET_RICStopWatch;
+typedef struct {
+    s16 timer;
+    s16 index;
+} ET_StopwatchCrash;
+
 typedef struct {
     s16 t;
     s16 unk7E;
@@ -1095,7 +1093,7 @@ typedef struct {
     f32 unk88;
     s16 unk8C;
     s16 unk8E;
-} ET_stopwatch;
+} ET_DRAStopWatch;
 typedef struct {
     s16 unk7C;
     s16 unk7E;
@@ -1136,26 +1134,6 @@ typedef struct {
 #endif
     s16 subweaponId;
 } ET_BibleSubwpn;
-
-typedef struct {
-#ifdef PLATFORM_64BIT
-    s32 _align_parent[2];
-#endif
-    s16 unk7C; // TODO rename as timer
-    s16 unk7E;
-    /* 0x80 */ s32 : 32;
-    /* 0x84 */ s32 : 32;
-    /* 0x88 */ s32 : 32;
-    /* 0x8C */ struct Entity* parent;
-    /* 0x90 */ s32 : 32;
-    /* 0x94 */ s32 : 32;
-    /* 0x98 */ s32 : 32;
-    /* 0x9C */ s32 : 32;
-    /* 0xA0 */ s32 : 32;
-    /* 0xA4 */ s32 : 32;
-    /* 0xA8 */ s32 : 32;
-    /* 0xAC */ s32 : 32;
-} ET_80161FF0;
 
 typedef struct {
 #ifdef PLATFORM_64BIT
@@ -1899,6 +1877,25 @@ typedef struct {
     /* 0x01 */ s8 targetAngle;
 } ET_801CC9B4;
 
+typedef struct {
+    u8 r, g, b;
+} ET_EntranceUnk16;
+
+typedef struct {
+    s16 width;
+    s16 height;
+} ET_ExpandingCircle;
+
+typedef struct {
+    s16 size;
+    s16 timer;
+} ET_RicMariaPower;
+
+typedef struct {
+    s16 timer;
+    s16 boolDidSound;
+} ET_RicMaria;
+
 // ====== RIC ENTITIES ======
 
 // ==========================
@@ -1978,11 +1975,11 @@ typedef union { // offset=0x7C
     ET_801291C4 et_801291C4;
     ET_8017091C et_8017091C;
     ET_AguneaCrash aguneaCrash;
-    ET_stopwatch stopwatch;
-    ET_StopWatch et_801719A4;
+    ET_RICStopWatch ricStopWatch;
+    ET_StopwatchCrash stopwatchCrash;
+    ET_DRAStopWatch stopwatch;
     ET_stopwatchCircle et_stopwatchCircle;
     ET_stopwatchSparkle et_stopWatchSparkle;
-    ET_80161FF0 et_80161FF0;
     ET_80162870 et_80162870;
     ET_Whip whip;
     ET_RichterPowerUpRing ricPowerRing;
@@ -2061,6 +2058,10 @@ typedef union { // offset=0x7C
     ET_BloodSkeleton bloodSkeleton;
     ET_UnusedCENEnt unusedCENEnt;
     ET_SmallRisingHeart smallRisingHeart;
+    ET_EntranceUnk16 entrance16;
+    ET_ExpandingCircle circleExpand;
+    ET_RicMariaPower ricMariaPower;
+    ET_RicMaria ricMaria;
 } Ext;
 
 #define SYNC_FIELD(struct1, struct2, field)                                    \
@@ -2091,7 +2092,6 @@ SYNC_FIELD(ET_EntFactory, ET_HolyWater, parent);
 SYNC_FIELD(ET_EntFactory, ET_GiantSpinningCross, parent);
 SYNC_FIELD(ET_EntFactory, ET_CrashCross, parent);
 SYNC_FIELD(ET_EntFactory, ET_RicRevivalColumn, parent);
-SYNC_FIELD(ET_EntFactory, ET_80161FF0, parent);
 SYNC_FIELD(ET_EntFactory, ET_80162870, parent);
 SYNC_FIELD(ET_EntFactory, ET_PlayerBlink, parent);
 SYNC_FIELD(ET_EntFactory, ET_RichterPowerUpRing, parent);

--- a/src/dra/6D59C.c
+++ b/src/dra/6D59C.c
@@ -354,14 +354,14 @@ void func_8010DFF0(s32 resetAnims, s32 arg1) {
 void func_8010E0A8(void) {
     Entity* entity = &g_Entities[UNK_ENTITY_1];
 
-    entity->ext.generic.unk7E.modeU8.unk0 = 0;
+    entity->ext.entSlot1.unk2 = 0;
 }
 
 void func_8010E0B8(void) {
     Entity* entity = &g_Entities[UNK_ENTITY_1];
 
-    entity->ext.generic.unk7C.U8.unk1 = 0;
-    entity->ext.generic.unk7C.U8.unk0 = 0;
+    entity->ext.entSlot1.unk1 = 0;
+    entity->ext.entSlot1.unk0 = 0;
 }
 
 void func_8010E0D0(s32 arg0) {

--- a/src/dra/7A4D0.c
+++ b/src/dra/7A4D0.c
@@ -49,7 +49,7 @@ PfnEntityUpdate g_DraEntityTbl[] = {
     EntityStopWatch,
     EntityStopWatchExpandingCircle,
     EntitySubwpnBible,
-    func_8012B78C,
+    EntitySubwpnBibleTrail,
     EntityBatFireball,
     func_80123B40,
     func_80119F70,

--- a/src/dra/8A0A4.c
+++ b/src/dra/8A0A4.c
@@ -134,7 +134,7 @@ void EntityStopWatch(Entity* self) {
         prim->priority = PLAYER.zPriority + 3;
         prim->drawMode = DRAW_UNK_200 | DRAW_UNK_100 | DRAW_HIDE | DRAW_UNK02;
 
-        CreateEntFactoryFromEntity(self, 0x4B, 0);
+        CreateEntFactoryFromEntity(self, FACTORY(75, 0), 0);
         PlaySfx(SFX_UI_ALERT_TINK);
         g_unkGraphicsStruct.D_800973FC = 1;
         goto label;
@@ -428,57 +428,50 @@ void EntityStopWatch(Entity* self) {
     }
 }
 
-void func_8012B78C(Entity* entity) {
+// DRA entity #44. Comes from blueprint 79.
+// Identical to RIC
+void EntitySubwpnBibleTrail(Entity* self) {
     Primitive* prim;
     s32 ret;
 
-    switch (entity->step) {
+    switch (self->step) {
     case 0:
         ret = AllocPrimitives(PRIM_GT4, 1);
-        entity->primIndex = ret;
-        if (entity->primIndex != -1) {
-            entity->flags =
-                FLAG_UNK_20000 | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
-            prim = &g_PrimBuf[entity->primIndex];
-            prim->tpage = 0x1C;
-            prim->clut = 0x19D;
-            prim->u0 = prim->u2 = 32;
-            prim->u1 = prim->u3 = 48;
-            prim->v0 = prim->v1 = 0;
-            prim->v2 = prim->v3 = 16;
-            prim->x0 = prim->x2 = entity->posX.i.hi - 8;
-            prim->x1 = prim->x3 = entity->posX.i.hi + 8;
-            prim->y0 = prim->y1 = entity->posY.i.hi - 8;
-            prim->y2 = prim->y3 = entity->posY.i.hi + 8;
-            prim->priority = entity->zPriority;
-            prim->drawMode =
-                DRAW_UNK_100 | DRAW_TPAGE | DRAW_COLORS | DRAW_TRANSP;
-            entity->ext.generic.unk7E.modeU16 = 96;
-            entity->step++;
-        } else {
-            DestroyEntity(entity);
+        self->primIndex = ret;
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
             return;
         }
+        self->flags =
+            FLAG_UNK_20000 | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
+        prim = &g_PrimBuf[self->primIndex];
+        prim->tpage = 0x1C;
+        prim->clut = 0x19D;
+        prim->u0 = prim->u2 = 0x20;
+        prim->u1 = prim->u3 = 0x30;
+        prim->v0 = prim->v1 = 0;
+        prim->v2 = prim->v3 = 0x10;
+        prim->x0 = prim->x2 = self->posX.i.hi - 8;
+        prim->x1 = prim->x3 = self->posX.i.hi + 8;
+        prim->y0 = prim->y1 = self->posY.i.hi - 8;
+        prim->y2 = prim->y3 = self->posY.i.hi + 8;
+        prim->priority = self->zPriority;
+        prim->drawMode = DRAW_UNK_100 | DRAW_TPAGE | DRAW_COLORS | DRAW_TRANSP;
+        self->ext.et_BibleSubwpn.unk7E = 0x60;
+        self->step++;
         break;
-
     case 1:
-        if (++entity->ext.generic.unk7C.s > 5) {
-            entity->step++;
+        if (++self->ext.et_BibleSubwpn.unk7C > 5) {
+            self->step++;
         }
-        entity->ext.generic.unk7E.modeU16 -= 8;
+        self->ext.et_BibleSubwpn.unk7E -= 8;
         break;
-
     case 2:
-        DestroyEntity(entity);
+        DestroyEntity(self);
         return;
-
-    default:
-        break;
     }
-    prim = &g_PrimBuf[entity->primIndex];
-    prim->r0 = prim->r1 = prim->r2 = prim->r3 = prim->g0 = prim->g1 = prim->g2 =
-        prim->g3 = prim->b0 = prim->b1 = prim->b2 = prim->b3 =
-            entity->ext.generic.unk7E.modeU8.unk0;
+    prim = &g_PrimBuf[self->primIndex];
+    PCOL(prim) = self->ext.et_BibleSubwpn.unk7E;
 }
 
 // book rotates around player
@@ -608,7 +601,7 @@ void EntitySubwpnBible(Entity* self) {
         prim->y0 = prim->y1 = top;
         prim->y2 = prim->y3 = bottom;
         prim->priority = self->zPriority;
-        CreateEntFactoryFromEntity(self, 79, 0);
+        CreateEntFactoryFromEntity(self, FACTORY(79, 0), 0);
         if (g_GameTimer % 10 == 0) {
             PlaySfx(BIBLE_SUBWPN_SWOOSH);
         }

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -626,7 +626,7 @@ void EntityHolyWaterBreakGlass(Entity* self);
 void EntityStopWatch(Entity* self);
 void EntityStopWatchExpandingCircle(Entity* self);
 void EntitySubwpnBible(Entity* self);
-void func_8012B78C(Entity* self);
+void EntitySubwpnBibleTrail(Entity* self);
 void EntityBatFireball(Entity* self);
 void func_80123B40(Entity* self);
 void func_80119F70(Entity* self);

--- a/src/ric/20920.c
+++ b/src/ric/20920.c
@@ -113,10 +113,10 @@ void DisableAfterImage(s32 resetAnims, s32 arg1) {
 void func_8015CC28(void) {
     Entity* entity = &g_Entities[UNK_ENTITY_1];
 
-    entity->ext.generic.unk7E.modeU8.unk1 = 0;
-    entity->ext.generic.unk7E.modeU8.unk0 = 0;
-    entity->ext.generic.unk7C.U8.unk1 = 0;
-    entity->ext.generic.unk7C.U8.unk0 = 0;
+    entity->ext.entSlot1.unk3 = 0;
+    entity->ext.entSlot1.unk2 = 0;
+    entity->ext.entSlot1.unk1 = 0;
+    entity->ext.entSlot1.unk0 = 0;
 }
 
 void RicSetDebug() { RicSetStep(PL_S_DEBUG); }

--- a/src/ric/211D0.c
+++ b/src/ric/211D0.c
@@ -1451,7 +1451,7 @@ void RicEntitySubwpnBible(Entity* self);
 void RicEntitySubwpnBibleTrail(Entity* self);
 void RicEntitySubwpnStopwatch(Entity* self);
 void RicEntitySubwpnStopwatchCircle(Entity* self);
-void func_801705EC(Entity* self);
+void RicEntityCrashStopwatch(Entity* self);
 void func_8016F198(Entity* self);
 void RicEntityAguneaCircle(Entity* self);
 void RicEntityAguneaLightning(Entity* self);
@@ -1520,7 +1520,7 @@ static PfnEntityUpdate entity_functions[] = {
     RicEntitySubwpnBibleTrail,
     RicEntitySubwpnStopwatch,
     RicEntitySubwpnStopwatchCircle,
-    func_801705EC,
+    RicEntityCrashStopwatch,
     func_8016F198,
     RicEntityAguneaCircle,
     RicEntityAguneaLightning,
@@ -1630,6 +1630,7 @@ FactoryBlueprint g_RicFactoryBlueprints[] = {
     B_MAKE(E_CRASH_CROSS_ROTATING, 1, 1, NON_CRITICAL, true, 0, B_KIND_9, 0, 0),
     B_MAKE(E_CRASH_CROSS_BEAM, 6, 1, true, true, 24, B_KIND_9, 0, 0),
     B_MAKE(E_NOT_IMPLEMENTED_1, 16, 16, NON_CRITICAL, true, 0, B_KIND_8, 1, 0),
+    //0x10
     B_MAKE(E_NOT_IMPLEMENTED_2, 15, 15, true, true, 0, B_KIND_8, 1, 0),
     B_MAKE(E_ARM_BRANDISH_WHIP, 1, 1, NON_CRITICAL, true, 0, B_KIND_12, 1, 0),
     B_MAKE(E_80167964, 1, 1, true, true, 0, B_KIND_8, 0, 0),
@@ -1646,6 +1647,7 @@ FactoryBlueprint g_RicFactoryBlueprints[] = {
     B_MAKE(E_MARIA, 1, 1, NON_CRITICAL, true, 0, B_KIND_5, 0, 0),
     B_MAKE(E_MARIA_POWERS, 4, 1, true, true, 4, B_KIND_3, 0, 0),
     B_MAKE(E_80160D2C, 1, 1, true, true, 0, B_WPN, 0, 0),
+    //0x20
     B_MAKE(E_NOT_IMPLEMENTED_4, 1, 1, true, true, 0, B_DECOR, 0, 0),
     B_MAKE(E_BLINK_WHITE, 1, 1, true, true, 0, B_DECOR, 0, 0),
     B_MAKE(E_SUBWPN_CRASH_CROSS_PARTICLES, 1, 1, true, true, 0, B_DECOR, 0, 0),
@@ -1662,6 +1664,7 @@ FactoryBlueprint g_RicFactoryBlueprints[] = {
     B_MAKE(E_80160F0C, 1, 1, true, true, 0, B_WPN, 0, 0),
     B_MAKE(E_HIT_BY_CUT_BLOOD, 12, 1, true, true, 2, B_KIND_8, 3, 0),
     B_MAKE(E_HIT_BY_ICE, 1, 1, true, true, 0, B_DECOR, 0, 0),
+    //0x30
     B_MAKE(E_HIT_BY_LIGHTNING, 1, 1, true, true, 0, B_DECOR, 0, 0),
     B_MAKE(E_SUBWPN_VIBHUTI, 1, 1, true, true, 0, B_WPN, 1, 8),
     B_MAKE(E_SUBWPN_REBOUND_STONE, 1, 1, true, true, 0, B_WPN, 1, 4),
@@ -1678,8 +1681,9 @@ FactoryBlueprint g_RicFactoryBlueprints[] = {
     B_MAKE(E_SUBWPN_BIBLE, 1, 1, true, true, 0, B_WPN, 0, 0),
     B_MAKE(E_SUBWPN_BIBLE_TRAIL, 1, 1, true, true, 0, B_DECOR, 0, 0),
     B_MAKE(E_SUBWPN_STOPWATCH, 1, 1, true, true, 0, B_WPN, 0, 0),
+    //0x40
     B_MAKE(E_SUBWPN_STOPWATCH_CIRCLE, 1, 1, true, true, 0, B_DECOR, 0, 0),
-    B_MAKE(E_801705EC, 1, 1, NON_CRITICAL, true, 0, B_DECOR, 0, 0),
+    B_MAKE(E_CRASH_STOPWATCH, 1, 1, NON_CRITICAL, true, 0, B_DECOR, 0, 0),
     B_MAKE(E_8016F198, 2, 1, true, true, 2, B_DECOR, 0, 0),
     B_MAKE(E_AGUNEA_CIRCLE, 1, 1, NON_CRITICAL, true, 0, B_WPN, 0, 20),
     B_MAKE(E_AGUNEA_LIGHTNING, 1, 1, true, true, 0, B_DECOR, 0, 0),

--- a/src/ric/24788.c
+++ b/src/ric/24788.c
@@ -815,7 +815,7 @@ typedef struct {
     s32 velocityY;
     s16 timerInit;
     s16 tpage;
-    s16 clut;
+    u16 clut;
     u8 uBase;
     u8 vBase;
 } Props_80161FF0; // size = 0x14
@@ -824,12 +824,15 @@ static Props_80161FF0 D_80154E5C[] = {
     {+0x40, 0, -FIX(2.5), FIX(0), 0x0048, 0x1B, 0x0119, 0, 128},
     {0, -0x40, FIX(0), +FIX(2.5), 0x0030, 0x19, 0x011A, 0, 0},
     {0, +0x40, FIX(0), -FIX(2.5), 0x0018, 0x19, 0x011B, 128, 0}};
+
 void RicEntityApplyMariaPowerAnim(Entity* self) {
     Primitive* prim;
 
-    u16 posX = self->posX.i.hi;
-    u16 posY = self->posY.i.hi;
-    Props_80161FF0* props = &D_80154E5C[(s16)self->params];
+    s16 posX = self->posX.i.hi;
+    s16 posY = self->posY.i.hi;
+    s16 params = self->params;
+
+    Props_80161FF0* props = &D_80154E5C[params];
 
     switch (self->step) {
     case 0:
@@ -839,7 +842,7 @@ void RicEntityApplyMariaPowerAnim(Entity* self) {
             return;
         }
         g_api.PlaySfx(0x881);
-        self->ext.et_80161FF0.unk7C = 0x100;
+        self->ext.ricMariaPower.size = 0x100;
         prim = &g_PrimBuf[self->primIndex];
         prim->u0 = props->uBase;
         prim->v0 = props->vBase;
@@ -855,174 +858,159 @@ void RicEntityApplyMariaPowerAnim(Entity* self) {
         prim->drawMode = DRAW_TPAGE2 | DRAW_TPAGE | DRAW_TRANSP;
         self->velocityX = props->velocityX;
         self->velocityY = props->velocityY;
-        self->posX.i.hi += props->xPos;
-        posX = self->posX.i.hi;
-        posY = self->posY.i.hi + props->yPos;
-        self->posY.i.hi = posY;
+
+        posX = self->posX.i.hi += props->xPos;
+        posY = self->posY.i.hi += props->yPos;
         self->flags =
             FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS | FLAG_UNK_10000;
         self->step++;
         break;
     case 1:
-        self->ext.et_80161FF0.unk7C -= 8;
+        self->ext.ricMariaPower.size -= 8;
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
-        if (self->ext.et_80161FF0.unk7C < 25) {
-            self->ext.et_80161FF0.unk7E = props->timerInit;
+        if (self->ext.ricMariaPower.size < 25) {
+            self->ext.ricMariaPower.timer = props->timerInit;
             self->step++;
         }
         break;
     case 2:
-        if (--self->ext.et_80161FF0.unk7E == 0) {
+        if (--self->ext.ricMariaPower.timer == 0) {
             self->step++;
         }
         break;
     case 3:
-        self->ext.et_80161FF0.unk7C -= 2;
-        if (self->ext.et_80161FF0.unk7C < 0) {
+        self->ext.ricMariaPower.size -= 2;
+        if (self->ext.ricMariaPower.size < 0) {
             DestroyEntity(self);
             return;
         }
         break;
     }
     prim = &g_PrimBuf[self->primIndex];
-    prim->x0 = posX + (((rcos(0x600) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->y0 = posY - (((rsin(0x600) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->x1 = posX + (((rcos(0x200) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->y1 = posY - (((rsin(0x200) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->x2 = posX + (((rcos(0xA00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->y2 = posY - (((rsin(0xA00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->x3 = posX + (((rcos(0xE00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    prim->y3 = posY - (((rsin(0xE00) >> 4) * self->ext.et_80161FF0.unk7C) >> 8);
-    return;
+    prim->x0 =
+        posX + (((rcos(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->y0 =
+        posY - (((rsin(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->x1 =
+        posX + (((rcos(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->y1 =
+        posY - (((rsin(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->x2 =
+        posX + (((rcos(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->y2 =
+        posY - (((rsin(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->x3 =
+        posX + (((rcos(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+    prim->y3 =
+        posY - (((rsin(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
 }
 
-void func_801623E0(Entity* entity) {
+void func_801623E0(Entity* self) {
     Primitive* prim;
-    s16 primIndex;
 
-    entity->posX.val = g_Entities->posX.val;
-    entity->posY.val = PLAYER.posY.val;
-    switch (entity->step) {
+    self->posX.val = g_Entities->posX.val;
+    self->posY.val = PLAYER.posY.val;
+    switch (self->step) {
     case 0:
-        primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
-        entity->primIndex = primIndex;
-        if (primIndex == -1) {
-            DestroyEntity(entity);
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
             return;
         }
-        entity->ext.et_80161FF0.unk7E = 32;
-        entity->ext.et_80161FF0.unk7C = 32;
-        prim = &g_PrimBuf[entity->primIndex];
-        prim->u2 = 64;
-        prim->u0 = 64;
-        prim->v1 = 192;
-        prim->v0 = 192;
-        prim->u3 = 127;
-        prim->u1 = 127;
-        prim->v3 = 255;
-        prim->v2 = 255;
+        self->ext.circleExpand.width = self->ext.circleExpand.height = 32;
+        prim = &g_PrimBuf[self->primIndex];
+        prim->u0 = prim->u2 = 64;
+        prim->v0 = prim->v1 = 192;
+        prim->u1 = prim->u3 = 127;
+        prim->v2 = prim->v3 = 255;
         prim->tpage = 0x1A;
         prim->clut = 0x13E;
         prim->priority = PLAYER.zPriority + 8;
         prim->drawMode = DRAW_DEFAULT;
-        entity->flags = FLAG_UNK_10000 | FLAG_POS_PLAYER_LOCKED |
-                        FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
-        entity->step++;
+        self->flags = FLAG_UNK_10000 | FLAG_POS_PLAYER_LOCKED |
+                      FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
+        self->step++;
         break;
 
     case 1:
-        entity->ext.et_80161FF0.unk7C++;
-        entity->ext.et_80161FF0.unk7E++;
-        if (entity->ext.et_80161FF0.unk7C >= 45) {
-            DestroyEntity(entity);
+        self->ext.circleExpand.width++;
+        self->ext.circleExpand.height++;
+        if (self->ext.circleExpand.width > 44) {
+            DestroyEntity(self);
             return;
         }
         break;
     }
 
-    prim = &g_PrimBuf[entity->primIndex];
-    prim->x0 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-    prim->y0 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-    prim->x1 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-    prim->y1 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-    prim->x2 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-    prim->y2 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
-    prim->x3 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-    prim->y3 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
-    prim->clut = (LOH(g_Timer) & 1) + 0x13E;
+    prim = &g_PrimBuf[self->primIndex];
+    prim->x0 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y0 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x1 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y1 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x2 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y2 = self->posY.i.hi + self->ext.circleExpand.height;
+    prim->x3 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y3 = self->posY.i.hi + self->ext.circleExpand.height;
+    prim->clut = (g_Timer & 1) + 0x13E;
 }
 
-void func_80162604(Entity* entity) {
+void func_80162604(Entity* self) {
     Primitive* prim;
-    s16 primIndex;
 
-    entity->posX.val = g_Entities->posX.val;
-    entity->posY.val = PLAYER.posY.val;
-    switch (entity->step) {
+    self->posX.val = PLAYER.posX.val;
+    self->posY.val = PLAYER.posY.val;
+    switch (self->step) {
     case 0:
-        primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
-        entity->primIndex = primIndex;
-        if (primIndex != -1) {
-            entity->ext.et_80161FF0.unk7E = 0;
-            entity->ext.et_80161FF0.unk7C = 0;
-            prim = &g_PrimBuf[entity->primIndex];
-            prim->v1 = 192;
-            prim->v0 = 192;
-            prim->u3 = 63;
-            prim->u1 = 63;
-            prim->v3 = 255;
-            prim->v2 = 255;
-            prim->tpage = 0x1A;
-            prim->u2 = 0;
-            prim->u0 = 0;
-            prim->clut = 0x162;
-            prim->priority = PLAYER.zPriority - 4;
-            prim->drawMode = DRAW_DEFAULT;
-            entity->flags = FLAG_UNK_10000 | FLAG_POS_PLAYER_LOCKED |
-                            FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
-            entity->step++;
-            goto def;
-        } else {
-            DestroyEntity(entity);
-            break;
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
         }
+        self->ext.circleExpand.width = self->ext.circleExpand.height = 0;
+        prim = &g_PrimBuf[self->primIndex];
 
+        prim->u0 = prim->u2 = 0;
+        prim->v0 = prim->v1 = 192;
+        prim->u1 = prim->u3 = 63;
+        prim->v2 = prim->v3 = 255;
+        prim->tpage = 0x1A;
+
+        prim->clut = 0x162;
+        prim->priority = PLAYER.zPriority - 4;
+        prim->drawMode = DRAW_DEFAULT;
+        self->flags = FLAG_UNK_10000 | FLAG_POS_PLAYER_LOCKED |
+                      FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
+        self->step++;
+        break;
     case 1:
-        entity->ext.generic.unk7C.s += 8;
-        entity->ext.generic.unk7E.modeU16 += 8;
-        if (entity->ext.generic.unk7C.s < 0x20) {
-            goto def;
-        }
-
-    case 2:
-        entity->step++;
-        goto def;
-
-    case 3:
-        entity->ext.generic.unk7C.s -= 8;
-        entity->ext.generic.unk7E.modeU16 -= 8;
-        if (entity->ext.generic.unk7C.s >= 5) {
-            goto def;
-        } else {
-
-            DestroyEntity(entity);
+        self->ext.circleExpand.width += 8;
+        self->ext.circleExpand.height += 8;
+        if (self->ext.circleExpand.width >= 0x20) {
+            self->step++;
         }
         break;
-
-    def:
-    default:
-        prim = &g_PrimBuf[entity->primIndex];
-        prim->x0 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-        prim->y0 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-        prim->x1 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-        prim->y1 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-        prim->x2 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-        prim->y2 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
-        prim->x3 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-        prim->y3 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
+    case 2:
+        self->step++;
+        break;
+    case 3:
+        self->ext.circleExpand.width -= 8;
+        self->ext.circleExpand.height -= 8;
+        if (self->ext.circleExpand.width < 5) {
+            DestroyEntity(self);
+            return;
+        }
         break;
     }
+    prim = &g_PrimBuf[self->primIndex];
+    prim->x0 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y0 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x1 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y1 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x2 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y2 = self->posY.i.hi + self->ext.circleExpand.height;
+    prim->x3 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y3 = self->posY.i.hi + self->ext.circleExpand.height;
 }
 
 static s16 D_80154EAC[] = {0x016E, 0x0161, 0x0160, 0x0162};
@@ -1133,55 +1121,56 @@ static AnimationFrame anim_maria_offering_powers[] = {
     {0x08, FRAME(0x11, 0)}, {0x0C, FRAME(0x12, 0)}, {0xB0, FRAME(0x13, 0)},
     {0x0A, FRAME(0x14, 0)}, {0x0A, FRAME(0x15, 0)}, {0x0A, FRAME(0x16, 0)},
     {0x30, FRAME(0x17, 0)}, {0xD0, FRAME(0x18, 0)}, A_END};
-void RicEntityMaria(Entity* entity) {
-    switch (entity->step) {
+
+void RicEntityMaria(Entity* self) {
+    switch (self->step) {
     case 0:
-        entity->flags = FLAG_UNK_100000 | FLAG_KEEP_ALIVE_OFFCAMERA |
-                        FLAG_UNK_10000 | FLAG_POS_CAMERA_LOCKED;
-        entity->facingLeft = 1;
-        entity->unk5A = 0x66;
-        entity->zPriority = PLAYER.zPriority - 8;
-        entity->palette = PAL_OVL(0x149);
-        entity->animSet = ANIMSET_OVL(19);
+        self->flags = FLAG_UNK_100000 | FLAG_KEEP_ALIVE_OFFCAMERA |
+                      FLAG_UNK_10000 | FLAG_POS_CAMERA_LOCKED;
+        self->facingLeft = 1;
+        self->unk5A = 0x66;
+        self->zPriority = PLAYER.zPriority - 8;
+        self->palette = PAL_OVL(0x149);
+        self->animSet = ANIMSET_OVL(19);
         RicSetAnimation(anim_maria_walk);
-        entity->velocityX = FIX(-1.75);
-        entity->posY.i.hi = 0xBB;
-        entity->posX.i.hi = 0x148;
-        entity->ext.et_80161FF0.unk7E = 0;
-        entity->step++;
+        self->velocityX = FIX(-1.75);
+        self->posY.i.hi = 0xBB;
+        self->posX.i.hi = 0x148;
+        self->ext.ricMaria.boolDidSound = 0;
+        self->step++;
         break;
     case 1:
-        if (entity->animFrameIdx == 0 && entity->animFrameDuration == 1) {
+        if (self->animFrameIdx == 0 && self->animFrameDuration == 1) {
             g_api.PlaySfx(0x882);
         }
-        if (entity->animFrameIdx == 4 && entity->animFrameDuration == 1) {
+        if (self->animFrameIdx == 4 && self->animFrameDuration == 1) {
             g_api.PlaySfx(0x883);
         }
 
-        entity->posX.val += entity->velocityX;
-        if (((s16)entity->ext.et_80161FF0.unk7E == 0) &&
-            (entity->posX.i.hi < 256)) {
+        self->posX.val += self->velocityX;
+        if ((self->ext.ricMaria.boolDidSound == false) &&
+            (self->posX.i.hi < 256)) {
             g_api.PlaySfx(0x87D);
-            entity->ext.et_80161FF0.unk7E++;
+            self->ext.ricMaria.boolDidSound++;
         }
-        if (entity->posX.i.hi < 0xE0) {
+        if (self->posX.i.hi < 0xE0) {
             RicSetAnimation(anim_maria_offering_powers);
-            entity->velocityX = 0;
-            entity->step++;
-            RicCreateEntFactoryFromEntity(entity, FACTORY(BP_SKID_SMOKE, 4), 0);
+            self->step++;
+            self->velocityX = 0;
+            RicCreateEntFactoryFromEntity(self, FACTORY(BP_SKID_SMOKE, 4), 0);
         }
         break;
     case 2:
-        if (entity->animFrameIdx == 16) {
+        if (self->animFrameIdx == 16) {
             g_api.PlaySfx(0x87E);
-            entity->ext.et_80161FF0.unk7C = 0x80;
-            entity->step++;
+            self->ext.ricMaria.timer = 0x80;
+            self->step++;
         }
         break;
     case 3:
-        if (!--entity->ext.et_80161FF0.unk7C) {
-            RicCreateEntFactoryFromEntity(entity, BP_MARIA_POWERS_INVOKED, 0);
-            entity->step++;
+        if (--self->ext.ricMaria.timer == 0) {
+            RicCreateEntFactoryFromEntity(self, BP_MARIA_POWERS_INVOKED, 0);
+            self->step++;
         }
         break;
     case 4:

--- a/src/ric/26C84.c
+++ b/src/ric/26C84.c
@@ -370,66 +370,60 @@ void RicEntityPlayerBlinkWhite(Entity* self) {
     }
 }
 
-void func_801641A0(Entity* entity) {
+void func_801641A0(Entity* self) {
     Primitive* prim;
     s16 primIndex;
 
-    entity->posX.i.hi = PLAYER.posX.i.hi;
-    entity->posY.i.hi = PLAYER.posY.i.hi - 8;
-    switch (entity->step) {
+    self->posX.i.hi = PLAYER.posX.i.hi - 0;
+    self->posY.i.hi = PLAYER.posY.i.hi - 8;
+    switch (self->step) {
     case 0:
-        primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
-        entity->primIndex = primIndex;
-        if (primIndex != -1) {
-            entity->ext.et_80161FF0.unk7C = 16;
-            entity->ext.et_80161FF0.unk7E = 12;
-            prim = &g_PrimBuf[entity->primIndex];
-            prim->u0 = prim->u2 = 64;
-            prim->v0 = prim->v1 = 192;
-            prim->u1 = prim->u3 = 127;
-            prim->v2 = prim->v3 = 255;
-            prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 = prim->b1 =
-                prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 =
-                    prim->b3 = 128;
-            prim->tpage = 0x1A;
-            prim->clut = 0x160;
-            prim->priority = PLAYER.zPriority + 8;
-            prim->drawMode =
-                DRAW_TPAGE2 | DRAW_TPAGE | DRAW_COLORS | DRAW_TRANSP;
-            entity->flags = FLAG_POS_PLAYER_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA |
-                            FLAG_HAS_PRIMS;
-            entity->step++;
-            goto def;
-        } else {
-            DestroyEntity(entity);
-            break;
+        self->primIndex = g_api.AllocPrimitives(PRIM_GT4, 1);
+        if (self->primIndex == -1) {
+            DestroyEntity(self);
+            return;
         }
+        self->ext.circleExpand.width = 16;
+        self->ext.circleExpand.height = 12;
+        prim = &g_PrimBuf[self->primIndex];
+        prim->u0 = prim->u2 = 64;
+        prim->v0 = prim->v1 = 192;
+        prim->u1 = prim->u3 = 127;
+        prim->v2 = prim->v3 = 255;
+        PGREY(prim, 0) = PGREY(prim, 1) = PGREY(prim, 2) = PGREY(prim, 3) = 128;
+        prim->tpage = 0x1A;
+        prim->clut = 0x160;
+        prim->priority = PLAYER.zPriority + 8;
+        prim->drawMode = DRAW_TPAGE2 | DRAW_TPAGE | DRAW_COLORS | DRAW_TRANSP;
+        self->flags =
+            FLAG_POS_PLAYER_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
+        self->step++;
+        break;
 
     case 1:
-        entity->ext.et_80161FF0.unk7C += 2;
-        entity->ext.et_80161FF0.unk7E += 2;
-        if (entity->ext.et_80161FF0.unk7C >= 57) {
-            DestroyEntity(entity);
-            break;
+        self->ext.circleExpand.width += 2;
+        self->ext.circleExpand.height += 2;
+        if (self->ext.circleExpand.width > 56) {
+            DestroyEntity(self);
+            return;
         }
-
-    default:
-    def:
-        prim = &g_PrimBuf[entity->primIndex];
-        prim->x0 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-        prim->y0 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-        prim->x1 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-        prim->y1 = entity->posY.i.hi - entity->ext.et_80161FF0.unk7E;
-        prim->x2 = entity->posX.i.hi - entity->ext.et_80161FF0.unk7C;
-        prim->y2 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
-        prim->x3 = entity->posX.i.hi + entity->ext.et_80161FF0.unk7C;
-        prim->y3 = entity->posY.i.hi + entity->ext.et_80161FF0.unk7E;
-        if (prim->b3 >= 12) {
-            prim->b3 += 244;
-        }
-        prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 = prim->b1 =
-            prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 = prim->b3;
+        break;
     }
+
+    prim = &g_PrimBuf[self->primIndex];
+    prim->x0 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y0 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x1 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y1 = self->posY.i.hi - self->ext.circleExpand.height;
+    prim->x2 = self->posX.i.hi - self->ext.circleExpand.width;
+    prim->y2 = self->posY.i.hi + self->ext.circleExpand.height;
+    prim->x3 = self->posX.i.hi + self->ext.circleExpand.width;
+    prim->y3 = self->posY.i.hi + self->ext.circleExpand.height;
+    if (prim->b3 >= 12) {
+        prim->b3 -= 12;
+    }
+    // remember last element of PGREY(prim,3) is prim->b3
+    PGREY(prim, 0) = PGREY(prim, 1) = PGREY(prim, 2) = PGREY(prim, 3);
 }
 
 // Entity ID # 34. Created by blueprints 36, 37, 38, 39.

--- a/src/ric/319C4.c
+++ b/src/ric/319C4.c
@@ -733,8 +733,8 @@ void func_8016F198(Entity* self) {
 }
 
 // Entity ID #64, created by blueprint #72. This call is in
-// RicEntitySubwpnStopwatch. When Richter has the stopwatch weapon, and uses it
-// as a crash, it makes 4 floating stopwatches. When they are done they
+// RicEntitySubwpnStopwatch. When Richter has the ricStopWatch weapon, and uses
+// it as a crash, it makes 4 floating ricStopWatches. When they are done they
 // disappear in a spinning sparkle. This entity represents that sparkle. 4
 // copies of this entity are made when the crash is done.
 void RicEntityCrashStopwatchDoneSparkle(Entity* self) {
@@ -1080,11 +1080,11 @@ void RicEntityCrashStopwatchDoneSparkle(Entity* self) {
 }
 
 // Created by blueprint #73.
-// When Stopwatch crash ends, each of the 4 stopwatches shoots out a lightning
-// Each lightning can harm enemies. This entity represents the attacking part
-// of that lightning. It does not do any graphics and just has the hitbox.
-// Not clear why this is a dedicated entity rather than having one entity
-// that is graphics + hitbox for the lightning.
+// When Stopwatch crash ends, each of the 4 ricStopWatches shoots out a
+// lightning Each lightning can harm enemies. This entity represents the
+// attacking part of that lightning. It does not do any graphics and just has
+// the hitbox. Not clear why this is a dedicated entity rather than having one
+// entity that is graphics + hitbox for the lightning.
 void RicEntityStopwatchCrashLightning(Entity* self) {
     switch (self->step) {
     case 0:
@@ -1103,35 +1103,37 @@ void RicEntityStopwatchCrashLightning(Entity* self) {
     }
 }
 
-void func_801705EC(Entity* entity) {
-    u16 temp;
-
-    switch (entity->step) {
+void RicEntityCrashStopwatch(Entity* self) {
+    // Kind of funny control flow.
+    // On odd steps, we'll create a ricStopWatch, and on evens, we wait.
+    // We end up producing the 4 individual ricStopWatches.
+    switch (self->step) {
     case 0:
-        entity->flags = FLAG_KEEP_ALIVE_OFFCAMERA;
-        entity->ext.et_80161FF0.unk7E = 0;
-        entity->step++;
+        self->flags = FLAG_KEEP_ALIVE_OFFCAMERA;
+        self->ext.stopwatchCrash.index = 0;
+        self->step++;
     case 1:
     case 3:
     case 5:
     case 7:
-        temp = entity->ext.et_80161FF0.unk7E + 1;
-        entity->ext.et_80161FF0.unk7E = temp;
+        self->ext.stopwatchCrash.index++;
+        // This value becomes ext.ricStopWatch.crashIndex for each stopwatch.
         RicCreateEntFactoryFromEntity(
-            entity, FACTORY(BP_SUBWPN_STOPWATCH, temp), 0);
-        entity->ext.et_80161FF0.unk7C = 0;
-        entity->step++;
+            self, FACTORY(BP_SUBWPN_STOPWATCH, self->ext.stopwatchCrash.index),
+            0);
+        self->ext.stopwatchCrash.timer = 0;
+        self->step++;
         break;
     case 2:
     case 4:
     case 6:
-        entity->ext.et_80161FF0.unk7C++;
-        if (entity->ext.et_80161FF0.unk7C >= 16) {
-            entity->step++;
+        self->ext.stopwatchCrash.timer++;
+        if (self->ext.stopwatchCrash.timer > 15) {
+            self->step++;
         }
         break;
     case 8:
-        DestroyEntity(entity);
+        DestroyEntity(self);
         break;
     }
 }
@@ -1603,24 +1605,26 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         prim->clut = 0x186;
         prim->priority = PLAYER.zPriority + 3;
         prim->drawMode = DRAW_UNK_100 | DRAW_HIDE | DRAW_UNK02;
+        // This holds the index of the ricStopWatch, when created by the crash.
+        // If it's 0, then we just used a normal stopwatch.
         if (self->params & 0xFF00) {
             RicCreateEntFactoryFromEntity(self, BP_66, 0);
-            D_801758D0 = self->ext.et_801719A4.unk94 = self->params >> 8;
-            if (self->ext.et_801719A4.unk94 < 4) {
-                D_801758D4[self->ext.et_801719A4.unk94 - 1] = self;
+            D_801758D0 = self->ext.ricStopWatch.crashIndex = self->params >> 8;
+            if (self->ext.ricStopWatch.crashIndex < 4) {
+                D_801758D4[self->ext.ricStopWatch.crashIndex - 1] = self;
             }
-            if (self->ext.et_801719A4.unk94 >= 2) {
-                self->ext.et_801719A4.unk98 =
-                    D_801758D4[self->ext.et_801719A4.unk94 - 2];
+            if (self->ext.ricStopWatch.crashIndex >= 2) {
+                self->ext.ricStopWatch.unk98 =
+                    D_801758D4[self->ext.ricStopWatch.crashIndex - 2];
             }
         } else {
-            RicCreateEntFactoryFromEntity(self, BP_STOPWATCH_RIPPLE, 0);
-            self->ext.et_801719A4.unk94 = 0;
+            RicCreateEntFactoryFromEntity(self, BP_STOPWATCH_CIRCLE, 0);
+            self->ext.ricStopWatch.crashIndex = 0;
         }
-        self->ext.et_801719A4.subweaponId = PL_W_STOPWATCH;
+        self->ext.ricStopWatch.subweaponId = PL_W_STOPWATCH;
         RicSetSubweaponParams(self);
         g_api.PlaySfx(SFX_UI_ALERT_TINK);
-        if (self->ext.et_801719A4.unk94 < 2) {
+        if (self->ext.ricStopWatch.crashIndex < 2) {
             g_unkGraphicsStruct.D_800973FC = 1;
         }
         self->step++;
@@ -1628,36 +1632,36 @@ void RicEntitySubwpnStopwatch(Entity* self) {
     case 1:
         prim = &g_PrimBuf[self->primIndex];
         prim->drawMode &= ~DRAW_HIDE;
-        self->ext.et_801719A4.unk84.val += 0x18000;
-        if (self->ext.et_801719A4.unk84.val > 0x19FFFF) {
+        self->ext.ricStopWatch.unk84.val += 0x18000;
+        if (self->ext.ricStopWatch.unk84.val > 0x19FFFF) {
             self->step++;
         }
         break;
     case 2:
-        self->ext.et_801719A4.unk84.val += 0xFFFF0000;
-        if (self->ext.et_801719A4.unk84.val <= 0x100000) {
-            self->ext.et_801719A4.unk7C = 5;
+        self->ext.ricStopWatch.unk84.val += 0xFFFF0000;
+        if (self->ext.ricStopWatch.unk84.val <= 0x100000) {
+            self->ext.ricStopWatch.t = 5;
             g_api.PlaySfx(SFX_CLOCK_TICK);
             self->step++;
         }
         break;
     case 3:
-        if (++self->ext.et_801719A4.unk7E >= 0x51) {
+        if (++self->ext.ricStopWatch.unk7E >= 0x51) {
             g_api.PlaySfx(SFX_CLOCK_TICK);
-            self->ext.et_801719A4.unk7E = 0;
-            self->ext.et_801719A4.unk90 = 1;
-            if (--self->ext.et_801719A4.unk7C < 0) {
+            self->ext.ricStopWatch.unk7E = 0;
+            self->ext.ricStopWatch.unk90 = 1;
+            if (--self->ext.ricStopWatch.t < 0) {
                 self->step++;
                 break;
             }
         }
 
-        if (self->ext.et_801719A4.unk7C < 5) {
+        if (self->ext.ricStopWatch.t < 5) {
             prim = g_PrimBuf[self->primIndex].next;
-            if (self->ext.et_801719A4.unk7C >= 10) {
-                self->ext.et_801719A4.unk92 = 1;
+            if (self->ext.ricStopWatch.t >= 10) {
+                self->ext.ricStopWatch.unk92 = 1;
                 // MISMATCH: Not using S4 for this
-                var_s4 = 8 * (self->ext.et_801719A4.unk7C / 10);
+                var_s4 = 8 * (self->ext.ricStopWatch.t / 10);
                 prim->u0 = prim->u2 = var_s4 + 0x18;
                 prim->u1 = prim->u3 = var_s4 + 0x1E;
                 prim->v0 = prim->v1 = 0x40;
@@ -1665,9 +1669,9 @@ void RicEntitySubwpnStopwatch(Entity* self) {
                 prim->drawMode &= ~DRAW_HIDE;
                 prim = prim->next;
             } else {
-                self->ext.et_801719A4.unk92 = 0;
+                self->ext.ricStopWatch.unk92 = 0;
             }
-            var_s4 = 8 * (self->ext.et_801719A4.unk7C % 10);
+            var_s4 = 8 * (self->ext.ricStopWatch.t % 10);
             if (var_s4 == 0) {
                 var_s4 = 0x50;
             }
@@ -1688,10 +1692,10 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         prim = prim->next;
         prim->drawMode |= DRAW_HIDE;
         self->posX.i.hi += self->facingLeft ? 6 : -6;
-        ySub = self->ext.et_801719A4.unk84.i.hi;
+        ySub = self->ext.ricStopWatch.unk84.i.hi;
         self->posY.i.hi -= ySub;
-        self->ext.et_801719A4.unk7C = 0;
-        if (self->ext.et_801719A4.unk94 != 0) {
+        self->ext.ricStopWatch.t = 0;
+        if (self->ext.ricStopWatch.crashIndex != 0) {
             self->step = 7;
             RicCreateEntFactoryFromEntity(self, BP_AGUNEA_THUNDER, 0);
         } else {
@@ -1699,7 +1703,7 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         }
         break;
     case 5:
-        if (++self->ext.et_801719A4.unk7C >= 4) {
+        if (++self->ext.ricStopWatch.t >= 4) {
             prim = &g_PrimBuf[self->primIndex];
             prim->clut = 0x15F;
             prim->g0 = prim->g1 = prim->g2 = prim->g3 = prim->r0 = prim->r1 =
@@ -1711,18 +1715,18 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         }
         break;
     case 6:
-        if (++self->ext.et_801719A4.unk7C >= 0xF) {
+        if (++self->ext.ricStopWatch.t >= 0xF) {
             RicCreateEntFactoryFromEntity(self, FACTORY(BP_EMBERS, 7), 0);
             self->step++;
         }
         break;
     case 7:
-        if ((self->ext.et_801719A4.unk94 == 0) ||
-            (self->ext.et_801719A4.unk94 == D_801758D0)) {
+        if ((self->ext.ricStopWatch.crashIndex == 0) ||
+            (self->ext.ricStopWatch.crashIndex == D_801758D0)) {
             g_unkGraphicsStruct.D_800973FC = 0;
         }
-        if (self->ext.et_801719A4.unk94 != 0) {
-            D_801758D4[self->ext.et_801719A4.unk94 - 1] = 0;
+        if (self->ext.ricStopWatch.crashIndex != 0) {
+            D_801758D4[self->ext.ricStopWatch.crashIndex - 1] = 0;
         }
         DestroyEntity(self);
         return;
@@ -1732,20 +1736,20 @@ void RicEntitySubwpnStopwatch(Entity* self) {
     }
     prim = &g_PrimBuf[self->primIndex];
     if (self->step < 5) {
-        if (self->ext.et_801719A4.unk94 < 2) {
+        if (self->ext.ricStopWatch.crashIndex < 2) {
             var_s4 = PLAYER.posX.val + (PLAYER.facingLeft ? FIX(8) : FIX(-8));
             var_s6 = PLAYER.posY.val + FIX(-16);
-        } else if (D_801758D4[self->ext.et_801719A4.unk94 - 2] != NULL) {
-            var_s4 = self->ext.et_801719A4.unk98->posX.val +
+        } else if (D_801758D4[self->ext.ricStopWatch.crashIndex - 2] != NULL) {
+            var_s4 = self->ext.ricStopWatch.unk98->posX.val +
                      (PLAYER.facingLeft ? FIX(16) : FIX(-16));
-            var_s6 = self->ext.et_801719A4.unk98->posY.val + FIX(-16);
+            var_s6 = self->ext.ricStopWatch.unk98->posY.val + FIX(-16);
         } else {
             var_s4 = self->posX.val;
             var_s6 = self->posY.val;
         }
         self->posX.val += (var_s4 - self->posX.val) / 12;
         self->posY.val += (var_s6 - self->posY.val) / 4;
-        if (self->ext.et_801719A4.unk94 < 2) {
+        if (self->ext.ricStopWatch.crashIndex < 2) {
             if (PLAYER.facingLeft != self->facingLeft) {
                 if (abs(var_s4 - self->posX.val) < FIX(1)) {
                     self->facingLeft = PLAYER.facingLeft;
@@ -1759,8 +1763,8 @@ void RicEntitySubwpnStopwatch(Entity* self) {
                     self->facingLeft = PLAYER.facingLeft;
                 }
             }
-        } else if (D_801758D4[self->ext.et_801719A4.unk94 - 2] != NULL) {
-            parent = self->ext.et_801719A4.unk98;
+        } else if (D_801758D4[self->ext.ricStopWatch.crashIndex - 2] != NULL) {
+            parent = self->ext.ricStopWatch.unk98;
             if (parent->facingLeft != self->facingLeft) {
                 if (abs(var_s4 - self->posX.val) >= FIX(1)) {
                     if (!self->facingLeft) {
@@ -1790,17 +1794,17 @@ void RicEntitySubwpnStopwatch(Entity* self) {
     }
     if (self->step < 3) {
         var_s4 = self->posX.i.hi + (self->facingLeft ? 6 : -6);
-        var_s6 = self->posY.i.hi - self->ext.et_801719A4.unk84.i.hi;
-        if (self->ext.et_801719A4.unk82 < 0x64) {
-            self->ext.et_801719A4.unk82 += 4;
+        var_s6 = self->posY.i.hi - self->ext.ricStopWatch.unk84.i.hi;
+        if (self->ext.ricStopWatch.unk82 < 0x64) {
+            self->ext.ricStopWatch.unk82 += 4;
         }
-        if (self->ext.et_801719A4.unk80 < 0x1000) {
-            self->ext.et_801719A4.unk80 += 0x80;
+        if (self->ext.ricStopWatch.unk80 < 0x1000) {
+            self->ext.ricStopWatch.unk80 += 0x80;
         }
-        firstmult = (self->ext.et_801719A4.unk82 * 8) / 100;
-        secondmult = (self->ext.et_801719A4.unk82 * 0xC) / 100;
-        sine = rsin(self->ext.et_801719A4.unk80);
-        cosine = rcos(self->ext.et_801719A4.unk80);
+        firstmult = (self->ext.ricStopWatch.unk82 * 8) / 100;
+        secondmult = (self->ext.ricStopWatch.unk82 * 0xC) / 100;
+        sine = rsin(self->ext.ricStopWatch.unk80);
+        cosine = rcos(self->ext.ricStopWatch.unk80);
         prim->x0 = var_s4 + ((cosine * -firstmult - sine * -secondmult) >> 0xC);
         prim->y0 = var_s6 + ((sine * -firstmult + cosine * -secondmult) >> 0xC);
         prim->x1 = var_s4 + ((cosine * firstmult - sine * -secondmult) >> 0xC);
@@ -1810,25 +1814,25 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         prim->y2 = var_s6 + ((sine * -firstmult + cosine * secondmult) >> 0xC);
         prim->y3 = var_s6 + ((sine * firstmult + cosine * secondmult) >> 0xC);
     } else if (self->step < 5U) {
-        if (self->ext.et_801719A4.unk84.val <= 0x100000) {
-            if (self->ext.et_801719A4.unk90 != 0) {
-                self->ext.et_801719A4.unk88 = (rand() % 0x40 + 0x200) * 0x100;
-                self->ext.et_801719A4.unk90 = 0;
+        if (self->ext.ricStopWatch.unk84.val <= 0x100000) {
+            if (self->ext.ricStopWatch.unk90 != 0) {
+                self->ext.ricStopWatch.unk88 = (rand() % 0x40 + 0x200) * 0x100;
+                self->ext.ricStopWatch.unk90 = 0;
             } else {
-                self->ext.et_801719A4.unk88 = (rand() % 0x80 + 0x100) * 0x100;
+                self->ext.ricStopWatch.unk88 = (rand() % 0x80 + 0x100) * 0x100;
             }
-            if (self->ext.et_801719A4.unk80 >= 0) {
-                self->ext.et_801719A4.unk80 = -(rand() % 0x40 + 0x40);
+            if (self->ext.ricStopWatch.unk80 >= 0) {
+                self->ext.ricStopWatch.unk80 = -(rand() % 0x40 + 0x40);
             } else {
-                self->ext.et_801719A4.unk80 = rand() % 0x40 + 0x40;
+                self->ext.ricStopWatch.unk80 = rand() % 0x40 + 0x40;
             }
         }
-        self->ext.et_801719A4.unk84.val += self->ext.et_801719A4.unk88;
-        self->ext.et_801719A4.unk88 -= 0x4000;
+        self->ext.ricStopWatch.unk84.val += self->ext.ricStopWatch.unk88;
+        self->ext.ricStopWatch.unk88 -= 0x4000;
         var_s4 = self->posX.i.hi + (self->facingLeft ? 6 : -6);
-        var_s6 = self->posY.i.hi - self->ext.et_801719A4.unk84.i.hi;
-        sine = rsin(self->ext.et_801719A4.unk80);
-        cosine = rcos(self->ext.et_801719A4.unk80);
+        var_s6 = self->posY.i.hi - self->ext.ricStopWatch.unk84.i.hi;
+        sine = rsin(self->ext.ricStopWatch.unk80);
+        cosine = rcos(self->ext.ricStopWatch.unk80);
         temp_t1 = cosine * 8;
         temp_a3 = -temp_t1;
         temp_t2 = sine * 0xC;
@@ -1846,12 +1850,12 @@ void RicEntitySubwpnStopwatch(Entity* self) {
         prim->x3 = var_s4 + ((temp_t1 - temp_t2) >> 0xC);
         prim->y3 = var_s6 + ((temp_a2_3 + temp_t0) >> 0xC);
     } else {
-        temp_v0 = 8 - self->ext.et_801719A4.unk7C;
+        temp_v0 = 8 - self->ext.ricStopWatch.t;
         var_a0 = temp_v0;
         if (temp_v0 <= 0) {
             var_a0 = 1;
         }
-        var_a1 = ((self->ext.et_801719A4.unk7C << 0x10) >> 0xB) + 0xC;
+        var_a1 = ((self->ext.ricStopWatch.t << 0x10) >> 0xB) + 0xC;
         if (var_a1 >= 0x80) {
             var_a1 = 0x80;
         }
@@ -1862,25 +1866,25 @@ void RicEntitySubwpnStopwatch(Entity* self) {
     }
     if (self->step < 4) {
         var_s6 = self->posY.i.hi - 0xE;
-        if (self->ext.et_801719A4.unk92 != 0) {
+        if (self->ext.ricStopWatch.unk92 != 0) {
             var_s4 = self->posX.i.hi + (self->facingLeft ? -10 : 4);
             prim = prim->next;
-            if (self->ext.et_801719A4.unk7E < 8) {
+            if (self->ext.ricStopWatch.unk7E < 8) {
                 prim->x0 = prim->x2 =
-                    var_s4 - (self->ext.et_801719A4.unk7E / 2);
+                    var_s4 - (self->ext.ricStopWatch.unk7E / 2);
                 prim->x1 = prim->x3 =
-                    var_s4 + (self->ext.et_801719A4.unk7E / 2);
+                    var_s4 + (self->ext.ricStopWatch.unk7E / 2);
                 temp_t2 = 0xF;
                 prim->y0 = prim->y1 =
-                    var_s6 + (self->ext.et_801719A4.unk7E - temp_t2);
+                    var_s6 + (self->ext.ricStopWatch.unk7E - temp_t2);
                 prim->y2 = prim->y3 =
-                    var_s6 - (self->ext.et_801719A4.unk7E - temp_t2);
-            } else if (self->ext.et_801719A4.unk7E >= 0x44) {
-                var_a0 = (0x4C - self->ext.et_801719A4.unk7E) / 2;
+                    var_s6 - (self->ext.ricStopWatch.unk7E - temp_t2);
+            } else if (self->ext.ricStopWatch.unk7E >= 0x44) {
+                var_a0 = (0x4C - self->ext.ricStopWatch.unk7E) / 2;
                 if (var_a0 < 0) {
                     var_a0 = 0;
                 }
-                var_a1 = self->ext.et_801719A4.unk7E - 0x44;
+                var_a1 = self->ext.ricStopWatch.unk7E - 0x44;
                 if (var_a1 >= 9) {
                     var_a1 = 8;
                 }
@@ -1899,12 +1903,12 @@ void RicEntitySubwpnStopwatch(Entity* self) {
             }
             var_s4 = self->posX.i.hi + (self->facingLeft ? -4 : 10);
             prim = prim->next;
-            if (self->ext.et_801719A4.unk7E < 0xC) {
-                var_a0 = (self->ext.et_801719A4.unk7E - 4) / 2;
+            if (self->ext.ricStopWatch.unk7E < 0xC) {
+                var_a0 = (self->ext.ricStopWatch.unk7E - 4) / 2;
                 if (var_a0 < 0) {
                     var_a0 = 0;
                 }
-                var_a1 = 0xB - self->ext.et_801719A4.unk7E;
+                var_a1 = 0xB - self->ext.ricStopWatch.unk7E;
                 if (var_a1 < 0) {
                     var_a1 = 0;
                 }
@@ -1915,45 +1919,45 @@ void RicEntitySubwpnStopwatch(Entity* self) {
                 // FAKE horrible thing needed to match, secondmult should be
                 // totally irrelevant here
                 prim->y2 = prim->y3 = (secondmult = var_s6) + var_a1;
-            } else if (self->ext.et_801719A4.unk7E < 0x48) {
+            } else if (self->ext.ricStopWatch.unk7E < 0x48) {
                 prim->x0 = prim->x2 = var_s4 - 4;
                 prim->x1 = prim->x3 = var_s4 + 4;
                 prim->y0 = prim->y1 = var_s6 - 8;
                 prim->y2 = prim->y3 = var_s6 + 8;
             } else {
                 prim->x0 = prim->x2 =
-                    var_s4 - ((0x50 - self->ext.et_801719A4.unk7E) / 2);
+                    var_s4 - ((0x50 - self->ext.ricStopWatch.unk7E) / 2);
                 prim->x1 = prim->x3 =
-                    var_s4 + ((0x50 - self->ext.et_801719A4.unk7E) / 2);
+                    var_s4 + ((0x50 - self->ext.ricStopWatch.unk7E) / 2);
                 temp_t2 = -0x40;
                 prim->y0 = prim->y1 =
-                    var_s6 - (self->ext.et_801719A4.unk7E + temp_t2);
+                    var_s6 - (self->ext.ricStopWatch.unk7E + temp_t2);
                 prim->y2 = prim->y3 =
-                    var_s6 + (self->ext.et_801719A4.unk7E + temp_t2);
+                    var_s6 + (self->ext.ricStopWatch.unk7E + temp_t2);
             }
         } else {
             var_s4 = self->posX.i.hi + (self->facingLeft ? -4 : 4);
             prim = prim->next;
-            if (self->ext.et_801719A4.unk7E < 8) {
+            if (self->ext.ricStopWatch.unk7E < 8) {
                 prim->x0 = prim->x2 =
-                    var_s4 - (self->ext.et_801719A4.unk7E / 2);
+                    var_s4 - (self->ext.ricStopWatch.unk7E / 2);
                 prim->x1 = prim->x3 =
-                    var_s4 + (self->ext.et_801719A4.unk7E / 2);
+                    var_s4 + (self->ext.ricStopWatch.unk7E / 2);
                 temp_t2 = 0xF;
                 prim->y0 = prim->y1 =
-                    var_s6 + (self->ext.et_801719A4.unk7E - temp_t2);
+                    var_s6 + (self->ext.ricStopWatch.unk7E - temp_t2);
                 prim->y2 = prim->y3 =
-                    var_s6 - (self->ext.et_801719A4.unk7E - temp_t2);
-            } else if (self->ext.et_801719A4.unk7E >= 0x48) {
+                    var_s6 - (self->ext.ricStopWatch.unk7E - temp_t2);
+            } else if (self->ext.ricStopWatch.unk7E >= 0x48) {
                 prim->x0 = prim->x2 =
-                    var_s4 - ((0x50 - self->ext.et_801719A4.unk7E) / 2);
+                    var_s4 - ((0x50 - self->ext.ricStopWatch.unk7E) / 2);
                 prim->x1 = prim->x3 =
-                    var_s4 + ((0x50 - self->ext.et_801719A4.unk7E) / 2);
+                    var_s4 + ((0x50 - self->ext.ricStopWatch.unk7E) / 2);
                 temp_t2 = -0x40;
                 prim->y0 = prim->y1 =
-                    var_s6 - (self->ext.et_801719A4.unk7E + temp_t2);
+                    var_s6 - (self->ext.ricStopWatch.unk7E + temp_t2);
                 prim->y2 = prim->y3 =
-                    var_s6 + (self->ext.et_801719A4.unk7E + temp_t2);
+                    var_s6 + (self->ext.ricStopWatch.unk7E + temp_t2);
             } else {
                 prim->x0 = prim->x2 = var_s4 - 5;
                 prim->x1 = prim->x3 = var_s4 + 5;
@@ -2005,9 +2009,7 @@ void RicEntitySubwpnBibleTrail(Entity* entity) {
         return;
     }
     prim = &g_PrimBuf[entity->primIndex];
-    prim->r0 = prim->r1 = prim->r2 = prim->r3 = prim->g0 = prim->g1 = prim->g2 =
-        prim->g3 = prim->b0 = prim->b1 = prim->b2 = prim->b3 =
-            entity->ext.et_BibleSubwpn.unk7E;
+    PCOL(prim) = entity->ext.et_BibleSubwpn.unk7E;
 }
 
 void RicEntitySubwpnBible(Entity* self) {

--- a/src/ric/ric.h
+++ b/src/ric/ric.h
@@ -135,7 +135,7 @@ enum RicEntities {
     E_SUBWPN_BIBLE_TRAIL,            // RicEntitySubwpnBibleTrail
     E_SUBWPN_STOPWATCH,              // RicEntitySubwpnStopwatch
     E_SUBWPN_STOPWATCH_CIRCLE,       // RicEntitySubwpnStopwatchCircle
-    E_801705EC,                      // func_801705EC
+    E_CRASH_STOPWATCH,               // RicEntityCrashStopwatch
     E_8016F198,                      // func_8016F198
     E_AGUNEA_CIRCLE,                 // RicEntityAguneaCircle
     E_AGUNEA_LIGHTNING,              // RicEntityAguneaLightning
@@ -166,6 +166,7 @@ enum RicBlueprints {
     BP_CRASH_CROSS,
     BP_CRASH_CROSSES_ONLY,
     BP_NOT_IMPLEMENTED_1,
+    // 0x10
     BP_NOT_IMPLEMENTED_2,
     BP_ARM_BRANDISH_WHIP,
     BP_18,
@@ -182,6 +183,7 @@ enum RicBlueprints {
     BP_MARIA,
     BP_MARIA_POWERS_INVOKED,
     BP_31,
+    // 0x20
     BP_NOT_IMPLEMENTED_4,
     BP_RIC_BLINK,
     BP_CRASH_CROSS_PARTICLES,
@@ -198,6 +200,7 @@ enum RicBlueprints {
     BP_HIGH_JUMP,
     BP_HIT_BY_CUT,
     BP_HIT_BY_ICE,
+    // 0x30
     BP_HIT_BY_THUNDER,
     BP_VIBHUTI,
     BP_REBOUND_STONE,
@@ -214,7 +217,8 @@ enum RicBlueprints {
     BP_BIBLE,
     BP_BIBLE_TRAIL,
     BP_SUBWPN_STOPWATCH,
-    BP_STOPWATCH_RIPPLE,
+    // 0x40
+    BP_STOPWATCH_CIRCLE,
     BP_CRASH_STOPWATCH,
     BP_66,
     BP_CRASH_AGUNEA,

--- a/src/st/entrance_stage_entities.h
+++ b/src/st/entrance_stage_entities.h
@@ -12,17 +12,17 @@ void EntityUnkId16(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_EInitSpawner);
-        self->ext.generic.unk7C.S8.unk0 = 16;
-        self->ext.generic.unk7C.S8.unk1 = 8;
-        self->ext.generic.unk7E.modeU8.unk0 = 56;
+        self->ext.entrance16.r = 16;
+        self->ext.entrance16.g = 8;
+        self->ext.entrance16.b = 56;
 
     case 1:
-        g_GpuBuffers[0].draw.r0 = self->ext.generic.unk7C.S8.unk0;
-        g_GpuBuffers[0].draw.g0 = self->ext.generic.unk7C.S8.unk1;
-        g_GpuBuffers[0].draw.b0 = self->ext.generic.unk7E.modeU8.unk0;
-        g_GpuBuffers[1].draw.r0 = self->ext.generic.unk7C.S8.unk0;
-        g_GpuBuffers[1].draw.g0 = self->ext.generic.unk7C.S8.unk1;
-        g_GpuBuffers[1].draw.b0 = self->ext.generic.unk7E.modeU8.unk0;
+        g_GpuBuffers[0].draw.r0 = self->ext.entrance16.r;
+        g_GpuBuffers[0].draw.g0 = self->ext.entrance16.g;
+        g_GpuBuffers[0].draw.b0 = self->ext.entrance16.b;
+        g_GpuBuffers[1].draw.r0 = self->ext.entrance16.r;
+        g_GpuBuffers[1].draw.g0 = self->ext.entrance16.g;
+        g_GpuBuffers[1].draw.b0 = self->ext.entrance16.b;
         break;
     }
 }


### PR DESCRIPTION
Generic is almost gone!

As usual, eliminating those uses also ended up leading me to seeing other functions that needed some cleanup, so I did those too. The common stuff like using Entity* self, making PSP compatible, using proper extensions (lots of RIC was using a fake extension called 80161FF0), and more. Also did a little bit of labeling on the blueprints to hopefully make them more readable.

This ended up being lots of changes, but as usual, they're almost all cosmetic.