### PR TITLE
Updated "Build saturn binaries" to use VERSION env

### DIFF
--- a/.github/workflows/saturn-build.yml
+++ b/.github/workflows/saturn-build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Extract asm
         run: VERSION=saturn make extract
       - name: Build saturn binaries
-        run: make build_saturn
+        run: VERSION=saturn make build
       - name: Check saturn
         run: VERSION=saturn make check
 


### PR DESCRIPTION
#2188 will fail until this is merged.