### PR TITLE
Created a loader for decomp-permuter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ sotn_calltree.txt
 function_calls
 
 gmon.out
+
+nonmatchings/
+tools/sotn_permuter/permute.me/

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 [submodule "tools/mwccgap"]
 	path = tools/mwccgap
 	url = https://github.com/mkst/mwccgap.git
+[submodule "tools/decomp-permuter"]
+	path = tools/decomp-permuter
+	url = https://github.com/simonlindholm/decomp-permuter
+	update = none

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,9 @@ format-tools:
 	black tools/*.py
 	black tools/splat_ext/*.py
 	black tools/split_jpt_yaml/*.py
+	black tools/sotn_str/*.py
+	black tools/sotn_permuter/sotn_permuter.py
+	black tools/split_jpt_yaml/*.py
 format-symbols:
 	VERSION=us $(PYTHON) ./tools/symbols.py sort
 	VERSION=hd $(PYTHON) ./tools/symbols.py sort

--- a/tools/permuter_settings.toml
+++ b/tools/permuter_settings.toml
@@ -1,3 +1,0 @@
-compiler_type = "gcc"
-[decompme.compilers]
-"mipsel-linux-gnu-cpp" = "psyq4.0"

--- a/tools/sotn_permuter/README.md
+++ b/tools/sotn_permuter/README.md
@@ -1,0 +1,85 @@
+# I'm not fluent in markdown, so I'm not going to mess with it.  If anybody wants to improve this readme, please do.
+sotn_permuter.py is just a loader for decomp-permuter to address the hurdles that decomp-permuter presents for standardized use within sotn-decomp.
+
+It passes any arguments except --version and import|permute directly to import.py and permuter.py as appropriate.
+
+default usage:
+tools/sotn_permuter/sotn_permuter.py import {path_to_c_file} {path_to_s_file}
+tools/sotn_permuter/sotn_permuter.py permute tools/sotn_permuter/permute.me/{func_name}
+
+sotn_permuter.py arguments
+usage: sotn_permuter.py [-h] [--version VERSION] {import,permute} [import.py or permuter.py args as appropriate]
+
+Use decomp-permuter with sotn specific adjustments
+
+positional arguments:
+  {import,permute}   Whether to import or permute the function
+
+options:
+  -h, --help         show this help message and exit
+  --version VERSION  Sets game version and overrides VERSION environment variable
+
+
+import.py arguments
+usage: import.py [-h] [--keep] [--preserve-macros REGEX] [--no-prune] [--decompme] [--settings SETTINGS_FILE] c_file {asm_file|func_name} [make_flags ...]
+
+Import a function for use with the permuter. Will create a new directory nonmatchings/<funcname>-<id>/.
+
+positional arguments:
+  c_file                File containing the function. Assumes that the file can be built with 'make' to create an .o file.
+  {asm_file|func_name}  File containing assembly for the function. Must start with 'glabel <function_name>' and contain no other functions. Alternatively, a function name can be given, which will be looked for in all GLOBAL_ASM blocks in the C
+                        file.
+  make_flags            Arguments to pass to 'make'. PERMUTER=1 will always be passed.
+
+options:
+  -h, --help            show this help message and exit
+  --keep                Keep the directory on error.
+  --preserve-macros REGEX
+                        Regex for which macros to preserve, or empty string for no macros. By default, this is read from permuter_settings.toml, tools/permuter_settings.toml or config/permuter_settings.toml in a parent directory of the imported
+                        file. Type information is also read from this file.
+  --no-prune            Don't minimize the source to keep only the imported function and functions/struct/variables that it uses. Normally this behavior is useful to make the permuter faster, but in cases where unrelated code affects the generated
+                        assembly asm it can be necessary to turn off. Note that regardless of this setting the permuter always removes all other functions by replacing them with declarations.
+  --decompme            Upload the function to decomp.me to share with other people, instead of importing.
+  --settings SETTINGS_FILE
+                        Path to settings file.
+
+    
+permuter arguments
+usage: permuter.py [-h] [--help=randomization-passes] [--show-errors] [--show-timings] [--print-diffs] [--abort-exceptions] [--better-only] [--best-only] [--stop-on-zero] [--quiet] [--stack-diffs] [--algorithm {difflib,levenshtein}] [--keep-prob PROB] [-j THREADS] [-J] [--pah-debug] [--priority PRIORITY] [--no-context-output] [--only-if-below SCORE_THRESHOLD] [--debug] [--speed [1-100]] directory [directory ...]
+
+Randomly permute C files to better match a target binary.
+
+positional arguments:
+    directory       Directory containing base.c, target.o and compile.sh. Multiple directories may be given.
+
+options:
+  -h, --help            show this help message and exit
+  --help=randomization-passes
+                        Show documentation for all the available randomization passes.
+  --show-errors         Display compiler error/warning messages, and keep .c files for failed compiles.
+  --show-timings        Display the time taken by permuting vs. compiling vs. scoring.
+  --print-diffs         Instead of compiling generated sources, display diffs against a base version.
+  --abort-exceptions    Stop execution when an internal permuter exception occurs.
+  --better-only         Only report scores better than the base.
+  --best-only           Only report ties or new high scores.
+  --stop-on-zero        Stop after producing an output with score 0.
+  --quiet               Don't print a status line with the number of iterations.
+  --stack-diffs         Take stack differences into account when computing the score.
+  --algorithm           Diff algorithm to use, difflib or levenshtein.
+  --keep-prob           Continue randomizing the previous output with the given probability, 0.0 to 1.0.
+  -j                    Number of own threads to use (default: 1 without -J, 0 with -J).
+  -J                    Harness extra compute power through cyberspace (permuter@home).
+  --pah-debug           Enable debug prints for permuter@home
+  --priority            Proportion of server resources to use when multiple people
+                        are using -J at the same time.
+                        Defaults to 1.0, meaning resources are split equally, but can be
+                        set to any value within [{MIN_PRIO}, {MAX_PRIO}].
+                        Each server runs with a priority threshold, which defaults to 0.1,
+                        below which they will not run permuter jobs at all.
+  --no-context-output"  Removes all text above the target function in the output source files.
+  --only-if-below       Only report scores better (lower) than this value.
+  --debug               Debug mode, only compiles and scores the base for debugging issues.
+  --speed               Speed% to run at to reduce resources. Default 100
+
+undocumented options:
+  --seed                Forces a seed value for permuter.

--- a/tools/sotn_permuter/decomp_permuter
+++ b/tools/sotn_permuter/decomp_permuter
@@ -1,0 +1,1 @@
+../decomp-permuter

--- a/tools/sotn_permuter/default_weights.toml
+++ b/tools/sotn_permuter/default_weights.toml
@@ -1,0 +1,1 @@
+../decomp-permuter/default_weights.toml

--- a/tools/sotn_permuter/importer.py
+++ b/tools/sotn_permuter/importer.py
@@ -1,0 +1,1 @@
+../decomp-permuter/import.py

--- a/tools/sotn_permuter/permuter_settings.pspeu.toml
+++ b/tools/sotn_permuter/permuter_settings.pspeu.toml
@@ -1,0 +1,8 @@
+compiler_type = "gcc"
+compiler_command_old = "bin/wibo bin/mwccpsp.exe -gccinc -Iinclude -D_internal_version_pspeu -Op -c -lang c -sdatathreshold 0 -char unsigned"
+compiler_command = "python3 tools/mwccgap/mwccgap.py $INPUT $OUTPUT --mwcc-path bin/mwccpsp.exe --use-wibo --wibo-path bin/wibo --as-path bin/allegrex-as --asm-dir-prefix asm/pspeu --macro-inc-path include/macro.inc -gccinc -Iinclude -D_internal_version_pspeu -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck -Op"
+assembler_command = "bin/allegrex-as -EL -I include/ -G0 -march=allegrex -mabi=eabi"
+asm_prelude_file = "tools/sotn_permuter/prelude.inc"
+
+[decompme.compilers]
+"mipsel-linux-gnu-cpp" = "psyq4.0"

--- a/tools/sotn_permuter/permuter_settings.us.toml
+++ b/tools/sotn_permuter/permuter_settings.us.toml
@@ -1,0 +1,7 @@
+compiler_type = "gcc"
+compiler_command = "mipsel-linux-gnu-cpp -Iinclude -Iinclude/psxsdk -undef -Wall -fno-builtin -Dmips -D__GNUC__=2 -D__OPTIMIZE__ -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D_LANGUAGE_C -DLANGUAGE_C -DNO_LOGS -DHACKS -DUSE_INCLUDE_ASM -D_internal_version_us -DSOTN_STR -lang-c | python3 tools/sotn_str/sotn_str.py process | iconv --from-code=UTF-8 --to-code=Shift-JIS | ./bin/cc1-psx-26 -G0 -w -O2 -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -msoft-float -g -quiet -mcpu=3000 -fgnu-linker -mgas -gcoff | python3 tools/maspsx/maspsx.py --expand-div --aspsx-version=2.34 | mipsel-linux-gnu-as -Iinclude -march=r3000 -mtune=r3000 -no-pad-sections -O1 -G0"
+assembler_command = "mipsel-linux-gnu-as -Iinclude -march=r3000 -mtune=r3000 -no-pad-sections -O1 -G0"
+asm_prelude_file = "tools/sotn_permuter/prelude.inc"
+
+[decompme.compilers]
+"mipsel-linux-gnu-cpp" = "psyq4.0"

--- a/tools/sotn_permuter/prelude.inc
+++ b/tools/sotn_permuter/prelude.inc
@@ -1,0 +1,55 @@
+.set noat
+.set noreorder
+#.set gp=64
+.macro glabel label
+    .global \label
+    .type \label, @function
+    \label:
+.endm
+
+.macro dlabel label
+    .global \label
+    \label:
+.endm
+
+.macro jlabel label
+    \label:
+.endm
+
+.macro endlabel label
+.endm
+
+# Float register aliases (o32 ABI)
+
+.set $fv0,          $f0
+.set $fv0f,         $f1
+.set $fv1,          $f2
+.set $fv1f,         $f3
+.set $ft0,          $f4
+.set $ft0f,         $f5
+.set $ft1,          $f6
+.set $ft1f,         $f7
+.set $ft2,          $f8
+.set $ft2f,         $f9
+.set $ft3,          $f10
+.set $ft3f,         $f11
+.set $fa0,          $f12
+.set $fa0f,         $f13
+.set $fa1,          $f14
+.set $fa1f,         $f15
+.set $ft4,          $f16
+.set $ft4f,         $f17
+.set $ft5,          $f18
+.set $ft5f,         $f19
+.set $fs0,          $f20
+.set $fs0f,         $f21
+.set $fs1,          $f22
+.set $fs1f,         $f23
+.set $fs2,          $f24
+.set $fs2f,         $f25
+.set $fs3,          $f26
+.set $fs3f,         $f27
+.set $fs4,          $f28
+.set $fs4f,         $f29
+.set $fs5,          $f30
+.set $fs5f,         $f31

--- a/tools/sotn_permuter/sotn_permuter.py
+++ b/tools/sotn_permuter/sotn_permuter.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+import multiprocessing
+import decomp_permuter.src.objdump
+import decomp_permuter.src.main as permuter
+import importer
+
+
+# These functions exist solely to overwrite some of the undesirable hardcoded behavior in decomp-permuter import.py
+# They intentionally retain as much of the original code and naming as possible to avoid unexpected incompatibility
+def sotn_create_directory(func_name: str) -> str:
+    os.makedirs(f"tools/sotn_permuter/permute.me/", exist_ok=True)
+    ctr = 0
+    while True:
+        ctr += 1
+        dirname = f"{func_name}-{ctr}" if ctr > 1 else func_name
+        dirname = f"tools/sotn_permuter/permute.me/{dirname}"
+        try:
+            os.mkdir(dirname)
+            return dirname
+        except FileExistsError:
+            pass
+
+
+def sotn_finalize_compile_command(cmdline: importer.List[str]) -> str:
+    quoted = [
+        (
+            arg
+            if arg == "|" or arg == "$INPUT" or arg == "$OUTPUT"
+            else importer.shlex.quote(arg)
+        )
+        for arg in cmdline
+    ]
+    ind = (quoted + ["|"]).index("|")
+    ret_list = quoted[:ind]
+    ret_list.extend(['"$INPUT"'] if "$INPUT" not in quoted else [])
+    ret_list.extend(quoted[ind:])
+    ret_list.extend(["-o", '"$OUTPUT"'] if "$OUTPUT" not in quoted else [])
+    return " ".join(ret_list)
+
+
+if __name__ == "__main__":
+    actions = ["import", "permute"]
+    parser = argparse.ArgumentParser(
+        description="Use decomp-permuter with sotn specific adjustments"
+    )
+    # sotn-decomp specific args
+    parser.add_argument(
+        "--version",
+        required=False,
+        type=str,
+        default=os.getenv("VERSION") or "us",
+        help="Sets game version and overrides VERSION environment variable",
+    )
+    parser.add_argument(
+        "action",
+        choices=actions,
+        type=str,
+        help="Whether to import or permute the function",
+    )
+
+    # This will keep the loader from choking on args intended for decomp-permuter
+    args, unknown = parser.parse_known_args()
+    # Removes args intended only for the loader
+    sys.argv = [a for a in sys.argv if not a.startswith("--v") and a not in actions]
+
+    # Function overwrites
+    importer.create_directory = sotn_create_directory
+    importer.finalize_compile_command = sotn_finalize_compile_command
+
+    if args.version == "us":
+        if args.action == "import":
+            importer.DEFAULT_AS_CMDLINE = [
+                "mipsel-linux-gnu-as",
+                "-march=r3000",
+                "-mabi=32",
+            ]
+            settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
+            defaultArgs = (
+                [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
+                if not any(i.startswith("--settings") for i in sys.argv)
+                else []
+            )
+        elif args.action == "permute":
+            decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
+                "mipsel-linux-gnu-objdump"
+            ]
+            decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
+                "-drz",
+                "-m",
+                "mips:3000",
+            ]
+            defaultArgs = ["--no-context-output", "--best-only", "-j"]
+    elif args.version == "pspeu":
+        if args.action == "import":
+            importer.DEFAULT_AS_CMDLINE = [
+                "bin/allegrex-as",
+                "-march=allegrex",
+                "-mabi=eabi",
+                "-EL",
+                "-G0",
+                "-I",
+                "include/",
+            ]
+            settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
+            defaultArgs = (
+                [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
+                if not any(i.startswith("--settings") for i in sys.argv)
+                else []
+            )
+        elif args.action == "permute":
+            decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
+                "bin/allegrex-objdump"
+            ]
+            decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
+                "-drz",
+                "-m",
+                "mips:allegrex",
+            ]
+            defaultArgs = ["--no-context-output", "--best-only", "-j"]
+    else:
+        print(f"{args.version} is currently unsupported.")
+        exit()
+
+    if args.action == "import":
+        print(f"Importing ${args.version} function.")
+        args = [a for a in defaultArgs]
+        sys.argv.extend(args)
+        importer.main(sys.argv[1:])
+    elif args.action == "permute":
+        print(f"Permuting ${args.version} function.")
+        args = [a for a in defaultArgs if not any(i.startswith(a) for i in sys.argv)]
+        args = [a + f"{multiprocessing.cpu_count()}" if a == "-j" else a for a in args]
+        sys.argv.extend(args)
+        permuter.main()

--- a/tools/sotn_permuter/src
+++ b/tools/sotn_permuter/src
@@ -1,0 +1,1 @@
+../decomp-permuter/src/

--- a/tools/sotn_str/jp.py
+++ b/tools/sotn_str/jp.py
@@ -126,12 +126,19 @@ def get_chr(chr):
 
 alt_utf8_to_index = dict((value, index) for index, value in enumerate("ＡＴＤＥＦ"))
 
-alt_hd_utf8_to_index = dict((value, index) for index, value in enumerate("".join([
-    #0 1 2 3 4 5 6 7 8 9 A B C D E F
-    "装備技システム短剣必殺使攻撃力防",
-    "御魔導器拳こ一覧棒両手食物爆弾盾",
-    "投射薬ん右左武兜鎧マントその他い",
-])))
+alt_hd_utf8_to_index = dict(
+    (value, index)
+    for index, value in enumerate(
+        "".join(
+            [
+                # 0 1 2 3 4 5 6 7 8 9 A B C D E F
+                "装備技システム短剣必殺使攻撃力防",
+                "御魔導器拳こ一覧棒両手食物爆弾盾",
+                "投射薬ん右左武兜鎧マントその他い",
+            ]
+        )
+    )
+)
 
 
 def convert_j(f):
@@ -253,7 +260,7 @@ def remove_dakuten_handakuten(utf8_char):
         "プ": "フ",
         "ペ": "ヘ",
         "ポ": "ホ",
-        "ヴ": "ウ"
+        "ヴ": "ウ",
     }
     return table[utf8_char]
 
@@ -273,12 +280,13 @@ def utf8_to_byte_literals(input_str):
     for char in input_str:
         if has_dakuten(char) or has_handakuten(char):
             bytes += dakuten_to_bytes(char)
-        elif char == '月':
-            bytes += [0xff, 0xff]
+        elif char == "月":
+            bytes += [0xFF, 0xFF]
         else:
             bytes.append(utf8_to_index[char])
     bytes.append(0xFF)
     return bytes
+
 
 def alt_utf8_to_byte_literals(input_str):
     bytes = []
@@ -287,12 +295,14 @@ def alt_utf8_to_byte_literals(input_str):
     bytes.append(0xFF)
     return bytes
 
+
 def alt_hd_utf8_to_byte_literals(input_str):
     bytes = []
     for char in input_str:
         bytes.append(alt_hd_utf8_to_index[char])
     bytes.append(0xFF)
     return bytes
+
 
 def utf8_to_byte_literals_escaped(input):
     out = utf8_to_byte_literals(input)

--- a/tools/sotn_str/sotn_str.py
+++ b/tools/sotn_str/sotn_str.py
@@ -3,7 +3,11 @@
 import argparse
 import re
 import sys
-from jp import utf8_to_byte_literals, alt_utf8_to_byte_literals, alt_hd_utf8_to_byte_literals
+from jp import (
+    utf8_to_byte_literals,
+    alt_utf8_to_byte_literals,
+    alt_hd_utf8_to_byte_literals,
+)
 
 
 def parse(filename, str_offset):
@@ -27,6 +31,7 @@ def process_string(match: re.Match[str]):
         r += f"\\x{ch - 0x20:02X}"
     return f'"{r}\\xFF"'
 
+
 def transform_match(transform):
     def repl(match: re.Match[str]):
         s = match.group(1)
@@ -34,33 +39,32 @@ def transform_match(transform):
         out = transform(s)
         escaped = "".join([f"\\x{val:02X}" for val in out])
         return f'"{escaped}"'
+
     return repl
 
+
 def process_macro(line, macro_name, transform):
-    return re.sub(macro_name + r'\("((?:\\["]|[^"])*)"\)',
-                  transform,
-                  line)
+    return re.sub(macro_name + r'\("((?:\\["]|[^"])*)"\)', transform, line)
+
 
 def process_s_macro(line):
-    return process_macro(line,
-                         '_S',
-                         transform_match(utf8_to_byte_literals))
+    return process_macro(line, "_S", transform_match(utf8_to_byte_literals))
+
 
 def process_s2_macro(line):
-    return process_macro(line,
-                         "_S2",
-                         transform_match(alt_utf8_to_byte_literals))
+    return process_macro(line, "_S2", transform_match(alt_utf8_to_byte_literals))
+
 
 def process_s2_hd_macro(line):
-    return process_macro(line,
-                         "_S2_HD",
-                         transform_match(alt_hd_utf8_to_byte_literals))
+    return process_macro(line, "_S2_HD", transform_match(alt_hd_utf8_to_byte_literals))
+
 
 def do_sub(line):
     processed = process_s_macro(line)
     processed = process_s2_macro(processed)
     processed = process_s2_hd_macro(processed)
     return processed
+
 
 def process(filename):
     if not filename or filename == "-":

--- a/tools/sotn_str/test.py
+++ b/tools/sotn_str/test.py
@@ -33,7 +33,7 @@ class TestingJp(unittest.TestCase):
         assert out == "\\xB1\\xB6\\xC2\\xB7\\xC9\\x3C\\xFF"
 
     def check_sei():
-        assert(utf8_to_index['聖'] == 222)
+        assert utf8_to_index["聖"] == 222
 
     def test_glasses(self):
         input = "聖なるめがね"
@@ -43,12 +43,16 @@ class TestingJp(unittest.TestCase):
     def test_moon(self):
         input = "バルザイのえん月刀"
         out = utf8_to_byte_literals_escaped(input)
-        assert out == "\\x8A\\xFF\\x9E\\x99\\x7B\\xFF\\x9E\\x72\\xC9\\xB4\\xDD\\xFF\\xFF\\xED\\xFF"
+        assert (
+            out
+            == "\\x8A\\xFF\\x9E\\x99\\x7B\\xFF\\x9E\\x72\\xC9\\xB4\\xDD\\xFF\\xFF\\xED\\xFF"
+        )
 
     def test_str_potion(self):
         input = "Str. potion"
         out = utf8_to_byte_literals_escaped(input)
         assert out == "\\x33\\x54\\x52\\x0E\\x00\\x50\\x4F\\x54\\x49\\x4F\\x4E\\xFF"
+
 
 class TestingSotnStr(unittest.TestCase):
     def test_do_sub_jp(self):
@@ -58,13 +62,13 @@ class TestingSotnStr(unittest.TestCase):
         assert out == expected
 
     def test_jp_empty(self):
-        line = "_S(\"\")"
+        line = '_S("")'
         out = do_sub(line)
-        expected = '\"\\xFF\"'
+        expected = '"\\xFF"'
         assert out == expected
 
     def test_jp_symbols_and_quotes(self):
-        line = "_S(\"\\\"(\\\")\")"
+        line = '_S("\\"(\\")")'
         out = do_sub(line)
         expected = '"\\x02\\x08\\x02\\x09\\xFF"'
         assert out == expected, (out, expected)


### PR DESCRIPTION
I created a loader for decomp-permuter so that its code doesn't need to be edited for it to work.
    - There are 4 symlinks I needed to create in order to deal with a few things about decomp-permuter
      - The link to src/ and default_weights.toml are because of the pathing import.py expects
      - The link to import.py is needed because import.py cannot be imported
      - The link to decomp-permuter/ is needed because Python doesn't allow `-` in variables/modules

I noticed that some python was missing for make format, so I added those to make along with this script.

I added the decomp-permuter default `nonmatchings` directory and the loader's default directory to `.gitignore`.

I added decomp-permuter to git submodules and disabled updates to it since this loader is probably very fragile and any updates to that project could easily break its functionality.