### PR TITLE
Rename symbol for `g_UserLanguage` on PSP side

### DIFF
--- a/config/symbols.pspeu.txt
+++ b/config/symbols.pspeu.txt
@@ -88,6 +88,7 @@ SetBackColor = 0x089297E0;
 SsUtSetVVol = 0x0892F75C;
 D_psp_08B42050 = 0x08B42050;
 D_psp_08B42054 = 0x08B42054;
+g_UserLanguage = 0x08B42058;
 D_psp_08B42060 = 0x08B42060;
 D_psp_08C630DC = 0x08C630DC;
 PfnEntityUpdates = 0x08C6BC30;

--- a/include/game.h
+++ b/include/game.h
@@ -2073,13 +2073,15 @@ extern s32 D_800987C8;
 extern s32 g_DebugPlayer;
 extern s32 D_80098894;
 
-// exclusive PSP content
+// On PSP side this is compared against g_UserLanguage / 0x08B42058
+// which is the system language of the console. Used to determine the
+// language of various strings to display in-game
 typedef enum {
     LANG_JP,
     LANG_EN,
     LANG_FR,
-    LANG_SP,
-    LANG_GE,
+    LANG_ES,
+    LANG_DE,
     LANG_IT,
 } Language;
 u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* sp, u8* ge, u8* it);

--- a/include/game.h
+++ b/include/game.h
@@ -2080,8 +2080,8 @@ typedef enum {
     LANG_JP,
     LANG_EN,
     LANG_FR,
-    LANG_ES,
-    LANG_DE,
+    LANG_SP,
+    LANG_GE,
     LANG_IT,
 } Language;
 u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* sp, u8* ge, u8* it);

--- a/src/dra/7879C.c
+++ b/src/dra/7879C.c
@@ -484,7 +484,7 @@ typedef struct {
 } GuardTextControl;
 
 #ifdef VERSION_PSP
