### PR TITLE
Eliminate MyLayer and MyRoomDef to use the normal structs

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -1187,7 +1187,7 @@ typedef struct {
     /* 0x08 */ u32 right : 6;
     /* 0x0C */ u32 bottom : 6;
     /* 0x10 */ u8 params : 8;
-} LayoutRect; // size = 0x14
+} LayoutRect; // size = 0x4
 
 typedef struct {
     /* 0x00 */ u16* layout;

--- a/include/stage.h
+++ b/include/stage.h
@@ -16,18 +16,6 @@ typedef struct {
     /* 0x8 */ u16 params;
 } LayoutEntity; // size = 0xA
 
-typedef struct {
-    u16* layout;
-    TileDefinition* tileDef;
-    u32 params;
-    u16 zPriority;
-    u16 flags;
-} MyLayer;
-typedef struct {
-    MyLayer* fg;
-    MyLayer* bg;
-} MyRoomDef;
-
 extern u16 g_ItemIconSlots[32];
 
 /*

--- a/include/stage.h
+++ b/include/stage.h
@@ -21,8 +21,7 @@ typedef struct {
     TileDefinition* tileDef;
     u32 params;
     u16 zPriority;
-    u8 unkE;
-    u8 unkF;
+    u16 flags;
 } MyLayer;
 typedef struct {
     MyLayer* fg;

--- a/src/boss/mar/header.c
+++ b/src/boss/mar/header.c
@@ -5,7 +5,7 @@ extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 

--- a/src/pc/stages/stage_dummy.c
+++ b/src/pc/stages/stage_dummy.c
@@ -27,7 +27,7 @@ static u16* clut_anims[] = {empty_clut_load, NULL};
 static void* entity_gfxs[] = {empty_entity_gfx, NULL};
 static void UpdateStageEntities(void);
 extern s16** WRP_spriteBanks[];
-extern MyRoomDef WRP_rooms_layers[];
+extern RoomDef WRP_rooms_layers[];
 
 static Overlay g_StageDesc = {
     Update,

--- a/src/st/cen/header.c
+++ b/src/st/cen/header.c
@@ -10,7 +10,7 @@ void UpdateStageEntities(void);
 extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 
 Overlay OVL_EXPORT(Overlay) = {

--- a/src/st/dre/header.c
+++ b/src/st/dre/header.c
@@ -4,7 +4,7 @@
 extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 

--- a/src/st/mad/header.c
+++ b/src/st/mad/header.c
@@ -5,7 +5,7 @@ extern RoomHeader g_Rooms[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 void func_8018E1D4();

--- a/src/st/no3/header.c
+++ b/src/st/no3/header.c
@@ -5,7 +5,7 @@ extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 

--- a/src/st/np3/header.c
+++ b/src/st/np3/header.c
@@ -5,7 +5,7 @@ extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 

--- a/src/st/nz0/header.c
+++ b/src/st/nz0/header.c
@@ -11,7 +11,7 @@ extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long** OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern RoomHeader OVL_EXPORT(rooms)[];
 
 AbbreviatedOverlay OVL_EXPORT(Overlay) = {

--- a/src/st/rwrp/header.c
+++ b/src/st/rwrp/header.c
@@ -4,7 +4,7 @@
 extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern void* OVL_EXPORT(gfxBanks)[];
 void UpdateStageEntities();
 

--- a/src/st/st0/header.c
+++ b/src/st/st0/header.c
@@ -5,7 +5,7 @@ extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
 extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern GfxBank* g_EntityGfxs[];
 void UpdateStageEntities();
 void PrologueScroll();

--- a/src/st/wrp/header.c
+++ b/src/st/wrp/header.c
@@ -10,7 +10,7 @@ void UpdateStageEntities(void);
 extern RoomHeader OVL_EXPORT(rooms)[];
 extern s16** OVL_EXPORT(spriteBanks)[];
 extern u_long* OVL_EXPORT(cluts)[];
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern u_long* OVL_EXPORT(gfxBanks)[];
 
 Overlay OVL_EXPORT(Overlay) = {

--- a/src/st/wrp_psp/wrp_data_142E0.c
+++ b/src/st/wrp_psp/wrp_data_142E0.c
@@ -6,7 +6,7 @@ void HitDetection(void);
 extern RoomHeader g_Rooms[];
 extern SpriteParts* g_SpriteBanks;
 extern u_long* g_Cluts;
-extern MyRoomDef OVL_EXPORT(rooms_layers)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
 extern GfxBank* g_EntityGfxs;
 void UpdateStageEntities(void);
 

--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -20,8 +20,7 @@ type layerDef struct {
 	Tiledef    psx.Addr
 	PackedInfo uint32
 	ZPriority  uint16
-	UnkE       uint8
-	UnkF       uint8
+	Flags      uint16
 }
 
 type layerUnpacked struct {
@@ -36,8 +35,7 @@ type layerUnpacked struct {
 	IsLoadingRoom bool   `json:"isLoadingRoom"`
 	UnusedFlag    bool   `json:"unusedFlag"`
 	ZPriority     int    `json:"zPriority"`
-	UnkE          int    `json:"unkE"`
-	UnkF          int    `json:"unkF"`
+	Flags         int    `json:"flags"`
 }
 
 type roomLayers struct {
@@ -68,8 +66,7 @@ func (l *layerDef) unpack() layerUnpacked {
 		IsLoadingRoom: int((l.PackedInfo>>24)&0x40) != 0,
 		UnusedFlag:    int((l.PackedInfo>>24)&0x80) != 0,
 		ZPriority:     int(l.ZPriority),
-		UnkE:          int(l.UnkE),
-		UnkF:          int(l.UnkF),
+		Flags:         int(l.Flags),
 	}
 }
 
@@ -149,8 +146,7 @@ func buildLayers(inputDir string, fileName string, outputDir string) error {
 			"params": l.Left | (l.Top << 6) | (l.Right << 12) | (l.Bottom << 18) | (l.ScrollMode << 24) |
 				(util.Btoi(l.IsSaveRoom) << 29) | (util.Btoi(l.IsLoadingRoom) << 30) | (util.Btoi(l.UnusedFlag) << 31),
 			"zPriority": l.ZPriority,
-			"unkE":      l.UnkE,
-			"unkF":      l.UnkF,
+			"flags":     l.Flags,
 		}
 	}
 
@@ -252,15 +248,14 @@ func buildLayers(inputDir string, fileName string, outputDir string) error {
 	}
 
 	sb.WriteString("static MyLayer layers[] = {\n")
-	sb.WriteString("    { NULL, NULL, 0, 0, 0, 0 },\n")
+	sb.WriteString("    { NULL, NULL, 0, 0, 0 },\n")
 	for _, l := range layers[1:] {
-		sb.WriteString(fmt.Sprintf("    { %s, %s, 0x%08X, 0x%02X, %d, %d },\n",
+		sb.WriteString(fmt.Sprintf("    { %s, %s, 0x%08X, 0x%02X, 0x%04X},\n",
 			makeSymbolFromFileName(l["data"].(string)),
 			makeSymbolFromFileName(l["tiledef"].(string)),
 			l["params"],
 			l["zPriority"],
-			l["unkE"],
-			l["unkF"],
+			l["flags"],
 		))
 	}
 	sb.WriteString("};\n")

--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -63,7 +63,7 @@ func (l *layerDef) unpack() layerUnpacked {
 		Right:         int((l.PackedInfo >> 12) & 0x3F),
 		Bottom:        int((l.PackedInfo >> 18) & 0x3F),
 		ScrollMode:    int((l.PackedInfo >> 24) & 0xF),
-		HideOnMap:	   int((l.PackedInfo>>24)&0x10) != 0,
+		HideOnMap:     int((l.PackedInfo>>24)&0x10) != 0,
 		IsSaveRoom:    int((l.PackedInfo>>24)&0x20) != 0,
 		IsLoadingRoom: int((l.PackedInfo>>24)&0x40) != 0,
 		UnusedFlag:    int((l.PackedInfo>>24)&0x80) != 0,


### PR DESCRIPTION
These were temporary structs that were needed for the assets tool.

I adjusted the assets tool so that we will now properly produce normal RoomDef and LayerDef structs, so now we don't need these.

Should help with understanding how the rooms work.