### PR TITLE
Use pad2_anim_debug in `func_us_801BDAE4`

### DIFF
--- a/src/st/lib/e_candle_table.c
+++ b/src/st/lib/e_candle_table.c
@@ -12,10 +12,7 @@ static u16 D_us_80181A68[] = {
 static u16 D_us_80181A78[] = {0x0903, 0x0A03, 0x0B03, 0x0C03, 0x0D03, 0x0E03,
                               0xF03,  0x1003, 0x0000, 0x0000, 0x0000, 0x0000};
 extern u32 D_psp_092A5590;
-extern s32 D_8B42050;
-// I expect this symbol will change depending on the function that is including
-// pad2_anim_debug.h
-#define BUTTON_SYMBOL D_8B42050
+extern s32 D_psp_08B42050;
 #else
 static u16 D_us_80181A78[] = {0x0903, 0x0A03, 0x0B03, 0x0C03, 0x0D03, 0x0E03,
                               0xF03,  0x1003, 0x0000, 0x0000, 0x0003, 0x0000};
@@ -88,6 +85,9 @@ void EntityCandleTable(Entity* self) {
     case 4:
         break;
     case 255:
+#ifdef VERSION_PSP
+#define DEBUG_REWIND_BUTTON D_psp_08B42050
+#endif
 #include "../pad2_anim_debug.h"
     }
 }

--- a/src/st/lib/e_candle_table.c
+++ b/src/st/lib/e_candle_table.c
@@ -10,13 +10,14 @@ static u16 D_us_80181A68[] = {
 
 #ifdef VERSION_PSP
 static u16 D_us_80181A78[] = {0x0903, 0x0A03, 0x0B03, 0x0C03, 0x0D03, 0x0E03,
-                              0xF03,  0x1003, 0x0000, 0x0000, 0x0000, 0x0000};
-extern u32 D_psp_092A5590;
-extern s32 D_psp_08B42050;
+                              0x0F03, 0x1003, 0x0000, 0x0000, 0x0000, 0x0000};
 #else
 static u16 D_us_80181A78[] = {0x0903, 0x0A03, 0x0B03, 0x0C03, 0x0D03, 0x0E03,
-                              0xF03,  0x1003, 0x0000, 0x0000, 0x0003, 0x0000};
+                              0x0F03, 0x1003, 0x0000, 0x0000, 0x0003, 0x0000};
 #endif
+
+extern u32 D_psp_092A5590;
+extern s32 D_psp_08B42050;
 
 void EntityCandleTable(Entity* self) {
     Entity* newEntity;

--- a/src/st/lib/unk_3C57C.c
+++ b/src/st/lib/unk_3C57C.c
@@ -565,29 +565,10 @@ void func_us_801BDAE4(Entity* self) {
         break;
 
     case 32:
-        FntPrint("charal %x\n", self->animCurFrame);
-        if (g_pads[1].pressed & PAD_SQUARE) {
-            if (self->params) {
-                break;
-            }
-            self->animCurFrame++;
-            self->params |= 1;
-        } else {
-            self->params = 0;
-        }
 #ifdef VERSION_PSP
-        if (g_pads[1].pressed & D_psp_08B42050) {
-#else
-        if (g_pads[1].pressed & PAD_CIRCLE) {
+#define DEBUG_REWIND_BUTTON D_psp_08B42050
 #endif
-            if (!self->step_s) {
-                self->animCurFrame--;
-                self->step_s |= 1;
-            }
-        } else {
-            self->step_s = 0;
-        }
-        break;
+#include "../pad2_anim_debug.h"
     }
     xOffset = self->posX.i.hi + g_Tilemap.scrollX.i.hi;
     yOffset = self->posY.i.hi + g_Tilemap.scrollY.i.hi;

--- a/src/st/pad2_anim_debug.h
+++ b/src/st/pad2_anim_debug.h
@@ -20,10 +20,8 @@ if (g_pads[1].pressed & PAD_SQUARE) {
 } else {
     self->params = 0;
 }
-#ifdef VERSION_PSP
-// I expect this symbol will change depending on the function that is including
-// pad2_anim_debug.h
-if (g_pads[1].pressed & BUTTON_SYMBOL) {
+#ifdef DEBUG_REWIND_BUTTON
+if (g_pads[1].pressed & DEBUG_REWIND_BUTTON) {
 #else
 if (g_pads[1].pressed & PAD_CIRCLE) {
 #endif


### PR DESCRIPTION
`func_us_801BDAE4` uses a custom rewind button so I had originally not used `#include "../pad2_anim_debug.h"`. Now that the include supports a custom rewind button I use that + refactor the code a bit. Now the debug code will use `DEBUG_REWIND_BUTTON` if it is defined, rather than if the platform is PSP