### PR TITLE
Pin rabbitizer to 1.12.0

### DIFF
--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -11,7 +11,7 @@ graphviz
 splat64==0.24.6
 crunch64
 spimdisasm>=1.26.0
-rabbitizer>=1.11.0
+rabbitizer==1.12.0
 n64img==0.3.3
 pygfxd
 pillow


### PR DESCRIPTION
Version 1.12.1 appears to have something which broke the build, pinning for now.
https://github.com/Decompollaborate/rabbitizer/releases/tag/1.12.1