### PR TITLE
Force 32-Bit When Generating Context

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -23,6 +23,7 @@
 #define VERSION "us"
 #endif
 
+#ifndef M2CTX
 #if defined(_MSC_VER)
 #if defined(_WIN64) || defined(_M_X64) || defined(_M_ARM64)
 #define PLATFORM_64BIT
@@ -35,6 +36,7 @@
 #else
 #if (defined(__LP64__) || defined(_LP64))
 #define PLATFORM_64BIT
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This suppresses the `PLATFORM_64BIT` macro when generating the context. Because the context is generated with the platform `gcc` it appears to be a 64-bit environment rather than one of the 32-Bit MIPS environments expected when decompiling.