### PR TITLE
Fix VERSION Warning When Generating Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,7 @@ force_symbols: ##@ Extract a full list of symbols from a successful build
 	$(PYTHON) ./tools/symbols.py elf build/us/tt_002.elf > config/symbols.us.tt_002.txt
 
 context: ##@ create a context for decomp.me. Set the SOURCE variable prior to calling this target
-	$(M2CTX) $(SOURCE)
+	VERSION=$(VERSION) $(M2CTX) $(SOURCE)
 	@echo ctx.c has been updated.
 
 extract_disk: ##@ Extract game files from a disc image.

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -25,16 +25,21 @@ CPP_FLAGS = [
     "-DM2CTX",
 ]
 
+VERSION_DEF = []
+
 
 def import_c_file(in_file) -> str:
     in_file = os.path.relpath(in_file, root_dir)
     cpp_command = ["gcc", "-E", "-P", "-dM", *CPP_FLAGS, in_file]
-    cpp_command2 = ["gcc", "-E", "-P", *CPP_FLAGS, in_file]
+    cpp_command2 = ["gcc", "-E", "-P", *CPP_FLAGS, *VERSION_DEF, in_file]
 
     with tempfile.NamedTemporaryFile(suffix=".c") as tmp:
         stock_macros = subprocess.check_output(
-            ["gcc", "-E", "-P", "-dM", tmp.name], cwd=root_dir, encoding="utf-8"
+            ["gcc", "-E", "-P", "-dM", *VERSION_DEF, tmp.name],
+            cwd=root_dir,
+            encoding="utf-8",
         )
+    stock_macros += "#define __STDC_HOSTED__ 0\n"
 
     out_text = ""
     try:
@@ -68,6 +73,9 @@ def main():
         help="""File from which to create context""",
     )
     args = parser.parse_args()
+
+    if "VERSION" in os.environ:
+        VERSION_DEF.append("-D_internal_version_" + os.environ["VERSION"])
 
     output = import_c_file(args.c_file)
 


### PR DESCRIPTION
This updates `m2ctx` to be aware of the `VERSION` env var and sets that env var in the Makefile prior to running `m2ctx` to eliminate the:

    warning: #warning "Version not specified. Falling back to the US version." [-Wcpp]

error caused by `common.h`.

This also removes `#define __STDC_HOSTED__ 0` from the generated context. That macro causes redefinition warnings in decomp.me.