### PR TITLE
Fix decompile.py failing on duplicate C filenames

### DIFF
--- a/tools/decompile.py
+++ b/tools/decompile.py
@@ -52,7 +52,7 @@ class NonMatchingFunc(object):
         self.text_offset = split[split.index("nonmatchings") + 1]
 
         assumed_path = "/".join(split[split.index("nonmatchings") + 1 : -1]) + ".c"
-        c_paths = [src for src in src_files if src.endswith(assumed_path)]
+        c_paths = [src for src in src_files if src.endswith(assumed_path) and self.overlay_name in src.split("/")]
         assert len(c_paths) == 1
         self.src_path = c_paths[0]
 

--- a/tools/decompile.py
+++ b/tools/decompile.py
@@ -52,7 +52,11 @@ class NonMatchingFunc(object):
         self.text_offset = split[split.index("nonmatchings") + 1]
 
         assumed_path = "/".join(split[split.index("nonmatchings") + 1 : -1]) + ".c"
-        c_paths = [src for src in src_files if src.endswith(assumed_path) and self.overlay_name in src.split("/")]
+        c_paths = [
+            src
+            for src in src_files
+            if src.endswith(assumed_path) and self.overlay_name in src.split("/")
+        ]
         assert len(c_paths) == 1
         self.src_path = c_paths[0]
 


### PR DESCRIPTION
Check that the C path is taken from the relevant overlay.

Before:
```
$ dec func_us_801C9764
Traceback (most recent call last):
  File "/<repo_path>/sotn-decomp/./tools/decompile.py", line 334, in <module>
    decompile(args.function, args.number_occurrence, args.force)
  File "/<repo_path>/sotn-decomp/./tools/decompile.py", line 269, in decompile
    funcs = get_nonmatching_functions(asm_dir, func_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<repo_path>/sotn-decomp/./tools/decompile.py", line 67, in get_nonmatching_functions
    function = NonMatchingFunc(full_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<repo_path>/sotn-decomp/./tools/decompile.py", line 56, in __init__
    assert len(c_paths) == 1
           ^^^^^^^^^^^^^^^^^
AssertionError
```

After:
```
$ dec func_us_801C9764
In file included from include/stage.h:5,
                 from src/st/no4/no4.h:2,
                 from src/st/no4/first_c_file.c:2:
include/common.h:23:2: warning: #warning "Version not specified. Falling back to the US version." [-Wcpp]
   23 | #warning "Version not specified. Falling back to the US version."
      |  ^~~~~~~
function 'func_us_801C9764' decompiled but cannot be compiled
python3 tools/asm-differ/diff.py -mwo --overlay st/no4 func_us_801C9764
```