### PR TITLE
Speed Up `dups` & Fix Grouping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ endif
 # Force to extract all the assembly code regardless if a function is already decompiled
 force_extract:
 	mv src src_tmp
-	rm $(BUILD_DIR)/*.ld
+	find $(BUILD_DIR) -type f -name "*.ld" -delete
 	make extract -j
 	rm -rf src/
 	mv src_tmp src
@@ -465,6 +465,8 @@ force_symbols: ##@ Extract a full list of symbols from a successful build
 	$(PYTHON) ./tools/symbols.py elf build/us/stchi.elf > config/symbols.us.stchi.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stdre.elf > config/symbols.us.stdre.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stlib.elf > config/symbols.us.stlib.txt
+	# note the lack of `version` for mad
+	$(PYTHON) ./tools/symbols.py elf build/us/stmad.elf > config/symbols.stmad.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stno0.elf > config/symbols.us.stno0.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stno1.elf > config/symbols.us.stno1.txt
 	$(PYTHON) ./tools/symbols.py elf build/us/stno3.elf > config/symbols.us.stno3.txt


### PR DESCRIPTION
Peeling the speedup and grouping bug fix off from the other changes in the `speedy-dups` PR (#2205).

Looking at the difference of size of two functions is a constant time approximation to the Levenshtein distance. Checking this prior to calculating the true edit distance provides a significant speedup without any modification to behavior.

This also fixes an issue where a "similarity" calculation (one minus the ratio of edits to size) was being returned but treated as a "distance" in some calculations. This meant that functions where grouped with the least similar function which was above the threshold instead of the most similar. This affects a few groups, like `*_EntityCutscene` where the two groups now contain functions that match more closely than before.

Some make recipes are also fixed: Finally, `MAD` symbols are extracted and `force_extract` will no longer fail if there are no linker scripts in the build directory.

Without the approximation shortcut:

```
$> time target/release/dups --threshold 0.9 --output-file ../../gh-duplicates/duplicates-current.txt
⋮
real    3m27.978s
user    3m26.470s
sys     0m1.493s
```

With the approximation shortcut:
```
$> time target/release/dups --threshold 0.9 --output-file ../../gh-duplicates/duplicates-new.txt
⋮
real    0m10.266s
user    0m9.739s
sys     0m0.526s
```
