### PR TITLE
Decompile tt_002 func_us_80173D60

### DIFF
--- a/src/servant/tt_002/3678.c
+++ b/src/servant/tt_002/3678.c
@@ -238,11 +238,11 @@ void func_us_80173BD0(Entity* arg0) {
 }
 
 void func_us_80173D60(Entity* self) {
-    s32 i; 
-    s32 params; 
-    s32 rnd;  
-    s32 unkHpSum; 
-    s32 playerUnk18Flag; 
+    s32 i;
+    s32 params;
+    s32 rnd;
+    s32 unkHpSum;
+    s32 playerUnk18Flag;
 
     g_api.GetServantStats(self, 0, 0, &s_FaerieStats);
     playerUnk18Flag = g_Player.unk18 & 0xFA00;
@@ -276,13 +276,13 @@ void func_us_80173D60(Entity* self) {
             D_us_80179318 = 0;
             D_us_80179310 = g_Status.hp;
             for (i = 0; i < 5; i++) {
-                D_us_8017930C[i] = 0;
+                D_us_801792FC[i] = 0;
             }
         }
     }
     if (g_Player.status & PLAYER_STATUS_UNK40000) {
         rnd = rand() % 100;
-        if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk0) {
+        if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk1) {
             self->entityId = 0xD2;
             self->step = 0;
             return;
@@ -304,11 +304,9 @@ void func_us_80173D60(Entity* self) {
         return;
     }
 
-    if (PLAYER.step == 0xB &&
-        (!IsMovementAllowed(0)) &&
-        D_80097A1D){
+    if (PLAYER.step == 0xB && (!IsMovementAllowed(0)) && D_80097A1D) {
         rnd = rand() % 100;
-        if(rnd <= D_us_80172408[(s_FaerieStats.level / 10)].unk2) {
+        if (rnd <= D_us_80172408[(s_FaerieStats.level / 10)].unk2) {
             self->ext.faerie.unk8E = 0;
             self->entityId = 0xD3;
             self->step = 0;
@@ -319,7 +317,7 @@ void func_us_80173D60(Entity* self) {
     if (self->entityId == 0xD4) {
         return;
     }
- 
+
     if (g_Player.status & PLAYER_STATUS_CURSE) {
         if (D_80097A1B) {
             rnd = rand() % 100;
@@ -343,7 +341,7 @@ void func_us_80173D60(Entity* self) {
     }
 
     if (g_Player.status & PLAYER_STATUS_POISON) {
-        if (D_80097A1A) {
+        if (D_80097A1A[0]) {
             rnd = rand() % 100;
             if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk4) {
                 self->ext.faerie.unk92 = false;
@@ -393,30 +391,22 @@ void func_us_80173D60(Entity* self) {
         return;
     }
 
-    
-
     for (unkHpSum = 0, params = 0, i = 0; i < 5; i++) {
         unkHpSum += D_us_801792FC[i];
     }
 
     if (unkHpSum >= (g_Status.hpMax / 2)) {
-        if(g_Status.hpMax < 100)
-        {
+        if (g_Status.hpMax < 100) {
             params = 1;
-        }
-        else
-        {
+        } else {
             params = 2;
         }
     }
 
     if (g_Status.hp <= (g_Status.hpMax / 10)) {
-        if(g_Status.hpMax < 100)
-        {
+        if (g_Status.hpMax < 100) {
             params = 1;
-        }
-        else
-        {
+        } else {
             params = 2;
         }
     }
@@ -434,7 +424,7 @@ void func_us_80173D60(Entity* self) {
         return;
     }
 
-    if ((D_80097A29 | D_80097A2A)) {
+    if (D_80097A29 | D_80097A2A) {
         rnd = rand() % 100;
         if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk6) {
             self->ext.faerie.unk94 = true;
@@ -460,7 +450,7 @@ void func_us_80173D60(Entity* self) {
             D_us_80179310 = g_Status.hp;
 
             for (i = 0; i < 5; i++) {
-                D_us_8017930C[i] = 0;
+                D_us_801792FC[i] = 0;
             }
         }
     }

--- a/src/servant/tt_002/3678.c
+++ b/src/servant/tt_002/3678.c
@@ -11,6 +11,7 @@ extern u16 g_FaerieClut[];
 extern Entity thisFamiliar;
 extern s32 s_zPriority;
 extern FamiliarStats s_FaerieStats;
+extern FaerieAbilityStats D_us_80172408[];
 extern s32 D_us_8017931C;
 extern s32 D_us_80179320;
 extern s32 D_us_80179310;
@@ -25,7 +26,14 @@ extern s32 s_TargetLocationX_calc;
 extern s32 s_TargetLocationY;
 extern s32 s_TargetLocationY_calc;
 
+// These are likely able to be consolidated during data cleanup
 extern u8 D_80097A1A[];
+extern u8 D_80097A1B;
+extern u8 D_80097A1D;
+
+extern u8 D_80097A29;
+extern u8 D_80097A2A;
+
 extern s32 D_us_80172BCC;
 extern s32 D_us_80172BD8;
 
@@ -44,6 +52,12 @@ extern u16 D_us_80172D28;
 extern u16 D_us_80172D2A;
 extern u32 D_us_801792D0;
 extern s32 D_us_801792EC;
+
+extern s32 D_us_801792F0;
+extern s32 D_us_801792F4;
+extern s32 D_us_801792F8;
+extern s32 D_us_801792FC[];
+extern s32 D_us_8017930C[];
 
 // Ranked lookup tables
 extern s32 D_us_80172C04[];
@@ -223,7 +237,234 @@ void func_us_80173BD0(Entity* arg0) {
     }
 }
 
-INCLUDE_ASM("servant/tt_002/nonmatchings/3678", func_us_80173D60);
+void func_us_80173D60(Entity* self) {
+    s32 i; 
+    s32 params; 
+    s32 rnd;  
+    s32 unkHpSum; 
+    s32 playerUnk18Flag; 
+
+    g_api.GetServantStats(self, 0, 0, &s_FaerieStats);
+    playerUnk18Flag = g_Player.unk18 & 0xFA00;
+    if (playerUnk18Flag) {
+        if ((D_us_801792F0 & playerUnk18Flag) == playerUnk18Flag) {
+            D_us_801792F8 = 0;
+            D_us_801792F4++;
+            D_us_801792F0 = playerUnk18Flag & D_us_801792F0;
+        } else {
+            D_us_801792F4 = 0;
+            D_us_801792F0 |= playerUnk18Flag;
+        }
+    } else {
+        D_us_801792F8++;
+        if (D_us_801792F8 > 3600) {
+            D_us_801792F0 = D_us_801792F4 = D_us_801792F8 = 0;
+        }
+    }
+
+    if (D_us_80179310 > g_Status.hp) {
+        D_us_801792FC[D_us_80179314++] = D_us_80179310 - g_Status.hp;
+        if (D_us_80179314 > 4) {
+            D_us_80179314 = 0;
+        }
+        D_us_80179310 = g_Status.hp;
+        D_us_80179318 = 0;
+    } else {
+        D_us_80179318++;
+        if (D_us_80179318 > 120) {
+            D_us_80179314 = 0;
+            D_us_80179318 = 0;
+            D_us_80179310 = g_Status.hp;
+            for (i = 0; i < 5; i++) {
+                D_us_8017930C[i] = 0;
+            }
+        }
+    }
+    if (g_Player.status & PLAYER_STATUS_UNK40000) {
+        rnd = rand() % 100;
+        if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk0) {
+            self->entityId = 0xD2;
+            self->step = 0;
+            return;
+        }
+    }
+
+    if (self->ext.faerie.timer < 0) {
+        return;
+    }
+
+    if (self->ext.faerie.timer) {
+        self->ext.faerie.timer--;
+        return;
+    }
+
+    self->ext.faerie.timer = D_us_80172408[s_FaerieStats.level / 10].unk0;
+
+    if (self->entityId == 0xD3) {
+        return;
+    }
+
+    if (PLAYER.step == 0xB &&
+        (!IsMovementAllowed(0)) &&
+        D_80097A1D){
+        rnd = rand() % 100;
+        if(rnd <= D_us_80172408[(s_FaerieStats.level / 10)].unk2) {
+            self->ext.faerie.unk8E = 0;
+            self->entityId = 0xD3;
+            self->step = 0;
+            return;
+        }
+    }
+
+    if (self->entityId == 0xD4) {
+        return;
+    }
+ 
+    if (g_Player.status & PLAYER_STATUS_CURSE) {
+        if (D_80097A1B) {
+            rnd = rand() % 100;
+            if (rnd <= D_us_80172408[(s_FaerieStats.level / 10)].unk3) {
+                self->ext.faerie.unk90 = false;
+                self->entityId = 0xD4;
+                self->step = 0;
+                return;
+            }
+        }
+        if (!self->ext.faerie.unk90) {
+            self->ext.faerie.unk90 = true;
+            self->entityId = 0xD4;
+            self->step = 0;
+            return;
+        }
+    }
+
+    if (self->entityId == 0xD5) {
+        return;
+    }
+
+    if (g_Player.status & PLAYER_STATUS_POISON) {
+        if (D_80097A1A) {
+            rnd = rand() % 100;
+            if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk4) {
+                self->ext.faerie.unk92 = false;
+                self->entityId = 0xD5;
+                self->step = 0;
+                return;
+            }
+        }
+        if (!self->ext.faerie.unk92) {
+            self->ext.faerie.unk92 = true;
+            self->entityId = 0xD5;
+            self->step = 0;
+            return;
+        }
+    }
+
+    if (D_us_801792F4 >= 10) {
+        if (D_us_801792F0 & 0x8000) {
+            params = 0;
+        } else if (D_us_801792F0 & 0x4000) {
+            params = 1;
+        } else if (D_us_801792F0 & 0x2000) {
+            params = 2;
+        } else if (D_us_801792F0 & 0x1000) {
+            params = 3;
+        } else if (D_us_801792F0 & 0x800) {
+            params = 4;
+        } else if (D_us_801792F0 & 0x200) {
+            params = 5;
+        }
+
+        if (!g_api.func_800FF110(D_us_80172494[params * 4]) &&
+            g_Status.equipHandCount[D_us_80172494[(params * 4) + 1]]) {
+            rnd = rand() % 100;
+            if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk5) {
+                self->entityId = 0xD6;
+                self->step = 0;
+                self->params = params;
+                D_us_801792F8 = 0;
+                D_us_801792F4 = 0;
+                return;
+            }
+        }
+    }
+
+    if (self->entityId == 0xD7) {
+        return;
+    }
+
+    
+
+    for (unkHpSum = 0, params = 0, i = 0; i < 5; i++) {
+        unkHpSum += D_us_801792FC[i];
+    }
+
+    if (unkHpSum >= (g_Status.hpMax / 2)) {
+        if(g_Status.hpMax < 100)
+        {
+            params = 1;
+        }
+        else
+        {
+            params = 2;
+        }
+    }
+
+    if (g_Status.hp <= (g_Status.hpMax / 10)) {
+        if(g_Status.hpMax < 100)
+        {
+            params = 1;
+        }
+        else
+        {
+            params = 2;
+        }
+    }
+
+    // if health greater than ¼ max
+    if (!(g_Status.hp > (g_Status.hpMax >> 2))) {
+        if (unkHpSum >= (g_Status.hpMax / 8)) {
+            params = 2;
+        } else if (unkHpSum >= (g_Status.hpMax / 16)) {
+            params = 1;
+        }
+    }
+
+    if (!params) {
+        return;
+    }
+
+    if ((D_80097A29 | D_80097A2A)) {
+        rnd = rand() % 100;
+        if (rnd <= D_us_80172408[s_FaerieStats.level / 10].unk6) {
+            self->ext.faerie.unk94 = true;
+            self->entityId = 0xD7;
+            self->step = 0;
+            self->params = params - 1;
+            D_us_80179314 = 0;
+            D_us_80179318 = 0;
+            D_us_80179310 = g_Status.hp;
+
+            for (i = 0; i < 5; i++) {
+                D_us_801792FC[i] = 0;
+            }
+        }
+    } else {
+        if (!self->ext.faerie.unk94) {
+            self->ext.faerie.unk94 = true;
+            self->entityId = 0xD7;
+            self->step = 0;
+            self->params = params - 1;
+            D_us_80179314 = 0;
+            D_us_80179318 = 0;
+            D_us_80179310 = g_Status.hp;
+
+            for (i = 0; i < 5; i++) {
+                D_us_8017930C[i] = 0;
+            }
+        }
+    }
+}
 
 void ServantInit(InitializeMode mode) {
     u16* src;

--- a/src/servant/tt_002/faerie.h
+++ b/src/servant/tt_002/faerie.h
@@ -6,3 +6,15 @@ typedef struct {
     s16 animIndex;
     s16 zPriorityFlag;
 } FaerieAnimIndex;
+
+// It looks like most if not all of the ability stats for faerie are
+// essentially % chance for abilities to trigger.
+typedef struct {
+    s16 unk0;
+    s16 unk1;
+    s16 unk2;
+    s16 unk3;
+    s16 unk4;
+    s16 unk5;
+    s16 unk6;
+} FaerieAbilityStats;


### PR DESCRIPTION
This is the primary ability update function for Faerie.  The basic idea is that we some upkeep every frame, and tick down the timer. 

Once the timer has ticked down, it resets and then  searches through it's logic to figure out if the player is in a state that the Faerie  can alliviate.  If a path is found, a luck check is performed and if sucessful, the Entity ID is updated so that a different update function is called on the next update(s) to perform the action.

Note, this is not initiated from the engine, this is called from many of the update functions that the engine does call on every frame.

PSX: https://decomp.me/scratch/3ADW8
PSP: https://decomp.me/scratch/53Vc0

This should be a PSP match.

@hohle got this most of the way, I just figured out the local variables.

Co-authored-by: hohle <jonhohle@gmail.com>