### PR TITLE
Dedupe `lib` `e_stage_name`

### DIFF
--- a/config/symbols.us.stlib.txt
+++ b/config/symbols.us.stlib.txt
@@ -3,6 +3,7 @@ LIB_pStObjLayoutVertical = 0x801805F4;
 LIB_EntityUpdates = 0x801806C8;
 g_EInitObtainable = 0x8018080C;
 g_EInitParticle = 0x80180818;
+g_EInitInteractable = 0x80180830;
 g_EInitUnkId13 = 0x8018083C;
 g_EInitCommon = 0x80180854;
 g_EInitDamageNum = 0x80180860;

--- a/src/st/lib/e_stage_name.c
+++ b/src/st/lib/e_stage_name.c
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "common.h"
+#include "lib.h"
 
-INCLUDE_ASM("st/lib/nonmatchings/e_stage_name", StageNamePopupHelper);
-
-INCLUDE_ASM("st/lib/nonmatchings/e_stage_name", EntityStageNamePopup);
+#include "../e_stage_name.h"

--- a/src/st/lib/lib.h
+++ b/src/st/lib/lib.h
@@ -3,6 +3,7 @@
 
 #define STAGE_IS_LIB
 #define OVL_EXPORT(x) LIB_##x
+#define CASTLE_FLAG_BANK 0x6F
 
 typedef enum EntityIDs {
     // /* 0x00 */ E_NONE,


### PR DESCRIPTION
PSP is completely different for these funcs so just going to do PSX for now and work on PSP separately.
Once I've worked that out on PSP I'm hopeful I can port similar changes into `wrp` `e_stage_name` for PSP too which is missing a match currently.