### PR TITLE
DrawRichterHUD matching for PSP

### DIFF
--- a/config/symbols.pspeu.dra.txt
+++ b/config/symbols.pspeu.dra.txt
@@ -135,6 +135,7 @@ func_80106A28 = 0x0913EC20;
 LoadMonsterLibrarianPreview = 0x0913F780;
 func_801071CC = 0x0913F7F8;
 func_80107250 = 0x0913F860;
+func_801072DC = 0x0913F8D0;
 SetPrimRect = 0x0913F8D8;
 SetTexturedPrimRect = 0x0913F908;
 func_80131F68 = 0x09140610;

--- a/src/dra/5F60C.c
+++ b/src/dra/5F60C.c
@@ -579,21 +579,28 @@ void InitStatsAndGear(bool isDeathTakingItems) {
     func_800F53A4();
 }
 
+#ifdef VERSION_PSP
+#define RIC_HUD_NUM_SPRITES 10
+#else
+#define RIC_HUD_NUM_SPRITES 9
+#endif
+
 void DrawRichterHud(void) {
+    s32 i;
     Primitive* prim;
 
-    g_PlayerHud.unk0C = 400;
-    g_PlayerHud.unk10 = 400;
     D_801397FC = 0;
     D_80139008 = 0;
     g_PlayerHud.unk28 = 0;
     D_8003C744 = 0;
+    g_PlayerHud.unk0C = 400;
+    g_PlayerHud.unk10 = 400;
     g_PlayerHud.unk14 = 48;
     g_PlayerHud.unk18 = 0;
+    g_PlayerHud.unk1C = g_PlayerHud.unk20 =
+        g_PlayerHud.unk0C * 100 / g_PlayerHud.unk10;
     g_PlayerHud.unk24 = 0;
-    g_PlayerHud.unk20 = 40000 / (u32)g_PlayerHud.unk0C;
-    g_PlayerHud.unk1C = 40000 / g_PlayerHud.unk10;
-    g_PlayerHud.primIndex1 = func_800EDD9C(PRIM_GT4, 9);
+    g_PlayerHud.primIndex1 = func_800EDD9C(PRIM_GT4, RIC_HUD_NUM_SPRITES);
     prim = &g_PrimBuf[g_PlayerHud.primIndex1];
 
     SetTexturedPrimRect(prim, 2, 22, 32, 96, 0, 0);
@@ -654,6 +661,16 @@ void DrawRichterHud(void) {
     prim->drawMode = DRAW_ABSPOS;
     prim = prim->next;
 
+    // Extra HUD sprite on PSP! Should identify what this is.
+#ifdef VERSION_PSP
+    SetTexturedPrimRect(prim, 18, 38, 8, 8, 0, 0);
+    prim->tpage = 0x1B;
+    prim->clut = 0x102;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+#endif
+
     SetTexturedPrimRect(prim, 33, 20, 64, 24, 64, 40);
     prim->tpage = 0x1B;
     prim->clut = 0x103;
@@ -661,23 +678,16 @@ void DrawRichterHud(void) {
     prim->drawMode = DRAW_ABSPOS;
 
     g_PlayerHud.primIndex2 = func_800EDD9C(4, 16);
-    prim = &g_PrimBuf[g_PlayerHud.primIndex2];
-    if (prim != 0) {
-        s32 u = 32;
-        s32 x = 216;
-        do {
-            SetTexturedPrimRect(prim, x, 22, 2, 96, u, 0);
-            func_801072DC(prim);
-            prim->tpage = 0x1B;
-            prim->clut = 0x100;
-            prim->priority = 0x1EE;
-            prim->drawMode = DRAW_HIDE;
-            prim->p1 = (rand() & 0x3F) + 1;
-            prim->p2 = 0;
-            prim = prim->next;
-            u += 2;
-            x += 2;
-        } while (prim != 0);
+    for (prim = &g_PrimBuf[g_PlayerHud.primIndex2], i = 0; prim != 0; i++,
+        prim = prim->next) {
+        SetTexturedPrimRect(prim, 216 + i * 2, 22, 2, 96, 32 + i * 2, 0);
+        func_801072DC(prim);
+        prim->tpage = 0x1B;
+        prim->clut = 0x100;
+        prim->priority = 0x1EE;
+        prim->drawMode = DRAW_HIDE;
+        prim->p1 = (rand() & 0x3F) + 1;
+        prim->p2 = 0;
     }
 }
 

--- a/src/dra/63ED4.c
+++ b/src/dra/63ED4.c
@@ -1615,7 +1615,7 @@ void func_80107250(Primitive* prim, s32 colorIntensity) {
 
 void func_801072BC(POLY_GT4* poly) { func_80107250(poly, 0); }
 
-void func_801072DC(POLY_GT4* poly) { func_80107250(poly, 0x80); }
+void func_801072DC(Primitive* prim) { func_80107250(prim, 0x80); }
 
 void func_801072FC(POLY_G4* poly) {
     setRGB0(poly, 0, 0, 0);

--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -465,7 +465,7 @@ extern s32 D_800B0918;
 extern s32 D_800B091C;
 extern s32 D_800B0920;
 
-void func_801072DC(POLY_GT4* poly);
+void func_801072DC(Primitive* prim);
 void InitializePads(void);
 void ReadPads(void);
 void ClearBackbuffer(void);

--- a/src/dra_psp/61F30.c
+++ b/src/dra_psp/61F30.c
@@ -13,6 +13,6 @@ INCLUDE_ASM("dra_psp/psp/dra_psp/61F30", func_80107250);
 
 INCLUDE_ASM("dra_psp/psp/dra_psp/61F30", func_psp_0913F8C8);
 
-INCLUDE_ASM("dra_psp/psp/dra_psp/61F30", func_psp_0913F8D0);
+INCLUDE_ASM("dra_psp/psp/dra_psp/61F30", func_801072DC);
 
 #include "../set_prim_rect.h"

--- a/src/dra_psp/67F0.c
+++ b/src/dra_psp/67F0.c
@@ -7,7 +7,120 @@ INCLUDE_ASM("dra_psp/psp/dra_psp/67F0", func_psp_090E3170);
 
 INCLUDE_ASM("dra_psp/psp/dra_psp/67F0", func_psp_090E31F8);
 
-INCLUDE_ASM("dra_psp/psp/dra_psp/67F0", DrawRichterHud);
+extern PlayerHud g_PlayerHud;
+extern s32 g_HealingMailTimer[1]; // maybe part of g_PlayerHud
+
+#ifdef VERSION_PSP
+#define RIC_HUD_NUM_SPRITES 10
+#else
+#define RIC_HUD_NUM_SPRITES 9
+#endif
+
+void DrawRichterHud(void) {
+    s32 i;
+    Primitive* prim;
+
+    D_801397FC = 0;
+    D_80139008 = 0;
+    g_PlayerHud.unk28 = 0;
+    D_8003C744 = 0;
+    g_PlayerHud.unk0C = 400;
+    g_PlayerHud.unk10 = 400;
+    g_PlayerHud.unk14 = 48;
+    g_PlayerHud.unk18 = 0;
+    g_PlayerHud.unk1C = g_PlayerHud.unk20 =
+        g_PlayerHud.unk0C * 100 / g_PlayerHud.unk10;
+    g_PlayerHud.unk24 = 0;
+    g_PlayerHud.primIndex1 = func_800EDD9C(PRIM_GT4, RIC_HUD_NUM_SPRITES);
+    prim = &g_PrimBuf[g_PlayerHud.primIndex1];
+
+    SetTexturedPrimRect(prim, 2, 22, 32, 96, 0, 0);
+    prim->tpage = 0x1B;
+    prim->clut = 0x101;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, g_PlayerHud.unk14 + 216, 22, 32, 96, 32, 0);
+    prim->tpage = 0x1B;
+    prim->clut = 0x100;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, 4, 112, 9, 3, 64, 89);
+    prim->tpage = 0x1B;
+    prim->clut = 0x105;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, g_PlayerHud.unk14 + 228, 112, 9, 3, 64, 89);
+    prim->tpage = 0x1B;
+    prim->clut = 0x103;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim->p1 = 0;
+    prim->p2 = 6;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, g_PlayerHud.unk14 + 236, 112, 9, 3, 64, 89);
+    prim->tpage = 0x1B;
+    prim->clut = 0x103;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, 14, 27, 8, 8, 0, 96);
+    prim->tpage = 0x1B;
+    prim->clut = 0x103;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, 22, 27, 8, 8, 0, 96);
+    prim->tpage = 0x1B;
+    prim->clut = 0x103;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    SetTexturedPrimRect(prim, 18, 38, 8, 8, 0, 0);
+    prim->tpage = 0x1B;
+    prim->clut = 0x102;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+
+    // Extra HUD sprite on PSP! Should identify what this is.
+#ifdef VERSION_PSP
+    SetTexturedPrimRect(prim, 18, 38, 8, 8, 0, 0);
+    prim->tpage = 0x1B;
+    prim->clut = 0x102;
+    prim->priority = 0x1F0;
+    prim->drawMode = DRAW_ABSPOS;
+    prim = prim->next;
+#endif
+
+    SetTexturedPrimRect(prim, 33, 20, 64, 24, 64, 40);
+    prim->tpage = 0x1B;
+    prim->clut = 0x103;
+    prim->priority = 0x1EF;
+    prim->drawMode = DRAW_ABSPOS;
+
+    g_PlayerHud.primIndex2 = func_800EDD9C(4, 16);
+    for (prim = &g_PrimBuf[g_PlayerHud.primIndex2], i = 0; prim != 0; i++,
+        prim = prim->next) {
+        SetTexturedPrimRect(prim, 216 + i * 2, 22, 2, 96, 32 + i * 2, 0);
+        func_801072DC(prim);
+        prim->tpage = 0x1B;
+        prim->clut = 0x100;
+        prim->priority = 0x1EE;
+        prim->drawMode = DRAW_HIDE;
+        prim->p1 = (rand() & 0x3F) + 1;
+        prim->p2 = 0;
+    }
+}
 
 extern s32 D_psp_091472F8[];
 extern s32 D_psp_09147418[];
@@ -187,9 +300,6 @@ u16 g_HudSpriteBlend[HUD_NUM_SPRITES] = {
     DRAW_HIDE, DRAW_HIDE, DRAW_HIDE, 0x2000, 0x2000, 0x2000, 0x2000,
     0x2000,    0x2000,    0x2000,    0x2000, 0x2000, 0x2000, 0x2000,
 };
-
-extern PlayerHud g_PlayerHud;
-extern s32 g_HealingMailTimer[1]; // maybe part of g_PlayerHud
 
 // Need these for now, they might be changed later.
 extern Primitive* func_psp_090E4CD0(Primitive*);


### PR DESCRIPTION
Yet another one in sequence. As usual, a bit of tweaking for the match, but looks nice on both systems.

Very curious what the PSP sprite is. Might need to fire up my PSP version and compare side by side. As far as I know there isn't a good debugging-friendly PSP emulator out there, because it would be nice to be able to view the VRAM to see what's in the tpage.