### PR TITLE
make-config PSP enhancementa

### DIFF
--- a/tools/make-config.py
+++ b/tools/make-config.py
@@ -514,7 +514,7 @@ def make_config_psp(ovl_path: str, version: str):
     text_len = ovl_header["text_len"]
     data_len = ovl_header["data_len"]
     bss_len = ovl_header["bss_len"]
-    data_start = align(text_len, 0x80) + 0x80
+    data_start = align(text_len, 0x80)
     bss_start = align(vram + data_start + data_len - 0x80, 0x80)
     file_size = os.stat(ovl_path).st_size
     config = get_splat_config(


### PR DESCRIPTION
Changelog:

* Fix runtime error when adding new symbols
* Remove splat deprecated config flag `disassemble_all`
* Add entity symbols from the existing US overlay counterpart
* Automatically detect rodata table and perform migration to functions

tested with `python3 tools/make-config.py st0 --version pspeu`