### PR TITLE
Decompile tt_003 func_us_80175810

### DIFF
--- a/config/symbols.us.tt_003.txt
+++ b/config/symbols.us.tt_003.txt
@@ -7,6 +7,7 @@ g_DemonClut = 0x80171C24;
 s_PassthroughFunctions = 0x80171CC4;
 s_DemonSfxMap = 0x80171D2C;
 g_DemonAnimationFrames = 0x80172010;
+D_us_80172080 = 0x80172080;
 g_Events = 0x80172090;
 g_PlaySfxStep = 0x801729C0;
 g_EntityRanges = 0x801729C4;

--- a/include/entity.h
+++ b/include/entity.h
@@ -667,8 +667,11 @@ typedef struct {
     /* 0x88 */ s16 defaultDistToTargetLoc;
     /* 0x8A */ s16 maxAngle;
     /* 0x8C */ s16 abilityTimer;
-    /* 0x8E */ s16 pad_8E[0x9]; // this will possbily get broken out more
-    /*0xA0*/ s16 unkCounter;
+    /* 0x8E */ s16 pad_8E[2];
+    /* 0x92 */ s16 attackEndCounter;
+    /* 0x94 */ s16 attackVelocityOffset;
+    /* 0x96 */ s16 pad_96[5];
+    /* 0xA0 */ s16 unkCounter;
     /* 0xA4 */ struct Entity* target;
 } ET_Demon;
 

