### PR TITLE
libgpu sys functions

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -126,6 +126,7 @@ int sprintf(char* dst, const char* fmt, ...);
 #define SP(x) (0x1F800000 + (x))
 #endif
 
+#define CLAMP(x, min, max) x < min ? min : (x > max ? max : x)
 #define CLAMP_MIN(v, min) ((v) < (min) ? (min) : (v))
 #define CLAMP_MAX(v, max) ((v) > (max) ? (max) : (v))
 

--- a/src/main/psxsdk/libgpu/sys.c
+++ b/src/main/psxsdk/libgpu/sys.c
@@ -23,12 +23,6 @@ typedef struct {
 const char aIdSysCV1831995[] =
     "$Id: sys.c,v 1.83 1995/05/25 13:43:27 suzu Exp $";
 
-extern const char D_800101FC[]; // "ResetGraph(%d)...\n"
-extern const char D_80010360[]; // "PutDispEnv(%08x)...\n"
-extern const char D_80010378[]; // "GPU_exeque: null func.\n"
-extern const char
-    D_80010390[]; // "GPU timeout:que=%d,stat=%08x,chcr=%08x,madr=%08x\n"
-
 s32 VSync(s32);
 
 extern gpu* D_8002C260;
@@ -376,11 +370,33 @@ int get_mode(int dfe, int dtd, int tpage) {
     }
 }
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_cs);
+u_long get_cs(short x, short y) {
+    x = CLAMP(x, 0, 0x400 - 1);
+    y = CLAMP(y, 0, (D_8002C26C ? 0x400 : 0x200) - 1);
+    if (D_8002C26C) {
+        return 0xE3000000 | ((y & 0xFFF) << 12) | (x & 0xFFF);
+    } else {
+        return 0xE3000000 | ((y & 0x3FF) << 10) | (x & 0x3FF);
+    }
+}
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_ce);
+u_long get_ce(short x, short y) {
+    x = CLAMP(x, 0, 0x400 - 1);
+    y = CLAMP(y, 0, (D_8002C26C ? 0x400 : 0x200) - 1);
+    if (D_8002C26C) {
+        return 0xE4000000 | ((y & 0xFFF) << 12) | (x & 0xFFF);
+    } else {
+        return 0xE4000000 | ((y & 0x1FF) << 10) | (x & 0x3FF);
+    }
+}
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/sys", get_ofs);
+u_long get_ofs(short x, short y) {
+    if (D_8002C26C) {
+        return 0xE5000000 | ((y & 0xFFF) << 12) | (x & 0xFFF);
+    } else {
+        return 0xE5000000 | ((y & 0x7FF) << 11) | (x & 0x7FF);
+    }
+}
 
 u_long get_tw(RECT* arg0) {
     u32 pad[4];


### PR DESCRIPTION
`D_8002C26C` is the GPU type. zero is the retail GPU from the first PSX model. Non-zero values is used for arcade boards that have 2MB of VRAM instead of 1MB.

It is a bit hard to rename the symbols. Normally I would mark them as `static` and give them the original names. But on `main` the `.data` section is shuffled due to some linker silliness .

I removed the various `extern const char []` as those strings are now migrated to the functions that owns them.