### PR TITLE
Fix `MAX` Macro

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -49,7 +49,7 @@
 #define STRCPY(dst, src) __builtin_memcpy(dst, src, sizeof(src))
 #define SQ(x) ((x) * (x))
 #define MIN(a, b) ((a) > (b) ? (b) : (a))
-#define MAX(a, b) ((a) > (b) ? (b) : (a))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 #ifdef _MSC_VER
 #define __builtin_memcpy memcpy

--- a/src/st/e_skeleton.h
+++ b/src/st/e_skeleton.h
@@ -253,7 +253,7 @@ void EntitySkeletonThrownBone(Entity* self) { // Bone Projectile from Skeleton
         self->posY.val -= FIX(0.0625);
         xDistanceToPlayer = GetDistanceToPlayerX();
         xDistanceToPlayer /= 32;
-        xDistanceToPlayer = MAX(xDistanceToPlayer, 7);
+        xDistanceToPlayer = MIN(xDistanceToPlayer, 7);
         velocityX = bone_projectile_velocity_x[xDistanceToPlayer];
         xDistanceToPlayer = self->facingLeft;
 


### PR DESCRIPTION
Fixes the `MAX` macro to compute return greater of two args.