### PR TITLE
Streamlined arguments and added options to permuter_loader.py

### DIFF
--- a/tools/sotn_permuter/README.md
+++ b/tools/sotn_permuter/README.md
@@ -1,25 +1,70 @@
 # I'm not fluent in markdown, so I'm not going to mess with it.  If anybody wants to improve this readme, please do.
-sotn_permuter.py is just a loader for decomp-permuter to address the hurdles that decomp-permuter presents for standardized use within sotn-decomp.
+permuter_loader.py is just a loader for decomp-permuter to address the hurdles that decomp-permuter presents for standardized use within sotn-decomp.
 
+For the expected usage, OVL is the overlay as it is written in the splat config (i.e. stlib) and subsegment is the name of the c subsegment as set in the splat config (no .c extension).  The -p or --permuter arguments is an optional way to import and permute with a single command.
+
+expected usage:
+tools/sotn_permuter/permuter_loader.py import {SUBSEGMENT} {FUNCTION} -o {OVL}
+tools/sotn_permuter/permuter_loader.py permute {FUNCTION}
+tools/sotn_permuter/permuter_loader.py clean {FUNCTION|all}
+
+
+When using the -o or --overlay argument, any previously imported version of the same name will be overwritten.  Omitting the -o argument will need the full path passed and will not automatically permute even if the -p argument is passed.  It will also append a number to the name if a directory for the function already exists.
+
+
+legacy usage:
 It passes any arguments except --version and import|permute directly to import.py and permuter.py as appropriate.
+tools/sotn_permuter/permuter_loader.py import {path_to_c_file} {path_to_s_file}
+tools/sotn_permuter/permuter_loader.py permute tools/sotn_permuter/permute.me/{func_name}
 
-default usage:
-tools/sotn_permuter/sotn_permuter.py import {path_to_c_file} {path_to_s_file}
-tools/sotn_permuter/sotn_permuter.py permute tools/sotn_permuter/permute.me/{func_name}
 
-sotn_permuter.py arguments
-usage: sotn_permuter.py [-h] [--version VERSION] {import,permute} [import.py or permuter.py args as appropriate]
+permuter_loader.py arguments
+usage: permuter_loader.py [-h] [--version VERSION] {import,permute} [import.py or permuter.py args as appropriate]
 
 Use decomp-permuter with sotn specific adjustments
 
 positional arguments:
-  {import,permute}   Whether to import or permute the function
+  {import,permute,clean}
+                        Whether to import or permute the function
+    import              Import a function to be permuted
+    permute             Permute a function
+    clean               Clean function folders from permuter
 
 options:
   -h, --help         show this help message and exit
   --version VERSION  Sets game version and overrides VERSION environment variable
 
+usage: permuter_loader.py import [-h] [-o OVERLAY] [-p] source function
 
+positional arguments:
+  source                The name specified for the splat subsegment or the source filename if not using --overlay
+  function              The function to be permuted or the function asm filename if not using --overlay
+
+options:
+  -h, --help            show this help message and exit
+  -o OVERLAY, --overlay OVERLAY
+                        Specifies the overlay name where the function exists, as it is in the splat config filename, and causes the loader to treat the positional arguments
+                        as subsegment and function.
+  -p, --permute         Begins permuting immediately after the function is imported
+
+usage: permuter_loader.py permute [-h] function
+
+positional arguments:
+  function    The function to be permuted
+
+options:
+  -h, --help  show this help message and exit
+
+usage: permuter_loader.py clean [-h] function
+
+positional arguments:
+  function    The function to be cleaned, or use "all" to clean all folders
+
+options:
+  -h, --help  show this help message and exit
+
+
+decomp-permuter arguments:
 import.py arguments
 usage: import.py [-h] [--keep] [--preserve-macros REGEX] [--no-prune] [--decompme] [--settings SETTINGS_FILE] c_file {asm_file|func_name} [make_flags ...]
 

--- a/tools/sotn_permuter/permuter_loader.py
+++ b/tools/sotn_permuter/permuter_loader.py
@@ -1,22 +1,31 @@
 #!/usr/bin/env python3
+"""Author: ProjectOblivion
+This script is intended to address the alterations needed to run decomp-permuter within the context of the sotn-decomp project without
+altering the actual decomp-permuter code.
+The goal is to make it easier to effectively use decomp-permuter, so feel free to reach out to me with any comments, suggestions, or issues.
+For usage instructions, refer to tool/sotn_permuter/README.md
+"""
 import argparse
 import os
+import shutil
 import sys
+import yaml
 import multiprocessing
 import decomp_permuter.src.objdump
 import decomp_permuter.src.main as permuter
 import importer
 
+PERMUTE_PATH = os.path.join(os.getcwd(),"tools/sotn_permuter/permute.me/")
 
 # These functions exist solely to overwrite some of the undesirable hardcoded behavior in decomp-permuter import.py
 # They intentionally retain as much of the original code and naming as possible to avoid unexpected incompatibility
 def sotn_create_directory(func_name: str) -> str:
