### PR TITLE
Adding structs for servant ability stat tables

### DIFF
--- a/src/servant/tt_000/bat.h
+++ b/src/servant/tt_000/bat.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "common.h"
+#include "servant.h"
+
+typedef struct {
+    s32 delayFrames;
+    s32 maxAngle;
+    s32 additionalBatCount;
+    s32 minimumEnemyHp;
+    s32 makeBadAttacks;
+} BatAbilityValues;

--- a/src/servant/tt_000/bat_data.c
+++ b/src/servant/tt_000/bat_data.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "servant.h"
+#include "bat.h"
 
 // sprite data
 Sprite g_BatSpriteData[] = {
@@ -9,13 +9,7 @@ Sprite g_BatSpriteData[] = {
     {-4, -4, 8, 8, 0x144, 0x78, 80, 0, 88, 8},
 };
 
-// ability by level table
-// 0 - attack delay (frames?)
-// 1 - max angle of attack
-// 2 - additional bat count
-// 3 - min enemy HP
-// 4 - make bad attacks (attack invincible?)
-s32 g_BatAbilityStats[][5] = {
+BatAbilityValues g_BatAbilityStats[] = {
     {90, 64, 0, 128, 1}, //
     {90, 96, 0, 128, 1}, //
     {60, 128, 1, 96, 1}, //

--- a/src/servant/tt_001/ghost.c
+++ b/src/servant/tt_001/ghost.c
@@ -7,6 +7,12 @@
 #define ENTITY_ID_ATTACK_CLOUD 0xDA
 #define ENTITY_ID_CONFUSION 0xDB
 
+#ifdef VERSION_PSP
+#define PSP_INLINE(code) code
+#else
+#define PSP_INLINE(code)
+#endif
+
 typedef enum { ATTACK_CLOUD, CONFUSION } ChildEntityType;
 
 static s16 s_DeltaX;
@@ -512,6 +518,7 @@ void UpdateServantDefault(Entity* self) {
         if (self->velocityX < 0) {
             self->facingLeft = 0;
         }
+
         s_DistanceToTarget2 = UpdateEntityVelocityTowardsTarget(
             self, s_TargetLocationX, s_TargetLocationY);
         if (self->step == 2) {
@@ -537,7 +544,8 @@ void UpdateServantDefault(Entity* self) {
             }
         } else {
             self->ext.ghost.frameCounter = 0;
-            if (self->ext.ghost.attackEntity->entityId ==
+            if (PSP_INLINE(self->ext.ghost.attackEntity&&)
+                    self->ext.ghost.attackEntity->entityId ==
                 ENTITY_ID_ATTACK_CLOUD) {
                 self->ext.ghost.attackEntity->params = 1;
                 // this is calling UpdateAttackEntites
@@ -550,7 +558,8 @@ void UpdateServantDefault(Entity* self) {
     case 4:
         if (!(g_Player.status &
               (PLAYER_STATUS_BAT_FORM | PLAYER_STATUS_AXEARMOR))) {
-            if (self->ext.ghost.confusedEntity->entityId ==
+            if (PSP_INLINE(self->ext.ghost.confusedEntity&&)
+                    self->ext.ghost.confusedEntity->entityId ==
                 ENTITY_ID_CONFUSION) {
                 self->ext.ghost.confusedEntity->params = 1;
                 // this is calling UpdateConfusedEntites

--- a/src/servant/tt_001/ghost.h
+++ b/src/servant/tt_001/ghost.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "common.h"
+#include "servant.h"
+
+typedef struct {
+    s32 delayFrames;
+    s32 spellId;
+    s32 makeBadAttacks;
+} GhostAbilityValues;

--- a/src/servant/tt_001/ghost_data.c
+++ b/src/servant/tt_001/ghost_data.c
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "servant.h"
+#include "ghost.h"
 
-// ability stats for level / 10
-// 0 - delay counter
-// 1 - spell Id
-// 2 - make bad attacks (skips enemy hitbox & 8)
-s32 g_GhostAbilityStats[][3] = {
+GhostAbilityValues g_GhostAbilityStats[] = {
     {120, FAM_ABILITY_GHOST_ATTACK, 1},
     {120, FAM_ABILITY_GHOST_ATTACK, 1},
     {100, FAM_ABILITY_GHOST_ATTACK, 1},


### PR DESCRIPTION
Adding GhostAbilityValues and BatAbilityValues structs for the ability stats by level lookup tables instead of using a multi dimension array with index defines.