### PR TITLE
Decompiling tt_002 func_us_801739D0

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -603,8 +603,22 @@ typedef struct {
 } ET_Ghost;
 
 typedef struct {
-    struct Entity* unk7C;
+    /* 0x7C */ struct Entity* unk7C;
 } ET_Faerie;
+
+// There appears to be a 2nd Ext used in the Faerie code
+typedef struct {
+    /* 0x7C */ s16 pad7c;
+    /* 0x7E */ s16 unk7E;
+    /* 0x80 */ s16 pad80;
+    /* 0x82 */ s16 pad82;
+    /* 0x84 */ s16 unk84;
+    /* 0x86 */ s16 unk86;
+    /* 0x88 */ s16 unk88;
+    /* 0x8A */ s16 unk8A;
+    /* 0x8C */ s16 pad8C[5];
+    /* 0x96 */ s16 unk96;
+} ET_FaerieUnk0;
 
 struct draculaPrimitive;
 typedef struct ET_Dracula {
@@ -1970,6 +1984,7 @@ typedef union { // offset=0x7C
     ET_BatEcho batEcho;
     ET_Ghost ghost;
     ET_Faerie faerie;
+    ET_FaerieUnk0 faerieUnk0;
     ET_SoulStealOrb soulStealOrb;
     ET_GaibonSlogra GS_Props;
     ET_WarpRoom warpRoom;

--- a/src/servant/tt_002/3678.c
+++ b/src/servant/tt_002/3678.c
@@ -22,9 +22,58 @@ extern UnkFaerieStruct D_us_80172368[];
 extern AnimationFrame* D_us_80172B14[];
 
 void func_us_80173994(Entity*, s32);
-void func_us_801739D0(Entity*);
 
-INCLUDE_ASM("servant/tt_002/nonmatchings/3678", func_us_801739D0);
+void func_us_801739D0(Entity* arg0) {
+    if (!arg0->ext.faerieUnk0.unk7E) {
+
+        switch (arg0->entityId) {
+        case 0xD1:
+        case 0xD8:
+            arg0->flags = FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA |
+                          FLAG_UNK_20000;
+
+            func_us_80173994(arg0, 0xE);
+
+            arg0->ext.faerieUnk0.unk84 = rand() % 4096;
+            arg0->ext.faerieUnk0.unk86 = 0;
+            arg0->ext.faerieUnk0.unk88 = 8;
+            arg0->ext.faerieUnk0.unk8A = 0x20;
+            arg0->step++;
+            break;
+        case 0xD9:
+            // loc 0xD8
+            arg0->flags = FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA |
+                          FLAG_UNK_20000;
+            arg0->step++;
+            break;
+        }
+    } else {
+        switch (arg0->entityId) {
+        case 0xD1:
+            arg0->ext.faerieUnk0.unk96 = 0x78;
+            // fallthrough
+        case 0xD2:
+        case 0xD3:
+        case 0xD4:
+        case 0xD5:
+        case 0xD6:
+        case 0xD7:
+        case 0xDA:
+        case 0xDB:
+            arg0->flags = FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA |
+                          FLAG_UNK_20000;
+            func_us_80173994(arg0, 0xE);
+            arg0->step++;
+            break;
+        case 0xD9:
+            arg0->flags = FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA |
+                          FLAG_UNK_20000;
+            arg0->step++;
+        }
+    }
+    arg0->ext.faerieUnk0.unk7E = arg0->entityId;
+    D_us_8017931C = 0;
+}
 
 // This is a duplicate CreateEventEntity which is lower in the file, but we need
 // both to match the binary for PSX


### PR DESCRIPTION
PSX: https://decomp.me/scratch/e2PlK
PSP: https://decomp.me/scratch/ien4a

PSP is close, but has a register swap going on starting at ASM 134-148.  v0 and v1 get flipped.  I couldn't get that to fix

I had to add a 2nd Ext for this overlay as in another function 0x7C is an Entity* and in this function 0x7E is an s16 set to an entity_id.  This leads me to believe that this is an update function used for a sub entity.