-    os.makedirs(f"tools/sotn_permuter/permute.me/", exist_ok=True)
+    os.makedirs(PERMUTE_PATH, exist_ok=True)
     ctr = 0
     while True:
         ctr += 1
         dirname = f"{func_name}-{ctr}" if ctr > 1 else func_name
-        dirname = f"tools/sotn_permuter/permute.me/{dirname}"
+        dirname = os.path.join(PERMUTE_PATH,dirname)
         try:
             os.mkdir(dirname)
             return dirname
@@ -54,84 +63,172 @@ if __name__ == "__main__":
         default=os.getenv("VERSION") or "us",
         help="Sets game version and overrides VERSION environment variable",
     )
-    parser.add_argument(
-        "action",
-        choices=actions,
+    
+    subparsers = parser.add_subparsers(dest="action", help="Whether to import or permute the function")
+    parser_import = subparsers.add_parser("import", help="Import a function to be permuted")
+    parser_import.add_argument(
+        "source",
         type=str,
-        help="Whether to import or permute the function",
+        help="The name specified for the splat subsegment or the source filename if not using --overlay",
     )
-
+    parser_import.add_argument(
+        "function",
+        type=str,
+        help="The function to be permuted or the function asm filename if not using --overlay",
+    )
+    parser_import.add_argument(
+        "-o",
+        "--overlay",
+        required=False,
+        type=str,
+        help="Specifies the overlay name where the function exists, as it is in the splat config filename, and causes the loader to treat the positional arguments as subsegment and function.",
+    )
+    parser_import.add_argument(
+        "-p",
+        "--permute",
+        required=False,
+        action="store_true",
+        help="Begins permuting immediately after the function is imported",
+    )
+    parser_permute = subparsers.add_parser("permute", help="Permute a function")
+    parser_permute.add_argument(
+        "function",
+        type=str,
+        help="The function to be permuted",
+    )
+    parser_clean = subparsers.add_parser("clean", help="Clean function folders from permuter")
+    parser_clean.add_argument(
+        "function",
+        type=str,
+        help="The function to be cleaned, or use \"all\" to clean all folders",
+    )
     # This will keep the loader from choking on args intended for decomp-permuter
     args, unknown = parser.parse_known_args()
     # Removes args intended only for the loader
-    sys.argv = [a for a in sys.argv if not a.startswith("--v") and a not in actions]
-
+    if "-o" in sys.argv:
+        sys.argv.pop(sys.argv.index("-o")+1)
+    sys.argv = [a for a in sys.argv if a not in ["-o","-p"] and a not in actions]
+    sys.argv = [a for a in sys.argv if not a.startswith("--v") and not a.startswith("--o") and not a.startswith("--p")]
+    
     # Function overwrites
     importer.create_directory = sotn_create_directory
     importer.finalize_compile_command = sotn_finalize_compile_command
-
+    
+    # Actual loader logic
     if args.version == "us":
-        if args.action == "import":
-            importer.DEFAULT_AS_CMDLINE = [
-                "mipsel-linux-gnu-as",
-                "-march=r3000",
-                "-mabi=32",
-            ]
-            settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
-            defaultArgs = (
-                [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
-                if not any(i.startswith("--settings") for i in sys.argv)
-                else []
-            )
-        elif args.action == "permute":
-            decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
-                "mipsel-linux-gnu-objdump"
-            ]
-            decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
-                "-drz",
-                "-m",
-                "mips:3000",
-            ]
-            defaultArgs = ["--no-context-output", "--best-only", "-j"]
+        importer.DEFAULT_AS_CMDLINE = [
+            "mipsel-linux-gnu-as",
+            "-march=r3000",
+            "-mabi=32",
+        ]
+        settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
+        importArgs = (
+            [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
+            if not any(i.startswith("--settings") for i in sys.argv)
+            else []
+        )
+        decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
+            "mipsel-linux-gnu-objdump"
+        ]
+        decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
+            "-drz",
+            "-m",
+            "mips:3000",
+        ]
+        permuteArgs = ["--no-context-output", "--best-only", "-j"]
     elif args.version == "pspeu":
