### PR TITLE
Report data (.data, .rodata, .bss) progress

### DIFF
--- a/tools/progress.py
+++ b/tools/progress.py
@@ -351,6 +351,7 @@ def report_human_readable_dryrun(progresses: dict[str, DecompProgressStats]):
 
 
 def report_markdown(progresses: dict[str, DecompProgressStats]):
+    report = ""
     for overlay in progresses:
         stat = progresses[overlay]
         if (
@@ -367,7 +368,7 @@ def report_markdown(progresses: dict[str, DecompProgressStats]):
             ) / stat.functions_total
             data = stat.data_imported / stat.data_total
             data_diff = (stat.data_imported - stat.data_prev) / stat.data_total
-            report = f"## **{overlay.upper()}** *{args.version}*\n\n"
+            report += f"## **{overlay.upper()}** *{args.version}*\n\n"
             if stat.code_matching != stat.code_matching_prev:
                 report += (
                     f"coverage {coverage*100:.2f}% ({coverage_diff*100:+.2f}%)\n\n"
@@ -375,10 +376,11 @@ def report_markdown(progresses: dict[str, DecompProgressStats]):
                 report += f"funcs {funcs*100:.2f}% ({funcs_diff*100:+.2f}%)\n\n"
             if stat.data_imported != stat.data_prev:
                 report += f"data {data*100:.2f}% ({data_diff*100:+.2f}%)\n\n"
-            report += "\n"
-            print(report)
+            report += "\n\n"
         else:
             continue  # no new progress
+    if len(report) > 0:
+        print(report)
 
 
 def report_frogress(entry, version):


### PR DESCRIPTION
I should have done this before the sotn-assets work. Better late than never.

```
MAIN (us): data 0.70% (+0.70%) 
DRA (us): data 34.65% (+34.65%) 
WEAPON (us): data 73.50% (+73.50%) 
RIC (us): data 100.00% (+100.00%) 
STCEN (us): data 100.00% (+100.00%) 
STDRE (us): data 97.45% (+97.45%) 
STMAD (us): data 8.25% (+8.25%) 
STNO0 (us): data 1.94% (+1.94%) 
STNO3 (us): data 96.32% (+96.32%) 
STNP3 (us): data 96.73% (+96.73%) 
STNZ0 (us): data 99.42% (+99.42%) 
STSEL (us): data 62.02% (+62.02%) 
STST0 (us): data 94.06% (+94.06%) 
STWRP (us): data 100.00% (+100.00%) 
STRWRP (us): data 100.00% (+100.00%) 
BOMAR (us): data 98.97% (+98.97%) 
BORBO3 (us): data 60.27% (+60.27%) 
TT_000 (us): data 100.00% (+100.00%) 
TT_001 (us): data 100.00% (+100.00%) 
TT_002 (us): data 5.78% (+5.78%)   
```