### PR TITLE
Fix builtin header definitions

### DIFF
--- a/include/psxsdk/libc.h
+++ b/include/psxsdk/libc.h
@@ -5,11 +5,11 @@ extern void exit();
 extern void puts(char*);
 // setjmp
 extern char* strcat(char*, char*);
-extern int strcmp(char*, char*);
-extern int strncmp(char*, char*);
-extern char* strcpy(char*, char*);
-extern int strlen(char*);
-extern void* memcpy(unsigned char*, unsigned char*, int);
+extern int strcmp(const char*, const char*);
+extern int strncmp(const char*, const char*);
+extern char* strcpy(const char*, const char*);
+extern int strlen(const char*);
+extern void* memcpy(void*, const void*, size_t);
 extern void* memset(unsigned char*, unsigned char, int);
 
 /*


### PR DESCRIPTION
Should mean no more

```
ctx.c:809: warning: conflicting types for built-in function `strcmp'
ctx.c:811: warning: conflicting types for built-in function `strcpy'
ctx.c:812: warning: conflicting types for built-in function `strlen'
ctx.c:813: warning: conflicting types for built-in function `memcpy'
```

When generating context