### PR TITLE
Remove Faerie data #ifdef

### DIFF
--- a/src/servant/tt_002/faerie.c
+++ b/src/servant/tt_002/faerie.c
@@ -1343,7 +1343,7 @@ void UpdateServantAdditionalInit(Entity* arg0) {
         rnd = rand() % 0x100;
         if (s_FaerieStats.unk8 == 1) {
             for (i = 0; true; i++) {
-                if (rnd <= g_FaerieIntroRandomizer[i * 2]) {
+                if (rnd <= (s32)g_FaerieIntroRandomizer[i * 2]) {
                     arg0->ext.faerie.currentSfxEvent =
                         (FaerieSfxEventDesc*)g_FaerieIntroRandomizer[i * 2 + 1];
                     break;
@@ -1351,7 +1351,7 @@ void UpdateServantAdditionalInit(Entity* arg0) {
             }
         } else {
             for (i = 0; true; i++) {
-                if (rnd <= g_SfxEventRandomizer[i * 2]) {
+                if (rnd <= (s32)g_SfxEventRandomizer[i * 2]) {
                     arg0->ext.faerie.currentSfxEvent =
                         (FaerieSfxEventDesc*)g_SfxEventRandomizer[i * 2 + 1];
                     break;

--- a/src/servant/tt_002/faerie.h
+++ b/src/servant/tt_002/faerie.h
@@ -105,11 +105,5 @@ typedef struct {
 } ItemPrimitiveParams; // size = 0x1C
 
 extern SpriteParts* g_FaerieSpriteParts[];
-
-#ifdef PLATFORM_64BIT
-extern s64 g_FaerieIntroRandomizer[];
-extern s64 g_SfxEventRandomizer[];
-#else
-extern s32 g_FaerieIntroRandomizer[];
-extern s32 g_SfxEventRandomizer[];
-#endif
+extern s32* g_FaerieIntroRandomizer[];
+extern s32* g_SfxEventRandomizer[];

--- a/src/servant/tt_002/faerie_data.c
+++ b/src/servant/tt_002/faerie_data.c
@@ -21,11 +21,7 @@ static FaerieSfxEventDesc s_IntroEventCommandVO[] = {
     { 0, 34, NA_VO_FAERIE_INTRO_COMMAND },
     {-1, 14, 0}};
 
-#ifdef VERSION_PC
-s64 g_FaerieIntroRandomizer[] = {
-#else
-s32 g_FaerieIntroRandomizer[] = {
-#endif
+s32* g_FaerieIntroRandomizer[] = {
     0x0000007F, s_IntroEventLifeVO, 0x000000FF, s_IntroEventCommandVO};
 
 static FaerieSfxEventDesc s_SfxEventLetsGo[] = {
@@ -35,11 +31,7 @@ static FaerieSfxEventDesc s_SfxEventFollow[] = {
     { 0, 38, NA_VO_FAERIE_FOLLOW },
     {-1, 14, 0}};
 
-#ifdef VERSION_PC
-s64 g_SfxEventRandomizer[] = {
-#else
-s32 g_SfxEventRandomizer[] = {
-#endif
+s32* g_SfxEventRandomizer[] = {
     0x0000007F, s_SfxEventLetsGo, 0x000000FF, s_SfxEventFollow};
 
 // position data with a flag field


### PR DESCRIPTION
Simple follow-up to #1913. The `s32*` type (or any pointer type) already aligns with the targeted architecture. So there is no need for a `#ifdef`

cc. @Onenutmcgee 
