### PR TITLE
Improve permute loader support for PSP overlays

### DIFF
--- a/tools/sotn_permuter/permuter_loader.py
+++ b/tools/sotn_permuter/permuter_loader.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
                             if isinstance(x, list)
                             and len(x) > 1
                             and x[1] == "c"
-                            and x[-1].endswith(args.source)
+                            and str(x[-1]).endswith(args.source)
                         ]
                     )
             if subsegments and len(subsegments) == 1:


### PR DESCRIPTION
cc @ProjectOblivion 

### `isinstance(x, list)` fix

PSP splat configs have a `{type: bss, vram: 0x92D6600}` at the end. We need to filter them out.

### `subsegments[0]` fix

Since the subsegment path is matched with `x[-1].endswith(args.source)`, if `x[-1]` contains a path with directories involved then we cannot simply use `args.source`. This led me to issue where `permute ric 6DB0 RicMain` was trying to open `src/6DB0.c`. And `permute ric ric_psp/6DB0 RicMain` was trying to open `asm/pspeu/ric_psp/nonmatchings/ric_psp/ric_psp/6DB0/RicMain.s` (notice the double `ric_psp/` in the path). 
