### PR TITLE
Update mwccgap

### DIFF
--- a/Makefile.psp.mk
+++ b/Makefile.psp.mk
@@ -89,7 +89,7 @@ OPTIMIZATION = $(if $(findstring dra, $@), $(OPT_HIGH), -Op)
 
 $(BUILD_DIR)/%.c.o: %.c $(MWCCPSP) $(MWCCGAP_APP)
 	@mkdir -p $(dir $@)
-	$(MWCCGAP) $< $@ --mwcc-path $(MWCCPSP) --use-wibo --wibo-path $(WIBO) --as-path $(AS) --asm-dir-prefix asm/pspeu $(MWCCPSP_FLAGS) $(OPTIMIZATION)
+	$(MWCCGAP) $< $@ --mwcc-path $(MWCCPSP) --use-wibo --wibo-path $(WIBO) --as-path $(AS) --asm-dir-prefix asm/pspeu --macro-inc-path include/macro.inc $(MWCCPSP_FLAGS) $(OPTIMIZATION)
 
 $(BUILD_DIR)/assets/%/mwo_header.bin.o: assets/%/mwo_header.bin
 	@mkdir -p $(dir $@)

--- a/config/splat.pspeu.dra.yaml
+++ b/config/splat.pspeu.dra.yaml
@@ -30,7 +30,8 @@ options:
   asm_inc_header: |
     .set noat      /* allow manual use of $at */
     .set noreorder /* don't insert nops after branches */
-    .include "macro.inc"
+sha1: 2ba697c152e240ee0d69619f4a460d145fae04c0
+
 segments:
   - [0x0, bin, mwo_header]
   - name: dra

--- a/config/splat.pspeu.stwrp.yaml
+++ b/config/splat.pspeu.stwrp.yaml
@@ -31,7 +31,6 @@ options:
   asm_inc_header: |
     .set noat      /* allow manual use of $at */
     .set noreorder /* don't insert nops after branches */
-    .include "macro.inc"
 sha1: 0584ddb3ba1afce61592d43497212fcb8ebf797b
 
 segments:

--- a/config/splat.pspeu.tt_000.yaml
+++ b/config/splat.pspeu.tt_000.yaml
@@ -29,7 +29,6 @@ options:
   asm_inc_header: |
     .set noat      /* allow manual use of $at */
     .set noreorder /* don't insert nops after branches */
-    .include "macro.inc"
 sha1: c8c34ac1d46b31e2e5336df271aa2409f44c9d01
 
 segments:


### PR DESCRIPTION
This PR updates mwccgap. The latest version supports the `INCLUDE_RODATA()` macro which you guys may need at some point. 

It also moves the 'macro.inc' logic into mwccgap itself - as splat does not allow configuration of the asm prelude for the INCLUDE_RODATA files.

.. this version will let you pip a file into mwccgap, but you'll need to figure out how to pre-process the file (`cpp -P foo.c | python3 mwccgap.py ...`) whilst preserving the INCLUDE_ASM macros so mwccpsp doesnt cry - i ran out of steam trying to figure it out..

PS - added the missing sha1 for dra :)


