### PR TITLE
Fix dupes report

### DIFF
--- a/config/splat.hd.dra.yaml
+++ b/config/splat.hd.dra.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.hd.ric.yaml
+++ b/config/splat.hd.ric.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   symbol_name_format: hd_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.hd.stcen.yaml
+++ b/config/splat.hd.stcen.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   symbol_name_format: hd_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.hd.stwrp.yaml
+++ b/config/splat.hd.stwrp.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.hd.tt_000.yaml
+++ b/config/splat.hd.tt_000.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.pspeu.dra.yaml
+++ b/config/splat.pspeu.dra.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   symbol_name_format: psp_$VRAM
   nonmatchings_path: psp
+  disassemble_all: true
   section_order:
     - .text
     - .data

--- a/config/splat.pspeu.stlib.yaml
+++ b/config/splat.pspeu.stlib.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   symbol_name_format: psp_$VRAM
   nonmatchings_path: psp
+  disassemble_all: true
   section_order:
     - .text
     - .data

--- a/config/splat.pspeu.stst0.yaml
+++ b/config/splat.pspeu.stst0.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   symbol_name_format: pspeu_$VRAM
   nonmatchings_path: psp
+  disassemble_all: true
   section_order:
     - .text
     - .data

--- a/config/splat.pspeu.stwrp.yaml
+++ b/config/splat.pspeu.stwrp.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   symbol_name_format: psp_$VRAM
   nonmatchings_path: psp
+  disassemble_all: true
   section_order:
     - ".text"
     - ".data"

--- a/config/splat.pspeu.tt_000.yaml
+++ b/config/splat.pspeu.tt_000.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: no
   migrate_rodata_to_functions: yes
   asm_jtbl_label_macro: jlabel
+  disassemble_all: true
   section_order:
     - ".text"
     - ".data"

--- a/config/splat.us.bomar.yaml
+++ b/config/splat.us.bomar.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.borbo3.yaml
+++ b/config/splat.us.borbo3.yaml
@@ -20,6 +20,7 @@ options:
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.dra.yaml
+++ b/config/splat.us.dra.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.main.yaml
+++ b/config/splat.us.main.yaml
@@ -17,6 +17,7 @@ options:
   find_file_boundaries: yes
   use_legacy_include_asm: no
   asm_jtbl_label_macro: jlabel
+  disassemble_all: true
   section_order:
     - ".rodata"
     - ".text"

--- a/config/splat.us.ric.yaml
+++ b/config/splat.us.ric.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"
@@ -45,7 +46,7 @@ segments:
       - [0x18C40, .data, 24788]
       - [0x18ED4, .data, 24788] # RicEntityMaria
       - [0x18F7C, .data, 26C84]
-      - [0x1938C, .data, pl_anims]    
+      - [0x1938C, .data, pl_anims]
       - [0x199AC, .data, 2A060]
       - [0x19D94, .data, 2C4C4]
       - [0x19EE0, .data, 319C4]

--- a/config/splat.us.stcen.yaml
+++ b/config/splat.us.stcen.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stdre.yaml
+++ b/config/splat.us.stdre.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stlib.yaml
+++ b/config/splat.us.stlib.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.stmad.yaml
+++ b/config/splat.us.stmad.yaml
@@ -21,6 +21,7 @@ options:
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   string_encoding: SHIFT-JIS
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stno0.yaml
+++ b/config/splat.us.stno0.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.stno1.yaml
+++ b/config/splat.us.stno1.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.stno3.yaml
+++ b/config/splat.us.stno3.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stnp3.yaml
+++ b/config/splat.us.stnp3.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stnz0.yaml
+++ b/config/splat.us.stnz0.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.strwrp.yaml
+++ b/config/splat.us.strwrp.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stsel.yaml
+++ b/config/splat.us.stsel.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stst0.yaml
+++ b/config/splat.us.stst0.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.stwrp.yaml
+++ b/config/splat.us.stwrp.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.tt_000.yaml
+++ b/config/splat.us.tt_000.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: no
   migrate_rodata_to_functions: no
   asm_jtbl_label_macro: jlabel
+  disassemble_all: true
   section_order:
     - ".data"
     - ".rodata"

--- a/config/splat.us.tt_001.yaml
+++ b/config/splat.us.tt_001.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.tt_002.yaml
+++ b/config/splat.us.tt_002.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.tt_003.yaml
+++ b/config/splat.us.tt_003.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/config/splat.us.tt_004.yaml
+++ b/config/splat.us.tt_004.yaml
@@ -19,6 +19,7 @@ options:
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
   symbol_name_format: us_$VRAM
+  disassemble_all: true
   section_order:
     - .data
     - .rodata

--- a/tools/make-config.py
+++ b/tools/make-config.py
@@ -436,7 +436,7 @@ def get_splat_config(
             "ld_bss_is_noload": bss_is_no_load,
             "disasm_unknown": True,
             "include_macro_inc": False,
-            "disassemble_all": True
+            "disassemble_all": True,
         }
     }
 

--- a/tools/make-config.py
+++ b/tools/make-config.py
@@ -436,6 +436,7 @@ def get_splat_config(
             "ld_bss_is_noload": bss_is_no_load,
             "disasm_unknown": True,
             "include_macro_inc": False,
+            "disassemble_all": True
         }
     }
 
@@ -642,7 +643,10 @@ def find_dups(threshold, dir1, dir2) -> dict[str, str]:
 
 
 def split(splat_config_path: str, disassemble_all: bool):
-    if disassemble_all:
+    with open(splat_config_path) as f:
+        c = yaml.load(f, Loader=yaml.SafeLoader)
+        config_disasm_all = c["options"]["disassemble_all"]
+    if disassemble_all and not config_disasm_all == True:
         return exec("splat", "split", splat_config_path, "--disassemble-all")
     else:
         return exec("splat", "split", splat_config_path)


### PR DESCRIPTION
I think I found the reason why @Xeeynamo had to remove `disassemble_all` from the yaml configs to get the `make_config` tools test passing

I think there is a bug with `splat` where it's supposed to prioritise the command line argument over the yaml value but it's not working right now, as if you pass it in via argument it treats the yaml value as an unread option and fails a validation check since the option never gets parsed
https://github.com/ethteck/splat/blob/main/src/splat/util/options.py#L558-L560