### PR TITLE
asm-differ: Fixed diff_settings.py to properly handle all versions and overlays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ format-tools:
 	$(BLACK) tools/split_jpt_yaml/*.py
 	$(BLACK) tools/sotn_str/*.py
 	$(BLACK) tools/sotn_permuter/permuter_loader.py
+	$(BLACK) diff_settings.py
 format-symbols:
 	VERSION=us $(PYTHON) ./tools/symbols.py sort
 	VERSION=hd $(PYTHON) ./tools/symbols.py sort


### PR DESCRIPTION
In looking at #2321, I found that the pathing wasn't being built properly.  I reworked it so that it should now be returning all of the proper pathing for all versions and overlays, as well as adding `_psp` `src/` directories for stage, boss, dra, and ric