### PR TITLE
Fix MAD funcs not appearing in function report

### DIFF
--- a/config/splat.us.stmad.yaml
+++ b/config/splat.us.stmad.yaml
@@ -17,7 +17,7 @@ options:
   undefined_syms_auto_path:  config/undefined_syms_auto.stmad.txt
   find_file_boundaries: yes
   use_legacy_include_asm: no
-  migrate_rodata_to_functions: no
+  migrate_rodata_to_functions: yes
   asm_jtbl_label_macro: jlabel
   extensions_path: tools/splat_ext
   string_encoding: SHIFT-JIS
@@ -76,12 +76,12 @@ segments:
       - [0x1774, data]
       - [0x19A4, data]
       - [0x1D14, data]
-      - [0xD794, rodata]
+      - [0xD794, .rodata, D8C8]
       - [0xD7CC, .rodata, e_red_door] # EntityRedDoor
       - [0xD83C, .rodata, e_collect]
       - [0xD85C, .rodata, e_collect] # EntityEquipItemDrop
       - [0xD874, .rodata, e_misc]
-      - [0xD8AC, rodata]
+      - [0xD8AC, .rodata, 17B94]
       - [0xD8C0, .rodata, prim_helpers]
       - [0xD8C8, c]
       - [0xE5AC, c, st_debug]

--- a/tools/symbols.py
+++ b/tools/symbols.py
@@ -434,7 +434,11 @@ def print_elf_symbols(file, elf_file_name, no_default):
     symbols = get_elf_symbols(elf_file_name)
     sorted_symbols = sorted(symbols.items(), key=lambda item: item[1])
     for name, offset in sorted_symbols:
-        if no_default and (name.startswith("func_") or name.startswith("D_")):
+        if (
+            no_default
+            and (name.startswith("func_") or name.startswith("D_"))
+            or name.startswith(".L")
+        ):
             continue
         print(f"{name} = 0x{offset:08X}; // allow_duplicated:True", file=file)
 

--- a/tools/symbols.py
+++ b/tools/symbols.py
@@ -434,11 +434,7 @@ def print_elf_symbols(file, elf_file_name, no_default):
     symbols = get_elf_symbols(elf_file_name)
     sorted_symbols = sorted(symbols.items(), key=lambda item: item[1])
     for name, offset in sorted_symbols:
-        if (
-            no_default
-            and (name.startswith("func_") or name.startswith("D_"))
-            or name.startswith(".L")
-        ):
+        if no_default and (name.startswith("func_") or name.startswith("D_")):
             continue
         print(f"{name} = 0x{offset:08X}; // allow_duplicated:True", file=file)
 


### PR DESCRIPTION
EDIT: Approach updated, below is no longer applicable. See comments for more details.

This restores two MAD functions to the function report which went missing

Output from local:
https://gist.github.com/JoshSchreuder/c146abedc057b18d588b44446b00b596

```
| mad    | func_8018D8C8                     |      250 |         45 |        |                                                                                                    |       |     |
| mad    | func_80197B94                     |      491 |         44 | Yes    |                                                                                                    |       |     |
```

This was because since #2248 added MAD to the force_symbols extract, it was mapping 5 labels in these functions as symbols which was [causing invalid splat disasm after extracting with these symbols](https://gist.github.com/JoshSchreuder/adb4dc20da482d23838fb50b56580a17)
```
.L80197ED4 = 0x80197ED4; // allow_duplicated:True
.L80197F8C = 0x80197F8C; // allow_duplicated:True
.L8019803C = 0x8019803C; // allow_duplicated:True
.L801980DC = 0x801980DC; // allow_duplicated:True
.L80198198 = 0x80198198; // allow_duplicated:True
```

I have added a simple exclude for .L. This does not appear to have any impact on any other overlays or functions. I am not clear why these .L symbols were being added to the MAD elf in the first place, so if anyone has a better solution please let me know.