-extern s32 D_8B42058;
+extern s32 g_UserLanguage;
 GuardTextControl D_psp_091835F0[] = {
     0x43, 0x4A,   0x59,   0x52, 0x0185, 0x0001, 0x4E, 0x53,   0x66,
     0x5B, 0x01B1, 0x0001, 0x20, 0x53,   0x36,   0x5B, 0x01B1, 0x0001,
@@ -1049,19 +1049,19 @@ GuardTextControl* func_psp_09125DB8(GuardTextControl* arg0, s32 arg1) {
     temp_s1 = &D_psp_091835F0[arg1];
     arg0->clut = temp_s1->clut;
     arg0->mode = temp_s1->mode;
-    if (D_8B42058 == 1) {
+    if (g_UserLanguage == LANG_EN) {
         arg0->left = temp_s1->left;
         arg0->top = temp_s1->top;
         arg0->right = temp_s1->right;
         arg0->bottom = temp_s1->bottom;
     } else {
-        temp_s0 = &D_psp_09183698[D_8B42058 - 2][arg1][0];
+        temp_s0 = &D_psp_09183698[g_UserLanguage - 2][arg1][0];
         arg0->left = temp_s0[0];
         arg0->top = temp_s0[1];
         arg0->right = temp_s0[0] + temp_s0[2];
         arg0->bottom = temp_s0[1] + temp_s0[3];
         if (arg1 == 6) {
-            arg0->right += D_psp_091837E8[D_8B42058 - 2][2] + 2;
+            arg0->right += D_psp_091837E8[g_UserLanguage - 2][2] + 2;
         }
     }
     return arg0;

--- a/src/dra_psp/E6A8.c
+++ b/src/dra_psp/E6A8.c
@@ -1773,10 +1773,10 @@ block_4:
                 case LANG_FR:
                     buttonAssignStr = "Attr. toutes les fonctions des touches";
                     break;
-                case LANG_ES:
+                case LANG_SP:
                     buttonAssignStr = "Asigna las funciones de los botones";
                     break;
-                case LANG_DE:
+                case LANG_GE:
                     buttonAssignStr = "Standard-Tastenbelegung";
                     break;
                 case LANG_IT:

--- a/src/dra_psp/E6A8.c
+++ b/src/dra_psp/E6A8.c
@@ -1309,7 +1309,7 @@ extern s32 D_80137848[1];
 extern s32 D_801375D0;
 extern s32* D_801375D8;
 extern bool D_psp_091CDD48;
-extern s32 D_8B42058;
+extern s32 g_UserLanguage;
 extern s32 D_psp_091CDD40;
 
 extern u32 D_psp_08B42050; // psp cross button
@@ -1765,7 +1765,7 @@ block_4:
             } else {
             block_117:
                 func_800F9808(2);
-                switch (D_8B42058) {
+                switch (g_UserLanguage) {
                 default:
                 case LANG_EN:
                     buttonAssignStr = "Allocate all button functions";
@@ -1773,10 +1773,10 @@ block_4:
                 case LANG_FR:
                     buttonAssignStr = "Attr. toutes les fonctions des touches";
                     break;
-                case LANG_SP:
+                case LANG_ES:
                     buttonAssignStr = "Asigna las funciones de los botones";
                     break;
-                case LANG_GE:
+                case LANG_DE:
                     buttonAssignStr = "Standard-Tastenbelegung";
                     break;
                 case LANG_IT:

--- a/src/st/e_mist_door.h
+++ b/src/st/e_mist_door.h
@@ -26,7 +26,7 @@ static char* alucard_mist_label; // bss
 static char* maria_mist_label;   // bss
 static char* richter_mist_label; // bss
 
-extern s32 D_8B42058; // User's language selection?
+extern s32 g_UserLanguage;
 #else
 static char alucard_mist_label[] = "\x7C\x0EMist could pass．";
 static char richter_mist_label[] =
@@ -36,7 +36,7 @@ static char richter_mist_label[] =
 #ifdef VERSION_PSP
 static char* GetMistLabel(
     char* str_EN, char* str_FR, char* str_ES, char* str_DE, char* str_IT) {
-    switch (D_8B42058) {
+    switch (g_UserLanguage) {
     case 1:
     default:
         return str_EN;

--- a/src/st/entity_relic_orb.h
+++ b/src/st/entity_relic_orb.h
@@ -2,7 +2,7 @@
 #include "stage.h"
 
 #if defined(VERSION_PSP) && STAGE != STAGE_ST0
-extern s32 D_8B42058;     // User's language selection?
+extern s32 g_UserLanguage;
 extern char* obtainedStr; // BSS
 #else
 const char* g_RelicOrbTexts[] = {
@@ -250,26 +250,26 @@ void EntityRelicOrb(Entity* self) {
         var_s2 = 0;
         isObtainedTextStored = false;
         msg = g_api.relicDefs[relicId].name;
-        switch (D_8B42058) {
-        case 1:
+        switch (g_UserLanguage) {
+        case LANG_EN:
         default:
             obtainedStr = "Obtained";
             break;
-        case 2:
+        case LANG_FR:
             obtainedStr = "Obtenu \xB1 ";
             break;
-        case 3:
+        case LANG_ES:
             obtainedStr = "Tienes";
             break;
-        case 4:
+        case LANG_DE:
             obtainedStr = "erhalten";
             break;
-        case 5:
+        case LANG_IT:
             obtainedStr = "Ottenuto";
             break;
         }
 
-        if (D_8B42058 != 4) {
+        if (g_UserLanguage != LANG_DE) {
             psp_sprintf(&sp34, "%s %s", obtainedStr, msg);
         } else {
             psp_sprintf(&sp34, "%s %s", msg, obtainedStr);

--- a/src/st/entity_relic_orb.h
+++ b/src/st/entity_relic_orb.h
@@ -258,10 +258,10 @@ void EntityRelicOrb(Entity* self) {
         case LANG_FR:
             obtainedStr = "Obtenu \xB1 ";
             break;
-        case LANG_ES:
+        case LANG_SP:
             obtainedStr = "Tienes";
             break;
-        case LANG_DE:
+        case LANG_GE:
             obtainedStr = "erhalten";
             break;
         case LANG_IT:
@@ -269,7 +269,7 @@ void EntityRelicOrb(Entity* self) {
             break;
         }
 
-        if (g_UserLanguage != LANG_DE) {
+        if (g_UserLanguage != LANG_GE) {
             psp_sprintf(&sp34, "%s %s", obtainedStr, msg);
         } else {
             psp_sprintf(&sp34, "%s %s", msg, obtainedStr);

--- a/src/st/get_lang.h
+++ b/src/st/get_lang.h
@@ -3,17 +3,17 @@
 
 extern s32 g_UserLanguage;
 
-u8* GetLang(u8* en, u8* fr, u8* es, u8* de, u8* it) {
+u8* GetLang(u8* en, u8* fr, u8* sp, u8* ge, u8* it) {
     switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en;
     case LANG_FR:
         return fr;
-    case LANG_ES:
-        return es;
-    case LANG_DE:
-        return de;
+    case LANG_SP:
+        return sp;
+    case LANG_GE:
+        return ge;
     case LANG_IT:
         return it;
     }

--- a/src/st/get_lang.h
+++ b/src/st/get_lang.h
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include <game.h>
 
-extern s32 D_8B42058;
+extern s32 g_UserLanguage;
 
-u8* GetLang(u8* en, u8* fr, u8* sp, u8* ge, u8* it) {
-    switch (D_8B42058) {
+u8* GetLang(u8* en, u8* fr, u8* es, u8* de, u8* it) {
+    switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en;
     case LANG_FR:
         return fr;
-    case LANG_SP:
-        return sp;
-    case LANG_GE:
-        return ge;
+    case LANG_ES:
+        return es;
+    case LANG_DE:
+        return de;
     case LANG_IT:
         return it;
     }

--- a/src/st/lib_psp/e_shop.c
+++ b/src/st/lib_psp/e_shop.c
@@ -2140,17 +2140,17 @@ static ShopItem D_us_801D4364[64];
 static u8* D_psp_092A5D38;
 static char D_us_80181650[4];
 
-void* func_psp_0925D430(void* en, void* fr, void* es, void* de, void* it) {
+void* func_psp_0925D430(void* en, void* fr, void* sp, void* ge, void* it) {
     switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en;
     case LANG_FR:
         return fr;
-    case LANG_ES:
-        return es;
-    case LANG_DE:
-        return de;
+    case LANG_SP:
+        return sp;
+    case LANG_GE:
+        return ge;
     case LANG_IT:
         return it;
     }

--- a/src/st/lib_psp/e_shop.c
+++ b/src/st/lib_psp/e_shop.c
@@ -14,7 +14,7 @@ extern s32 E_ID(ID_2F);
 extern s32 E_ID(ID_48);
 extern s32 E_ID(ID_4F);
 extern u8* D_psp_092A54E0;
-extern s32 D_8B42058;
+extern s32 g_UserLanguage;
 
 /// An inventory item consists of a category, which affects
 /// how the other fields are interpretted, an "unlock level",
@@ -2140,17 +2140,17 @@ static ShopItem D_us_801D4364[64];
 static u8* D_psp_092A5D38;
 static char D_us_80181650[4];
 
-void* func_psp_0925D430(void* en, void* fr, void* sp, void* ge, void* it) {
-    switch (D_8B42058) {
+void* func_psp_0925D430(void* en, void* fr, void* es, void* de, void* it) {
+    switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en;
     case LANG_FR:
         return fr;
-    case LANG_SP:
-        return sp;
-    case LANG_GE:
-        return ge;
+    case LANG_ES:
+        return es;
+    case LANG_DE:
+        return de;
     case LANG_IT:
         return it;
     }
@@ -6606,8 +6606,8 @@ void func_us_801B7DF8(Primitive* prim, Entity* arg1, s16 enemyId) {
             prim, posX - xOffset, posY, D_us_801818EC[0], 0x196); // "????????"
     }
     for (i = 0; i < 4; i++) {
-        prim = func_us_801B1064(prim, 0x84 - xOffset, ((i * 0x10) + 0x3C),
-                                D_psp_092A5F98[i], 0x196);
+        prim = func_us_801B1064(
+            prim, 0x84 - xOffset, (i * 0x10) + 0x3C, D_psp_092A5F98[i], 0x196);
     }
     prim = func_us_801B7D10(prim, enemyDef->strengths, 0x8C - xOffset, 0x44);
     prim = func_us_801B7D10(prim, enemyDef->immunes, 0x8C - xOffset, 0x54);

--- a/src/st/st0_psp/3101C.c
+++ b/src/st/st0_psp/3101C.c
@@ -62,13 +62,13 @@ u8 func_801B101C(u8* script) {
             g_Dialogue2.unk20 = unk20_fr_de_it;
             g_Dialogue2.clutArrLength = 2;
             break;
-        case LANG_ES:
+        case LANG_SP:
             g_Dialogue2.startY += func_pspeu_09242F68((u8*)opening_line_es);
             g_Dialogue2.clutIndexes = clut_en_es;
             g_Dialogue2.unk20 = unk20_en_es;
             g_Dialogue2.clutArrLength = 4;
             break;
-        case LANG_DE:
+        case LANG_GE:
             g_Dialogue2.startY += func_pspeu_09242F68((u8*)opening_line_de);
             g_Dialogue2.clutIndexes = clut_fr_de_it;
             g_Dialogue2.unk20 = unk20_fr_de_it;

--- a/src/st/st0_psp/3101C.c
+++ b/src/st/st0_psp/3101C.c
@@ -28,7 +28,7 @@ static char opening_line_es[] = "El Conde Dr\323cula hab\334a";
 static char opening_line_de[] = "Graf Dracula war mithilfe";
 static char opening_line_it[] = "Il Conte Dracula \xD7 risorto";
 
-extern s32 D_8B42058;
+extern s32 g_UserLanguage;
 
 static void SetPrim(s32 i, Primitive* prim) { D_pspeu_0927B0C8[i].prim = prim; }
 
@@ -48,7 +48,7 @@ u8 func_801B101C(u8* script) {
         g_Dialogue2.scriptCur = script;
         g_Dialogue2.startY = g_Dialogue2.nextCharX = 0x200;
 
-        switch (D_8B42058) {
+        switch (g_UserLanguage) {
         default:
         case LANG_EN:
             g_Dialogue2.startY += func_pspeu_09242F68((u8*)opening_line_en);
@@ -62,13 +62,13 @@ u8 func_801B101C(u8* script) {
             g_Dialogue2.unk20 = unk20_fr_de_it;
             g_Dialogue2.clutArrLength = 2;
             break;
-        case LANG_SP:
+        case LANG_ES:
             g_Dialogue2.startY += func_pspeu_09242F68((u8*)opening_line_es);
             g_Dialogue2.clutIndexes = clut_en_es;
             g_Dialogue2.unk20 = unk20_en_es;
             g_Dialogue2.clutArrLength = 4;
             break;
-        case LANG_GE:
+        case LANG_DE:
             g_Dialogue2.startY += func_pspeu_09242F68((u8*)opening_line_de);
             g_Dialogue2.clutIndexes = clut_fr_de_it;
             g_Dialogue2.unk20 = unk20_fr_de_it;

--- a/src/st/st0_psp/lang.c
+++ b/src/st/st0_psp/lang.c
@@ -2,17 +2,17 @@
 #include <game.h>
 
 extern s32 g_UserLanguage;
-u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* es, u8* de, u8* it) {
+u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* sp, u8* ge, u8* it) {
     switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en + idx;
     case LANG_FR:
         return fr + idx;
-    case LANG_ES:
-        return es + idx;
-    case LANG_DE:
-        return de + idx;
+    case LANG_SP:
+        return sp + idx;
+    case LANG_GE:
+        return ge + idx;
     case LANG_IT:
         return it + idx;
     }

--- a/src/st/st0_psp/lang.c
+++ b/src/st/st0_psp/lang.c
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include <game.h>
 
-extern s32 D_8B42058;
-u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* sp, u8* ge, u8* it) {
-    switch (D_8B42058) {
+extern s32 g_UserLanguage;
+u8* GetLangAt(s32 idx, u8* en, u8* fr, u8* es, u8* de, u8* it) {
+    switch (g_UserLanguage) {
     default:
     case LANG_EN:
         return en + idx;
     case LANG_FR:
         return fr + idx;
-    case LANG_SP:
-        return sp + idx;
-    case LANG_GE:
-        return ge + idx;
+    case LANG_ES:
+        return es + idx;
+    case LANG_DE:
+        return de + idx;
     case LANG_IT:
         return it + idx;
     }


### PR DESCRIPTION
Added a symbol / renamed this so it's clearer in code / assemblies what it's used for.

~~Also did a slight update of the LANG enum to use more "typical" 2 character ISO codes for German (DE) and Spanish (ES)~~