### PR TITLE
Fix some missed build elements for NO1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,8 @@ force_symbols: ##@ Extract a full list of symbols from a successful build
 	$(PYTHON) ./tools/symbols.py elf build/us/ric.elf > config/symbols.us.ric.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stcen.elf > config/symbols.us.stcen.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stdre.elf > config/symbols.us.stdre.txt
+	$(PYTHON) ./tools/symbols.py elf build/us/stno0.elf > config/symbols.us.stno0.txt
+	$(PYTHON) ./tools/symbols.py elf build/us/stno1.elf > config/symbols.us.stno1.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stno3.elf > config/symbols.us.stno3.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stnp3.elf > config/symbols.us.stnp3.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stnz0.elf > config/symbols.us.stnz0.txt

--- a/tools/dups/src/main.rs
+++ b/tools/dups/src/main.rs
@@ -329,6 +329,13 @@ fn do_dups_report(output_file: Option<String>, threshold: f64) {
             path_matcher: "st/no0".to_string(),
         },
         SrcAsmPair {
+            asm_dir: String::from("../../asm/us/st/no1/matchings/"),
+            src_dir: String::from("../../src/st/no1/"),
+            overlay_name: String::from("NO1"),
+            include_asm: get_all_include_asm("../../src/st/no1/"),
+            path_matcher: "st/no1".to_string(),
+        },
+        SrcAsmPair {
             asm_dir: String::from("../../asm/us/st/no3/matchings/"),
             src_dir: String::from("../../src/st/no3/"),
             overlay_name: String::from("NO3"),


### PR DESCRIPTION
Noticed the funcs report wasn't showing duplicates, so have added NO1 to the dups tool

Also noticed NO0 and NO1 were missing from force_symbols which I have added