### PR TITLE
Revert "pin spimdisasm 1.31.0"

### DIFF
--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -10,7 +10,7 @@ requests
 graphviz
 splat64==0.24.6
 crunch64
-spimdisasm==1.31.0
+spimdisasm>=1.26.0
 rabbitizer>=1.11.0
 n64img==0.3.3
 pygfxd


### PR DESCRIPTION
Reverts Xeeynamo/sotn-decomp#1957 as spimdisasm 1.31.2 fixes the problem encountered in 1.31.1: https://github.com/Decompollaborate/spimdisasm/pull/179