### PR TITLE
decompiling func_us_801753E4

### DIFF
--- a/include/sfx.h
+++ b/include/sfx.h
@@ -254,6 +254,9 @@ enum SfxModes {
 #define SFX_RBO3_UNK_802 0x802
 #define SFX_RBO3_UNK_804 0x804
 
+// SERVANT TT_002 - Faerie
+#define SFX_TT_002_UNK_675 0x675
+
 // SHARED SOUNDS
 // These are sounds that are shared across multiple BIN files
 #define SE_BOSS_DEFEATED 0x7D2


### PR DESCRIPTION
D_us_80172BE4 seems like it should be an array of a struct, but the psp version uses math to move around the single dim array of s32.  I messed with it, but couldn't figure out a way to do it where we kept all the left shifts in the psp version.

No condition for loop is weird, but it's what is needed. (or a while(1), but I really don't like that either).

PSX: https://decomp.me/scratch/r7VMm
PSP: https://decomp.me/scratch/zX0Ly