### PR TITLE
Decompile `lib` e_shop helpers

### DIFF
--- a/src/st/lib/unk_2FA80.c
+++ b/src/st/lib/unk_2FA80.c
@@ -894,7 +894,109 @@ loop:
     }
 }
 
-INCLUDE_ASM("st/lib/nonmatchings/unk_2FA80", func_us_801B1064);
+Primitive* func_us_801B1064(
+    Primitive* prim, s16 x, s16 y, const u8* str, u16 clut) {
+    u8 buffer[64];
+    u16 length;
+    s32 i;
+    u8 ch;
+    u8* chPtr;
+
+    chPtr = buffer;
+    length = 0;
+    for (i = 0; i < 64; i++) {
+        *chPtr++ = 0;
+    }
+    chPtr = buffer;
+    while (true) {
+        ch = *str++;
+        if (ch == 0xFF) {
+            ch = *str++;
+            if (ch == 0) {
+                break;
+            }
+        }
+        *chPtr++ = ch;
+        length++;
+#ifdef VERSION_PSP
+        ch = *str;
+        if (ch == 0xFF) {
+            str++;
+            ch = *str++;
+            if (ch == 0) {
+                break;
+            }
+            if (ch != 0xFF) {
+                *chPtr = ch;
+            } else {
+                str -= 2;
+            }
+        }
+        chPtr++;
+#endif
+    }
+    chPtr = buffer;
+    if (!length) {
+        return prim;
+    }
+    do {
+        ch = *chPtr++;
+#ifdef VERSION_PSP
+        if (ch) {
+            prim->clut = clut;
+            prim->u0 = (s8)((ch & 0xF) * 8);
+            prim->v0 = (s8)((ch & 0xF0) >> 1);
+            prim->drawMode = DRAW_DEFAULT;
+            prim->x0 = x;
+            prim->y0 = y;
+            prim = prim->next;
+        }
+        ch = *chPtr++;
+        if (ch) {
+            prim->clut = clut;
+            prim->u0 = (s8)((ch & 0xF) * 8);
+            prim->v0 = (s8)((ch & 0xF0) >> 1);
+            prim->drawMode = DRAW_DEFAULT;
+            prim->x0 = x;
+            prim->y0 = y - 8;
+            prim = prim->next;
+        }
+        if (ch >= 0xF0 && ch <= 0xFC) {
+            x += 12;
+        } else {
+            x += 8;
+        }
+#else
+        if (ch) {
+            prim->clut = clut;
+            prim->u0 = (s8)((ch & 0xF) * 8);
+            prim->v0 = (s8)((ch & 0xF0) >> 1);
+            prim->drawMode = DRAW_DEFAULT;
+            if (ch == CH('i') || ch == CH('l') || ch == CH('f') ||
+                ch == CH('I')) {
+                x--;
+            } else if (ch == CH('\'')) {
+                x -= 2;
+            }
+            prim->x0 = x;
+            prim->y0 = y;
+            prim = prim->next;
+            if (ch == CH('i') || ch == CH('l')) {
+                x += 7;
+            } else if (ch == CH('\'')) {
+                x += 6;
+            } else {
+                x += 8;
+            }
+        } else {
+            x += 4;
+        }
+#endif
+
+    } while (--length);
+
+    return prim;
+}
 
 void func_us_801B11A0(s16 x, s16 y, u16 w, u16 h) {
     RECT rect;

--- a/src/st/lib/unk_33EC8.c
+++ b/src/st/lib/unk_33EC8.c
@@ -37,34 +37,35 @@ Primitive* func_us_801B3EC8(Primitive* prim, u32 number, u16 maxDigits) {
     return prim;
 }
 
-Primitive* func_us_801B3FB4(Primitive* prim, u8* uv, u16 count, s32 arg3) {
-    u8 d;
+Primitive* func_us_801B3FB4(
+    Primitive* prim, const char* str, u16 length, s32 arg3) {
+    u8 ch;
     s32 i;
     u32 max;
-    u8* ptr;
+    u8* chPtr;
 
-    ptr = uv;
+    chPtr = str;
     max = 0;
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < length; i++) {
 #ifdef VERSION_PSP
-        if (*ptr == 0xFF) {
+        if (*chPtr == 0xFF) {
             break;
         }
-        ptr++;
+        chPtr++;
         max++;
     }
     for (i = 0; i < max; i++) {
 #endif
-        d = *uv++;
-        prim->u0 = (d & 0xF) * 8;
-        prim->v0 = (d & 0xF0) >> 1;
+        ch = *str++;
+        prim->u0 = (ch & 0xF) * 8;
+        prim->v0 = (ch & 0xF0) >> 1;
         if (arg3 != 0) {
             prim->drawMode = DRAW_DEFAULT;
         }
         prim = prim->next;
     }
 #ifdef VERSION_PSP
-    for (; i < count; i++) {
+    for (; i < length; i++) {
         prim->drawMode = DRAW_HIDE;
         prim = prim->next;
     }

--- a/src/st/lib/unk_3420C.c
+++ b/src/st/lib/unk_3420C.c
@@ -3,7 +3,7 @@
 
 void func_us_801B0FBC(u8* ptr, u16 x, u16 y);
 Primitive* func_us_801B1064(
-    Primitive* arg0, u16 arg1, s16 arg2, const char* arg3, u16 arg4);
+    Primitive* prim, s16 x, s16 y, const u8* str, u16 clut);
 void func_us_801B245C(Primitive* arg0, u16 arg1, u16 arg2, u16 arg3, u16 arg4,
                       s32 arg5, s32 arg6);
 Primitive* func_us_801B3EC8(Primitive* prim, u32 number, u16 maxDigits);

--- a/src/st/lib/unk_36F30.c
+++ b/src/st/lib/unk_36F30.c
@@ -1098,7 +1098,27 @@ void func_us_801B8234(Entity* self) {
     }
 }
 
-INCLUDE_ASM("st/lib/nonmatchings/unk_36F30", func_us_801B8958);
+#ifdef VERSION_PSP
+extern const char** D_us_801818F4;
+#else
+extern const char* D_us_801818F4[];
+#endif
+
+void func_us_801B8958(Primitive* prim, Entity* self) {
+    s16 var_s2;
+    s32 i, j;
+
+    var_s2 = 16;
+    j = self->ext.et_801B6F30.unk82;
+    for (i = 0; i < 7; i++, j++) {
+        prim = func_us_801B1064(prim, 16, var_s2, D_us_801818F4[j], 0x196);
+        var_s2 += 12;
+    }
+    while (prim != NULL) {
+        prim->drawMode = DRAW_HIDE;
+        prim = prim->next;
+    }
+}
 
 const char D_us_801AD4CC[] = _S("I am the wind");
 const char D_us_801AD4DC[] = _S("Metamorphosis 3");


### PR DESCRIPTION
I'm currently working on `func_us_801B7DF8`, but I needed to decompile these to make some progress. 

`func_us_801B1064`:
PSX: https://decomp.me/scratch/lSaMi
PSP: https://decomp.me/scratch/UVAF8

`func_us_801B8958`:
PSX: https://decomp.me/scratch/XaP6G
PSP: https://decomp.me/scratch/3EQre