### PR TITLE
Decompile `no0` func_us_801D4CAC

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -2192,7 +2192,12 @@ typedef struct {
     /* 0x9D */ u8 unk9D;
     /* 0x9E */ s16 : 16;
     /* 0xA0 */ struct Primitive* unkA0;
-    /* 0xA4 */ s16 unkA4[6];
+    /* 0xA4 */ s16 : 16;
+    /* 0xA6 */ s16 : 16;
+    /* 0xA8 */ s16 : 16;
+    /* 0xAA */ s16 : 16;
+    /* 0xAC */ s16 unkAC;
+    /* 0xAE */ s16 : 16;
     /* 0xB0 */ s16 unkB0;
 } ET_PlatelordUnknown;
 

--- a/src/st/no0/e_plate_lord.c
+++ b/src/st/no0/e_plate_lord.c
@@ -1362,13 +1362,13 @@ void func_us_801D4CAC(Entity* self) {
             x = self->posX.i.hi;
             y = self->posY.i.hi + 0xA;
             g_api.CheckCollision(x, y, &collider, 0);
-            if (collider.effects & 1) {
+            if (collider.effects & EFFECT_SOLID) {
                 self->velocityY = -self->velocityY / 2;
                 self->posY.i.hi += collider.unk18;
                 self->ext.plateLordUnknown.unk80++;
             }
             if (self->ext.plateLordUnknown.unk80 > 3) {
-                self->step = 0x11;
+                self->step = 17;
             }
         }
         break;

--- a/src/st/no0/e_plate_lord.c
+++ b/src/st/no0/e_plate_lord.c
@@ -1333,7 +1333,52 @@ void func_us_801D4AA4(Entity* self) {
     }
 }
 
-INCLUDE_ASM("st/no0/nonmatchings/e_plate_lord", func_us_801D4CAC);
+extern u16 D_us_80180B90;
+
+void func_us_801D4CAC(Entity* self) {
+    Collider collider;
+    Entity* tempEntity;
+    s32 x;
+    s32 y;
+
+    tempEntity = self - 9;
+    self->facingLeft = tempEntity->facingLeft;
+    switch (self->step) {
+    case 0:
+        InitializeEntity(&D_us_80180B90);
+        self->animCurFrame = 0x16;
+        self->zPriority = 0xB7;
+        self->hitPoints = 0x7FFF;
+        self->ext.plateLordUnknown.unkAC =
+            self->posY.i.hi + g_Tilemap.scrollY.i.hi;
+        break;
+    case 1:
+        break;
+    case 16:
+        self->posY.val += self->velocityY;
+        self->velocityY += FIX(0.375);
+        y = self->posY.i.hi + g_Tilemap.scrollY.i.hi;
+        if (y >= self->ext.plateLordUnknown.unkAC) {
+            x = self->posX.i.hi;
+            y = self->posY.i.hi + 0xA;
+            g_api.CheckCollision(x, y, &collider, 0);
+            if (collider.effects & 1) {
+                self->velocityY = -self->velocityY / 2;
+                self->posY.i.hi += collider.unk18;
+                self->ext.plateLordUnknown.unk80++;
+            }
+            if (self->ext.plateLordUnknown.unk80 > 3) {
+                self->step = 0x11;
+            }
+        }
+        break;
+    case 17:
+        self->hitboxState = 0;
+        self->flags |= FLAG_DESTROY_IF_OUT_OF_CAMERA |
+                       FLAG_DESTROY_IF_BARELY_OUT_OF_CAMERA;
+        break;
+    }
+}
 
 void func_us_801D4E30(void) {
     Primitive* prim;


### PR DESCRIPTION
PSX: https://decomp.me/scratch/3hzY4
PSP: https://decomp.me/scratch/jnXaI

I used ext.plateLordUnknown because unkAC in ext.plateLord couldn't apply. However ext.plateLordUnknown.unk80 seems to be used as an angle elsewhere while here it looks like it's used as a timer. Should I make a new ext struct for this entity ?