### PR TITLE
Decompile a couple of `no0` funcs + minor cleanup

### DIFF
--- a/config/splat.us.stno0.yaml
+++ b/config/splat.us.stno0.yaml
@@ -68,7 +68,7 @@ segments:
       - [0x41394, .rodata, e_collect]
       - [0x4141C, .rodata, e_misc]
       - [0x41468, .rodata, clock_room]
-      - [0x414A8, .rodata, 4C750]
+      - [0x414A8, .rodata, 4E2E0]
       - [0x414B8, .rodata, e_stage_name]
       - [0x414EC, .rodata, unk_4F4A8]
       - [0x4171C, .rodata, e_slinger]

--- a/include/servant.h
+++ b/include/servant.h
@@ -3,10 +3,6 @@
 #include <common.h>
 #include <game.h>
 
-#ifndef ABS
-#define ABS(x) (((x) >= 0) ? (x) : (-(x)))
-#endif
-
 // Unsure if these values are shared or are specific to SERVANT
 // May need to move if these init values are used for more entities
 typedef enum {

--- a/src/servant/tt_001/ghost.c
+++ b/src/servant/tt_001/ghost.c
@@ -166,9 +166,6 @@ static Entity* FindValidTarget(
     s32 i;
     s32 index;
     u32 matches = 0;
-#if !defined(VERSION_PSP)
-    s32 posDelta;
-#endif
 
     // Hunt through these entities looking for ones that match all criteria.
     // Call them a success and increment successes.
@@ -196,23 +193,11 @@ static Entity* FindValidTarget(
             g_GhostAbilityStats[s_GhostStats.level / 10][BAD_ATTACKS_INDEX] ==
                 0)
             continue;
-#if defined(VERSION_PSP)
         if (abs(self->posX.i.hi - entity->posX.i.hi) >= 49)
             continue;
-#else
-        posDelta = self->posX.i.hi - entity->posX.i.hi;
-        if (ABS(posDelta) >= 49)
-            continue;
-#endif
 
-#if defined(VERSION_PSP)
         if (abs(self->posY.i.hi - entity->posY.i.hi) >= 49)
             continue;
-#else
-        posDelta = self->posY.i.hi - entity->posY.i.hi;
-        if (ABS(posDelta) >= 49)
-            continue;
-#endif
 
         if (!self->facingLeft && self->posX.i.hi < entity->posX.i.hi)
             continue;

--- a/src/st/no0/4C750.c
+++ b/src/st/no0/4C750.c
@@ -103,5 +103,3 @@ void func_us_801CC9B4(Entity* self) {
     MoveEntity();
     self->ext.et_801CC9B4.currentAngle = (u8)adjustedAngle;
 }
-
-INCLUDE_RODATA("st/no0/nonmatchings/4C750", D_us_801C14A8);

--- a/src/st/no0/4E2E0.c
+++ b/src/st/no0/4E2E0.c
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "common.h"
+#include "no0.h"
 
 INCLUDE_ASM("st/no0/nonmatchings/4E2E0", func_us_801CE2E0);
+
+INCLUDE_RODATA("st/no0/nonmatchings/4E2E0", D_us_801C14A8);

--- a/src/st/no0/e_elevator.c
+++ b/src/st/no0/e_elevator.c
@@ -344,11 +344,7 @@ void func_us_801C27A4(Entity* self) {
         prim = prim->next;
     }
 
-#if defined(VERSION_PSP)
     if (abs(self->posY.i.hi) > 0x180) {
-#else
-    if (ABS(self->posY.i.hi) > 0x180) {
-#endif
         DestroyEntity(self);
     }
 }

--- a/src/st/no0/no0.h
+++ b/src/st/no0/no0.h
@@ -5,10 +5,6 @@
 
 #define OVL_EXPORT(x) NO0_##x
 
-#ifndef ABS
-#define ABS(x) (((x) >= 0) ? (x) : (-(x)))
-#endif
-
 void EntityExplosionVariants(Entity* entity);
 void EntityGreyPuff(Entity* entity);
 

--- a/src/st/no0/unk_4F4A8.c
+++ b/src/st/no0/unk_4F4A8.c
@@ -33,7 +33,15 @@ void func_us_801D2318(Entity* entity) {
     }
 }
 
-INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_801CD78C);
+void func_801CD78C(Point32* src, s32 speed, s16 angle, Point32* dst) {
+    if (g_CurrentEntity->facingLeft) {
+        angle = -angle;
+    }
+    *dst = *src;
+
+    dst->x -= speed * rsin(angle) * 16;
+    dst->y += speed * rcos(angle) * 16;
+}
 
 INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_us_801D2424);
 

--- a/src/st/no0/unk_4F4A8.c
+++ b/src/st/no0/unk_4F4A8.c
@@ -51,7 +51,22 @@ INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_us_801D274C);
 
 INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_us_801D27C4);
 
-INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_us_801D29F8);
+bool func_us_801D29F8(s16* arg0, s32 arg1, s32 arg2) {
+    if (abs(*arg0 - arg1) < arg2) {
+        *arg0 = arg1;
+        return true;
+    }
+
+    if (arg1 < *arg0) {
+        *arg0 -= arg2;
+    }
+
+    if (*arg0 < arg1) {
+        *arg0 += arg2;
+    }
+
+    return false;
+}
 
 INCLUDE_ASM("st/no0/nonmatchings/unk_4F4A8", func_us_801D2A64);
 


### PR DESCRIPTION
Fixed a rodata split in one of the `no0` files

Decompiled a couple of small functions

While working on this I was having trouble getting a match, looked like `abs` but as usual I was having trouble getting it to work.
Turns out I was using `--no-builtin` on decomp.me which breaks `abs` and is why I also had issues on my earlier scratches. So I've cleaned up the `ABS()` macro I added for those as it is not necessary on PSX