### PR TITLE
Remove PR bot

### DIFF
--- a/.github/workflows/validate-and-report.yml
+++ b/.github/workflows/validate-and-report.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ matrix.version }}
-      FROGRESS_API_BASE_URL: "https://progress.deco.mp"
     steps:
       - name: Install requirements
         run: sudo apt-get install gcc-mipsel-linux-gnu
@@ -85,23 +84,6 @@ jobs:
         with:
           name: build_${{ matrix.version }}
           path: build/${{ matrix.version }}
-      - name: Post the progress update as a comment to the pull request
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { execSync } = require('child_process');
-            const output = execSync('.venv/bin/python3 tools/progress.py --markdown').toString().trim();
-            if (output) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: output
-              });
-            }
-
 
   generate-progress-report:
     strategy:

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -23,14 +23,6 @@ parser.add_argument(
     action="store_true",
     help="Print the request instead of posting it to the server",
 )
-parser.add_argument(
-    "--markdown",
-    dest="markdown",
-    default=False,
-    required=False,
-    action="store_true",
-    help="Like a dry-run but format the output as a markdown",
-)
 args = parser.parse_args()
 if args.version == None:
     args.version = os.getenv("VERSION")
@@ -350,39 +342,6 @@ def report_human_readable_dryrun(progresses: dict[str, DecompProgressStats]):
             print(f"{overlay.upper()} no new progress")
 
 
-def report_markdown(progresses: dict[str, DecompProgressStats]):
-    report = ""
-    for overlay in progresses:
-        stat = progresses[overlay]
-        if (
-            stat.code_matching != stat.code_matching_prev
-            or stat.data_imported != stat.data_prev
-        ):
-            coverage = stat.code_matching / stat.code_total
-            coverage_diff = (
-                stat.code_matching - stat.code_matching_prev
-            ) / stat.code_total
-            funcs = stat.functions_matching / stat.functions_total
-            funcs_diff = (
-                stat.functions_matching - stat.functions_prev
-            ) / stat.functions_total
-            data = stat.data_imported / stat.data_total
-            data_diff = (stat.data_imported - stat.data_prev) / stat.data_total
-            report += f"## **{overlay.upper()}** *{args.version}*\n\n"
-            if stat.code_matching != stat.code_matching_prev:
-                report += (
-                    f"coverage {coverage*100:.2f}% ({coverage_diff*100:+.2f}%)\n\n"
-                )
-                report += f"funcs {funcs*100:.2f}% ({funcs_diff*100:+.2f}%)\n\n"
-            if stat.data_imported != stat.data_prev:
-                report += f"data {data*100:.2f}% ({data_diff*100:+.2f}%)\n\n"
-            report += "\n\n"
-        else:
-            continue  # no new progress
-    if len(report) > 0:
-        print(report)
-
-
 def report_frogress(entry, version):
     api_base_url = os.getenv("FROGRESS_API_BASE_URL")
     url = f"{api_base_url}/data/{slug}/{version}/"
@@ -457,11 +416,9 @@ if __name__ == "__main__":
     progress = remove_not_existing_overlays(progress)
 
     entry = get_progress_entry(progress)
-    if args.dryrun:
-        report_stdout(entry)
-        report_human_readable_dryrun(progress)
-    elif args.markdown:
-        report_markdown(progress)
-    else:
+    if args.dryrun == False:
         report_discord(progress)
         report_frogress(entry, args.version)
+    else:
+        report_stdout(entry)
+        report_human_readable_dryrun(progress)


### PR DESCRIPTION
It was a funny little experiment that it was worth trying. Unfortunately it had to major flaws:

* There is no easy way to update an existing comment without some scripting, use of tokens and PR manipulation through the GitHub API. It was simply not worth it.
* If the opened PR does not have the very latest changes from the default branch, it will report a drop in progress, which is obviously not correct. I could have internally rebased the PR before calculating the changed progress, but it has its own challenges like having to deal with conflicts.