### PR TITLE
Remove SOTN Includes from PSXSDK

### DIFF
--- a/src/main/psxsdk/libetc/intr.c
+++ b/src/main/psxsdk/libetc/intr.c
@@ -1,5 +1,6 @@
 
-#include <game.h>
+#include <common.h>
+#include <include_asm.h>
 #include <psxsdk/libetc.h>
 
 int ResetCallback(void) { return D_8002D340->ResetCallback(); }


### PR DESCRIPTION
Removes the SOTN-specific `game.h` include from an SDK file.