--- a/src/servant/tt_002/faerie.c
+++ b/src/servant/tt_002/faerie.c
@@ -1344,8 +1344,8 @@ void UpdateServantAdditionalInit(Entity* arg0) {
         if (s_FaerieStats.unk8 == 1) {
             for (i = 0; true; i++) {
                 if (rnd <= (s32)g_FaerieIntroRandomizer[i * 2]) {
-                    arg0->ext.faerie.currentSfxEvent = (ServantSfxEventDesc*)
-                        g_FaerieIntroRandomizer[i * 2 + 1];
+                    arg0->ext.faerie.currentSfxEvent =
+                        (ServantSfxEventDesc*)g_FaerieIntroRandomizer[i * 2 + 1];
                     break;
                 }
             }

--- a/src/servant/tt_002/faerie.c
+++ b/src/servant/tt_002/faerie.c
@@ -1344,8 +1344,8 @@ void UpdateServantAdditionalInit(Entity* arg0) {
         if (s_FaerieStats.unk8 == 1) {
             for (i = 0; true; i++) {
                 if (rnd <= (s32)g_FaerieIntroRandomizer[i * 2]) {
-                    arg0->ext.faerie.currentSfxEvent =
-                        (ServantSfxEventDesc*)g_FaerieIntroRandomizer[i * 2 + 1];
+                    arg0->ext.faerie.currentSfxEvent = (ServantSfxEventDesc*)
+                        g_FaerieIntroRandomizer[i * 2 + 1];
                     break;
                 }
             }

--- a/src/servant/tt_003/demon.c
+++ b/src/servant/tt_003/demon.c
@@ -968,9 +968,6 @@ void unused_5800(Entity* self) {}
 
 void unused_5808(Entity* self) {}
 
-// PSX: https://decomp.me/scratch/TLUnC
-// PSP: https://decomp.me/scratch/GQL4q
-
 extern AnimationFrame* D_us_8017202C;
 extern s32* D_us_80172080[];
 extern s32 D_us_80178628;
@@ -978,12 +975,11 @@ extern s32 D_us_8017862C;
 extern ServantSfxEventDesc* D_us_80178634;
 extern s16 D_us_80178638;
 
-void func_us_80175810(Entity* self)
-{
+void func_us_80175810(Entity* self) {
     Entity* sfxEntity;
-    s32 temp_v0_2;
-    s32 temp_v0_3;
-    s32 temp_again;
+    s32 xCalc;
+    s32 yCalc;
+    s32 facingLeft;
 
     if (D_us_801786D4) {
         self->zPriority = PLAYER.zPriority - 2;
@@ -993,90 +989,91 @@ void func_us_80175810(Entity* self)
         D_us_8017862C = D_us_801786D8->posY.val;
         self->ext.demon.pad_8E[3] += 0x40;
         self->ext.demon.pad_8E[3] &= 0xFFF;
-        D_us_8017862C = (rsin((s32) self->ext.demon.pad_8E[3]) << 3 << 4) + D_us_8017862C;
-        
-        self->velocityX =  (D_us_80178628 - self->posX.val) >> 5;
+        D_us_8017862C =
+            (rsin((s32)self->ext.demon.pad_8E[3]) << 3 << 4) + D_us_8017862C;
+
+        self->velocityX = (D_us_80178628 - self->posX.val) >> 5;
         self->velocityY = (D_us_8017862C - self->posY.val) >> 5;
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
     }
     switch (self->step) {
-        case 0:
-            func_us_80172DC4(self);
-            break;
-        case 1:
-            if(self->velocityX > 0)
-            {
-                temp_again = 0;
+    case 0:
+        func_us_80172DC4(self);
+        break;
+    case 1:
+        if (self->velocityX > 0) {
+            facingLeft = false;
+        } else {
+            facingLeft = true;
+        }
+        self->facingLeft = facingLeft;
+
+        xCalc = (D_us_80178628 - self->posX.val) >> 0x10;
+        yCalc = (D_us_8017862C - self->posY.val) >> 0x10;
+        if ((SquareRoot12((SQ(xCalc) + SQ(yCalc)) << 0xC) >> 0xC) < 0x10) {
+            if (g_StageId < 0x20 || g_StageId > 0x34) {
+                self->facingLeft = 0;
+                D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[1];
+            } else {
+                self->facingLeft = 1;
+                D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[3];
             }
-            else
-            {
-                temp_again = 1;
-            }
-            self->facingLeft = temp_again;
-            
-            temp_v0_2 = (D_us_80178628 - self->posX.val) >> 0x10;
-            temp_v0_3 = (D_us_8017862C - self->posY.val) >> 0x10;
-            if ((SquareRoot12(((temp_v0_2 * temp_v0_2) + (temp_v0_3 * temp_v0_3)) << 0xC) >> 0xC) < 0x10) {
-                if (g_StageId < 0x20 || g_StageId > 0x34) {
-                    self->facingLeft = 0;
-                    D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[1];
-                } else {
-                    self->facingLeft = 1;
-                    D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[3];
-                }
+            self->step++;
+        }
+        break;
+    case 2:
+        D_us_80178638 = ((s16*)D_us_80178634)[0];
+#ifndef VERSION_PSP
+        g_PauseAllowed = false;
+#endif
+        self->step++;
+        // fallthrough
+    case 3:
+
+        if (D_us_80178638 < 0) {
+            if (g_PlaySfxStep > 4) {
+
+                SetAnimationFrame(self, D_us_80178634->animIndex);
+#ifndef VERSION_PSP
+                g_PauseAllowed = true;
+#endif
                 self->step++;
             }
-            break;
-        case 2:
-            D_us_80178638 = ((s16*)D_us_80178634)[0];
-#ifndef VERSION_PSP
-            g_PauseAllowed = false;
-#endif
-            self->step++;
-        
-            // fallthrough
-        case 3:
-            
-            if (D_us_80178638 < 0) { 
-                if (g_PlaySfxStep > 4) {
-                    
-                    SetAnimationFrame(self, D_us_80178634->animIndex);
-#ifndef VERSION_PSP
-                    g_PauseAllowed = true;
-#endif
-                    self->step++;
-                }
-            } else {
-                if ((g_PlaySfxStep == 4) || (g_PlaySfxStep >= 0x63)) {
-                    D_us_80178638--;
-                }
-                if (D_us_80178638 < 0) {
-                    SetAnimationFrame(self, D_us_80178634->animIndex);
-                    if (D_us_80178634->sfxId != 0 && !SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) {
-                        CreateEventEntity(self, DEMON_EVENT_SFX_PASSTHROUGH, D_us_80178634->sfxId);
-                    }
-                    D_us_80178634++;
-                    D_us_80178638 = ((s16*)D_us_80178634)[0]; 
-                }
+        } else {
+            if ((g_PlaySfxStep == 4) || (g_PlaySfxStep >= 0x63)) {
+                D_us_80178638--;
             }
-            break;
-        case 4:
-            self->ext.demon.pad_8E[2]++;
-            if (self->ext.demon.pad_8E[2] > 0x78) {
-                self->entityId = DEMON_MODE_DEFAULT_UPDATE;
-                self->step = 0;
+            if (D_us_80178638 < 0) {
+                SetAnimationFrame(self, D_us_80178634->animIndex);
+                if (D_us_80178634->sfxId != 0 &&
+                    !SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) {
+                    CreateEventEntity(self, DEMON_EVENT_SFX_PASSTHROUGH,
+                                      D_us_80178634->sfxId);
+                }
+                D_us_80178634++;
+                D_us_80178638 = ((s16*)D_us_80178634)[0];
             }
-            break;
+        }
+        break;
+    case 4:
+        self->ext.demon.pad_8E[2]++;
+        if (self->ext.demon.pad_8E[2] > 0x78) {
+            self->entityId = DEMON_MODE_DEFAULT_UPDATE;
+            self->step = 0;
+        }
+        break;
     }
-    if (D_us_801786D8 && !D_us_801786D8->entityId ) {
+    if (D_us_801786D8 && !D_us_801786D8->entityId) {
 #ifndef VERSION_PSP
         g_PauseAllowed = true;
 #endif
         self->entityId = DEMON_MODE_DEFAULT_UPDATE;
         self->step = 0;
-         
-        if ((sfxEntity = SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) && sfxEntity->step < 5) {
+
+        if ((sfxEntity =
+                 SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) &&
+            sfxEntity->step < 5) {
             sfxEntity->step = 7;
         }
     }

--- a/src/servant/tt_003/demon.c
+++ b/src/servant/tt_003/demon.c
@@ -987,10 +987,11 @@ void func_us_80175810(Entity* self) {
     if (D_us_801786D8) {
         D_us_80178628 = D_us_801786D8->posX.val;
         D_us_8017862C = D_us_801786D8->posY.val;
-        self->ext.demon.pad_8E[3] += 0x40;
-        self->ext.demon.pad_8E[3] &= 0xFFF;
+        self->ext.demon.attackVelocityOffset += 0x40;
+        self->ext.demon.attackVelocityOffset &= 0xFFF;
         D_us_8017862C =
-            (rsin((s32)self->ext.demon.pad_8E[3]) << 3 << 4) + D_us_8017862C;
+            (rsin((s32)self->ext.demon.attackVelocityOffset) << 3 << 4) +
+            D_us_8017862C;
 
         self->velocityX = (D_us_80178628 - self->posX.val) >> 5;
         self->velocityY = (D_us_8017862C - self->posY.val) >> 5;
@@ -1012,7 +1013,7 @@ void func_us_80175810(Entity* self) {
         xCalc = (D_us_80178628 - self->posX.val) >> 0x10;
         yCalc = (D_us_8017862C - self->posY.val) >> 0x10;
         if ((SquareRoot12((SQ(xCalc) + SQ(yCalc)) << 0xC) >> 0xC) < 0x10) {
-            if (g_StageId < 0x20 || g_StageId > 0x34) {
+            if (g_StageId < STAGE_RNO0 || g_StageId >= STAGE_RNZ1_DEMO) {
                 self->facingLeft = 0;
                 D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[1];
             } else {
@@ -1057,13 +1058,14 @@ void func_us_80175810(Entity* self) {
         }
         break;
     case 4:
-        self->ext.demon.pad_8E[2]++;
-        if (self->ext.demon.pad_8E[2] > 0x78) {
+        self->ext.demon.attackEndCounter++;
+        if (self->ext.demon.attackEndCounter > 120) {
             self->entityId = DEMON_MODE_DEFAULT_UPDATE;
             self->step = 0;
         }
         break;
     }
+
     if (D_us_801786D8 && !D_us_801786D8->entityId) {
 #ifndef VERSION_PSP
         g_PauseAllowed = true;

--- a/src/servant/tt_003/demon.c
+++ b/src/servant/tt_003/demon.c
@@ -968,7 +968,123 @@ void unused_5800(Entity* self) {}
 
 void unused_5808(Entity* self) {}
 
-INCLUDE_ASM("servant/tt_003/nonmatchings/demon", func_us_80175810);
+// PSX: https://decomp.me/scratch/TLUnC
+// PSP: https://decomp.me/scratch/GQL4q
+
+extern AnimationFrame* D_us_8017202C;
+extern s32* D_us_80172080[];
+extern s32 D_us_80178628;
+extern s32 D_us_8017862C;
+extern ServantSfxEventDesc* D_us_80178634;
+extern s16 D_us_80178638;
+
+void func_us_80175810(Entity* self)
+{
+    Entity* sfxEntity;
+    s32 temp_v0_2;
+    s32 temp_v0_3;
+    s32 temp_again;
+
+    if (D_us_801786D4) {
+        self->zPriority = PLAYER.zPriority - 2;
+    }
+    if (D_us_801786D8) {
+        D_us_80178628 = D_us_801786D8->posX.val;
+        D_us_8017862C = D_us_801786D8->posY.val;
+        self->ext.demon.pad_8E[3] += 0x40;
+        self->ext.demon.pad_8E[3] &= 0xFFF;
+        D_us_8017862C = (rsin((s32) self->ext.demon.pad_8E[3]) << 3 << 4) + D_us_8017862C;
+        
+        self->velocityX =  (D_us_80178628 - self->posX.val) >> 5;
+        self->velocityY = (D_us_8017862C - self->posY.val) >> 5;
+        self->posX.val += self->velocityX;
+        self->posY.val += self->velocityY;
+    }
+    switch (self->step) {
+        case 0:
+            func_us_80172DC4(self);
+            break;
+        case 1:
+            if(self->velocityX > 0)
+            {
+                temp_again = 0;
+            }
+            else
+            {
+                temp_again = 1;
+            }
+            self->facingLeft = temp_again;
+            
+            temp_v0_2 = (D_us_80178628 - self->posX.val) >> 0x10;
+            temp_v0_3 = (D_us_8017862C - self->posY.val) >> 0x10;
+            if ((SquareRoot12(((temp_v0_2 * temp_v0_2) + (temp_v0_3 * temp_v0_3)) << 0xC) >> 0xC) < 0x10) {
+                if (g_StageId < 0x20 || g_StageId > 0x34) {
+                    self->facingLeft = 0;
+                    D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[1];
+                } else {
+                    self->facingLeft = 1;
+                    D_us_80178634 = (ServantSfxEventDesc*)D_us_80172080[3];
+                }
+                self->step++;
+            }
+            break;
+        case 2:
+            D_us_80178638 = ((s16*)D_us_80178634)[0];
+#ifndef VERSION_PSP
+            g_PauseAllowed = false;
+#endif
+            self->step++;
+        
+            // fallthrough
+        case 3:
+            
+            if (D_us_80178638 < 0) { 
+                if (g_PlaySfxStep > 4) {
+                    
+                    SetAnimationFrame(self, D_us_80178634->animIndex);
+#ifndef VERSION_PSP
+                    g_PauseAllowed = true;
+#endif
+                    self->step++;
+                }
+            } else {
+                if ((g_PlaySfxStep == 4) || (g_PlaySfxStep >= 0x63)) {
+                    D_us_80178638--;
+                }
+                if (D_us_80178638 < 0) {
+                    SetAnimationFrame(self, D_us_80178634->animIndex);
+                    if (D_us_80178634->sfxId != 0 && !SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) {
+                        CreateEventEntity(self, DEMON_EVENT_SFX_PASSTHROUGH, D_us_80178634->sfxId);
+                    }
+                    D_us_80178634++;
+                    D_us_80178638 = ((s16*)D_us_80178634)[0]; 
+                }
+            }
+            break;
+        case 4:
+            self->ext.demon.pad_8E[2]++;
+            if (self->ext.demon.pad_8E[2] > 0x78) {
+                self->entityId = DEMON_MODE_DEFAULT_UPDATE;
+                self->step = 0;
+            }
+            break;
+    }
+    if (D_us_801786D8 && !D_us_801786D8->entityId ) {
+#ifndef VERSION_PSP
+        g_PauseAllowed = true;
+#endif
+        self->entityId = DEMON_MODE_DEFAULT_UPDATE;
+        self->step = 0;
+         
+        if ((sfxEntity = SearchForEntityInRange(0, DEMON_EVENT_SFX_PASSTHROUGH)) && sfxEntity->step < 5) {
+            sfxEntity->step = 7;
+        }
+    }
+    if ((self->anim == D_us_8017202C) && (self->animFrameIdx == 8)) {
+        D_us_801786DC = 1;
+    }
+    ServantUpdateAnim(self, NULL, g_DemonAnimationFrames);
+}
 
 void func_us_80175C08(Entity* self) {
 


### PR DESCRIPTION
For whatever reason, the g_PauseAllowed code is stripped out of this function for PSP.

This also uses the (s16*) trick that other demon code uses for the SFX structs.  I'll circle back at refactor time to try and figure out a better way, although it's a small price to pay to use a proper struct.

Full match
// PSX: https://decomp.me/scratch/TLUnC
// PSP: https://decomp.me/scratch/GQL4q