### PR TITLE
Disable i686 from CI

### DIFF
--- a/.github/workflows/picci.yaml
+++ b/.github/workflows/picci.yaml
@@ -59,7 +59,7 @@ jobs:
         compiler: ["clang", "gcc"]
         build_type: ["Debug", "RelWithDebInfo"]
         sound_engine: ["lle", "custom"]
-        arch: ["x86_64", "i686"]
+        arch: ["x86_64"]
     runs-on: ubuntu-24.04
     needs: extract-assets
     steps:


### PR DESCRIPTION
Temporarily get rid of the following error triggered by the current Ubuntu 24.04 agent:

```
The following packages have unmet dependencies:
 libglib2.0-dev:i[38](https://github.com/Xeeynamo/sotn-decomp/actions/runs/11857786607/job/33047039313#step:3:39)6 : Depends: libglib2.0-dev-bin:i386 (= 2.80.0-6ubuntu3.1)
                       Depends: libglib2.0-dev-bin-linux:i386 (= 2.80.0-6ubuntu3.1)
E: Unable to correct problems, you have held broken packages.
```