### PR TITLE
Decompile tt_002 func_us_80176178 and func_us_80175DBC

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -1999,7 +1999,8 @@ typedef struct {
 
 typedef union { // offset=0x7C
     struct Primitive* prim;
-    ET_Placeholder ILLEGAL;
+    // ET_Placeholder ILLEGAL;
+    ET_Faerie faerie;
     ET_TimerOnly timer;
     ET_UTimerOnly utimer;
     ET_EntFactory factory;
@@ -2061,7 +2062,7 @@ typedef union { // offset=0x7C
     ET_BatFamBlueTrail batFamBlueTrail;
     ET_BatEcho batEcho;
     ET_Ghost ghost;
-    ET_Faerie faerie;
+
     ET_FaerieUnk0 faerieUnk0;
     ET_SoulStealOrb soulStealOrb;
     ET_GaibonSlogra GS_Props;

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -254,9 +254,6 @@ enum SfxModes {
 #define SFX_RBO3_UNK_802 0x802
 #define SFX_RBO3_UNK_804 0x804
 
-// SERVANT TT_002 - Faerie
-#define SFX_TT_002_UNK_675 0x675
-
 // SHARED SOUNDS
 // These are sounds that are shared across multiple BIN files
 #define SE_BOSS_DEFEATED 0x7D2

--- a/src/servant/tt_002/3678.c
+++ b/src/servant/tt_002/3678.c
@@ -29,7 +29,7 @@ extern s32 D_us_80172BCC;
 extern s32 D_us_80172BD8;
 
 extern s32 D_us_80172BE4[];
-
+extern s16 D_us_80172494[];
 extern s16 D_us_801724C4[];
 extern s32 D_us_80172BD0;
 
@@ -660,7 +660,102 @@ void func_us_80175A78(Entity* self) {
     ServantUpdateAnim(self, NULL, D_us_80172B14);
 }
 
-INCLUDE_ASM("servant/tt_002/nonmatchings/3678", func_us_80175DBC);
+void func_us_80175DBC(Entity* self) {
+    s32 i;
+    s32 rnd;
+    s32 temp;
+
+    s_TargetLocOffset_calc = -0x18;
+    if (!PLAYER.facingLeft) {
+        s_TargetLocOffset_calc = -s_TargetLocOffset_calc;
+    }
+    s_TargetLocationX = PLAYER.posX.i.hi + s_TargetLocOffset_calc;
+    s_TargetLocationY = PLAYER.posY.i.hi - 0x18;
+    switch (self->step) {
+    case 0:
+        func_us_801739D0(self);
+        func_us_80173994(self, 0xE);
+        break;
+    case 1:
+        s_AngleToTarget =
+            CalculateAngleToEntity(self, s_TargetLocationX, s_TargetLocationY);
+        s_AllowedAngle = GetTargetPositionWithDistanceBuffer(
+            s_AngleToTarget, self->ext.faerie.targetAngle, 0x180);
+        self->ext.faerie.targetAngle = s_AllowedAngle;
+        self->velocityY = -(rsin(s_AllowedAngle) << 5);
+        self->velocityX = rcos(s_AllowedAngle) << 5;
+        func_us_80173BD0(self);
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+        s_DistToTargetLocation =
+            CalculateDistance(self, s_TargetLocationX, s_TargetLocationY);
+        if (s_DistToTargetLocation < 2) {
+            self->step++;
+        }
+        break;
+    case 2:
+        self->facingLeft = PLAYER.facingLeft;
+        if (!g_Status.equipHandCount[D_us_80172494[self->params * 4 + 1]]) {
+            func_us_80173994(self, 0x10);
+            self->step = 5;
+            break;
+        }
+        if (SearchForEntityInRange(1, 0x27)) {
+            self->entityId = ENTITY_ID_SERVANT;
+            self->step = 0;
+            return;
+        }
+
+        func_us_80173994(self, 0x12);
+        self->step++;
+        break;
+    case 3:
+        if (PLAYER.facingLeft)
+            temp = 0;
+        else
+            temp = 1;
+        self->facingLeft = temp;
+
+        if (self->animFrameIdx == 0xB) {
+            for (rnd = rand() % 0x100, i = 0; true; i++) {
+                if (rnd <= D_us_80172BE4[i * 2]) {
+                    g_api.PlaySfx(D_us_80172BE4[(i * 2) + 1]);
+                    break;
+                }
+            }
+
+            g_Status.equipHandCount[D_us_80172494[self->params * 4 + 1]]--;
+
+            g_api.CreateEntFactoryFromEntity(
+                self, 0x37 + (D_us_80172494[self->params * 4 + 2] << 0x10), 0);
+            CreateEventEntity_Dupe(
+                self, 0xDF, D_us_80172494[self->params * 4 + 3]);
+            self->ext.faerie.unkCounter8C = 0;
+            self->step++;
+        }
+        break;
+    case 4:
+    case 6:
+        self->ext.faerie.unkCounter8C++;
+        if (self->ext.faerie.unkCounter8C > 0x3C) {
+            self->entityId = ENTITY_ID_SERVANT;
+            self->step = 0;
+            return;
+        }
+        break;
+    case 5:
+        self->facingLeft = PLAYER.facingLeft;
+        if (self->animFrameIdx == 0x20) {
+            g_api.PlaySfx(D_us_80172BD8);
+            self->ext.faerie.unkCounter8C = 0;
+            self->step++;
+        }
+        break;
+    }
+
+    func_us_80173D60(self);
+    ServantUpdateAnim(self, NULL, D_us_80172B14);
+}
 
 void func_us_80176178(Entity* self) {
     s32 temp;


### PR DESCRIPTION
A lot of these update functions are code revolving around the faerie using items (which makes sense, that's what the familiar does).  This means that these update functions share a lot of code.  In fact, entity update steps 0, 1, 4,5,6 are mostly shared between the update functions.  Steps 2 and 3 vary in what they do exactly, but tend to pull from common ideas.  Combined, they look like they do the same concepts for each function.  Data structures are slightly different, but all are used in similar methods.  
 
I will add an enum for these steps as I get farther along.  But there is still some steps that I am not sure of and I'd rather keep it like it is for now, and do it when I'm either done with decomp or at least done with the base update functions.  There is a lot of refactoring that I'll do when I'm closer as well.

Worth noting that I believe all of these functions are mostly a PSP perfect match meaning we may be able to add this to PSP build fairly easily once the decomp is finished.

This PR has 2 functions.  Step 2 and 3 are really the only differences.

func_us_80176178/func_psp_092EAC80
PSX: https://decomp.me/scratch/axD5C
PSP: https://decomp.me/scratch/3KWit

func_us_80175DBC/func_psp_092EA6F0
PSX: https://decomp.me/scratch/Rx6yJ
PSP: https://decomp.me/scratch/youUM