-        if args.action == "import":
-            importer.DEFAULT_AS_CMDLINE = [
-                "bin/allegrex-as",
-                "-march=allegrex",
-                "-mabi=eabi",
-                "-EL",
-                "-G0",
-                "-I",
-                "include/",
-            ]
-            settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
-            defaultArgs = (
-                [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
-                if not any(i.startswith("--settings") for i in sys.argv)
-                else []
-            )
-        elif args.action == "permute":
-            decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
-                "bin/allegrex-objdump"
-            ]
-            decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
-                "-drz",
-                "-m",
-                "mips:allegrex",
-            ]
-            defaultArgs = ["--no-context-output", "--best-only", "-j"]
+        importer.DEFAULT_AS_CMDLINE = [
+            "bin/allegrex-as",
+            "-march=allegrex",
+            "-mabi=eabi",
+            "-EL",
+            "-G0",
+            "-I",
+            "include/",
+        ]
+        settingsFile = f"tools/sotn_permuter/permuter_settings.{args.version}.toml"
+        importArgs = (
+            [f"--settings={os.path.join(os.getcwd(),settingsFile)}"]
+            if not any(i.startswith("--settings") for i in sys.argv)
+            else []
+        )
+        decomp_permuter.src.objdump.MIPS_SETTINGS.executable = [
+            "bin/allegrex-objdump"
+        ]
+        decomp_permuter.src.objdump.MIPS_SETTINGS.arguments = [
+            "-drz",
+            "-m",
+            "mips:allegrex",
+        ]
+        permuteArgs = ["--no-context-output", "--best-only", "-j"]
     else:
         print(f"{args.version} is currently unsupported.")
         exit()
 
     if args.action == "import":
-        print(f"Importing {args.version} function.")
-        args = [a for a in defaultArgs]
-        sys.argv.extend(args)
+        if args.overlay:
+            with open(
+                os.path.join(
+                    os.getcwd(), f"config/splat.{args.version}.{args.overlay}.yaml"
+                )
+            ) as yamlFile:
+                splatConfig = yaml.safe_load(yamlFile)
+            if "options" in splatConfig and "nonmatchings_path" in splatConfig["options"]:
+                if args.version == "pspeu":
+                    nonmatchings_path = os.path.join(splatConfig["options"]["nonmatchings_path"],f"{args.overlay[-3:]}_psp")
+                else:
+                    nonmatchings_path = splatConfig["options"]["nonmatchings_path"]
+            else:
+                nonmatchings_path = "nonmatchings"
+
+            if args.version == "pspeu":
+                src_path = os.path.join(os.getcwd(),splatConfig["options"]["src_path"],f"{args.overlay[-3:]}_psp")
+            else:
+                src_path = os.path.join(os.getcwd(),splatConfig["options"]["src_path"])
+            
+            cFilename = os.path.join(src_path, f"{args.source}.c")
+            sys.argv = [cFilename if a == args.source else a for a in sys.argv]
+            
+            sFilename = os.path.join(
+                os.getcwd(),
+                splatConfig["options"]["asm_path"],
+                nonmatchings_path,
+                args.source,
+                f"{args.function}.s",
+            )
+            sys.argv = [sFilename if a == args.function else a for a in sys.argv]
+            funcPath = os.path.join(PERMUTE_PATH,args.function)
+            if os.path.isdir(funcPath):
+                try:
+                    shutil.rmtree(funcPath)
+                    print(f"Existing {funcPath} and its contents deleted successfully.")
+                except OSError as e:
+                    print(f"Error deleting folder {funcPath}: {e}")
+
+        print(f"Importing {args.version} source {args.source} function {args.function}")
+        addArgs = [a for a in importArgs]
+        sys.argv.extend(addArgs)
+        print(sys.argv)
         importer.main(sys.argv[1:])
-    elif args.action == "permute":
-        print(f"Permuting {args.version} function.")
-        args = [a for a in defaultArgs if not any(i.startswith(a) for i in sys.argv)]
-        args = [a + f"{multiprocessing.cpu_count()}" if a == "-j" else a for a in args]
-        sys.argv.extend(args)
+        if args.permute and args.overlay:
+            sys.argv = [a for a in sys.argv if not a.startswith("--settings") and not a.endswith(".c")]
+            sys.argv[1] = sys.argv[1].split("/")[-1].rstrip(".s")
+            args.function = args.function.split("/")[-1].rstrip(".s")
+
+    if args.action == "permute" or (args.action == "import" and args.permute and args.overlay):
+        print(f"Permuting {args.version} function {args.function}")
+        sys.argv = [os.path.join(PERMUTE_PATH, args.function) if x == args.function else x for x in sys.argv]
+        addArgs = [a for a in permuteArgs if not any(i.startswith(a) for i in sys.argv)]
+        addArgs = [a + f"{multiprocessing.cpu_count()}" if a == "-j" else a for a in addArgs]
+        sys.argv.extend(addArgs)
         permuter.main()
+
+    if args.action == "clean":
+        for dirName in os.listdir(PERMUTE_PATH):
+            dirPath = os.path.join(PERMUTE_PATH, dirName)
+            if os.path.isdir(dirPath) and (dirName.startswith(args.function) or args.function == "all"):
+                try:
+                    shutil.rmtree(dirPath)
+                    print(f"{dirPath} and its contents deleted successfully.")
+                except OSError as e:
+                    print(f"Error deleting folder {dirPath}: {e}")


### PR DESCRIPTION
- Added the ability to specify overlay, sebsegment, and function instead of full paths.  It builds the paths using those arguments and information pulled from the splat config.
- Added the option to import and permute in a single command
- Added the ability to clean the permute.me directory
- Behavior without -o argument is the same as previous
- Permute action can now take the function (assumes permute.me path) or a full path