### PR TITLE
Several More `BO4` and `RBO5` Functions

### DIFF
--- a/config/symbols.us.bobo4.txt
+++ b/config/symbols.us.bobo4.txt
@@ -164,6 +164,7 @@ PlayerStepHighJump = 0x801C6F74;
 func_80113E68 = 0x801C7244;
 BatFormFinished = 0x801C80D8;
 func_8011690C = 0x801C8184;
+PlayerStepSwordWarp = 0x801C95E4;
 GetFreeEntity = 0x801C9A6C;
 GetFreeEntityReverse = 0x801C9AE0;
 func_80118C28 = 0x801C9B64;

--- a/include/entity.h
+++ b/include/entity.h
@@ -1821,8 +1821,8 @@ typedef struct {
 
 typedef struct {
     /* 0x7C */ u8 unk7C;
+    /* 0x7D */ u8 unk7D;
     /* 0x7E */ u8 unk7E;
-    /* 0x80 */ u8 unk80;
 } ET_DisableAfterImage;
 
 typedef struct {

--- a/include/game.h
+++ b/include/game.h
@@ -2021,7 +2021,7 @@ typedef enum {
     UNK_ENTITY_12 = 0x12, // related to wolf?
     UNK_ENTITY_13 = 0x13,
     UNK_ENTITY_20 = 0x20,
-    UNK_ENTITY_50 = 0x50,
+    E_BOSS_WEAPON = 0x50,
     UNK_ENTITY_51 = 0x51, // SubWeapons container falling liquid
     UNK_ENTITY_100 = 0x100
 } EntityTypes;

--- a/src/boss/bo4/doppleganger.c
+++ b/src/boss/bo4/doppleganger.c
@@ -380,6 +380,159 @@ INCLUDE_ASM("boss/bo4/nonmatchings/doppleganger", func_us_801C38C0);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/doppleganger", func_us_801C3EEC);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/doppleganger", func_us_801C44C8);
+extern Point16 D_us_801812AC[];
 
-INCLUDE_ASM("boss/bo4/nonmatchings/doppleganger", func_us_801C4710);
+void func_us_801C44C8(void) {
+    Collider collider;
+
+    s16* dopY;
+    s16* dopX;
+    s32 effects;
+    s32 i;
+    u32* pVramFlag;
+
+    s16 offsetX, offsetY;
+
+    dopY = &DOPPLEGANGER.posY.i.hi;
+    dopX = &DOPPLEGANGER.posX.i.hi;
+
+    pVramFlag = &g_Dop.vram_flag;
+    effects =
+        g_Dop.unk04 & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                       EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID);
+    if (effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID)) {
+        *pVramFlag |= 4;
+        return;
+    }
+
+    for (i = 0; i < 7; i++) {
+        effects = g_Dop.colWall[i].effects &
+                  (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                   EFFECT_UNK_0002 | EFFECT_SOLID);
+        if ((effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                         EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                         EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_0002 | EFFECT_SOLID))) {
+
+            offsetX = *dopX + D_us_801812AC[i].x + g_Dop.colWall[i].unk4 - 1;
+            offsetY = *dopY + D_us_801812AC[i].y;
+            g_api.CheckCollision(offsetX, offsetY, &collider, 0);
+
+            if (!(collider.effects & EFFECT_SOLID)) {
+                *pVramFlag |= 4;
+                *dopX += g_Dop.colWall[i].unk4;
+                return;
+            }
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                EFFECT_UNK_8000 &&
+            i != 0 &&
+            ((g_Dop.colWall[0].effects & EFFECT_UNK_0800) ||
+             !(g_Dop.colWall[0].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 4;
+            *dopX += g_Dop.colWall[i].unk4;
+            return;
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                EFFECT_UNK_0800 &&
+            i != 6 &&
+            ((g_Dop.colWall[6].effects & EFFECT_UNK_8000) ||
+             !(g_Dop.colWall[6].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 4;
+            *dopX += g_Dop.colWall[i].unk4;
+            return;
+        }
+    }
+}
+
+extern Point16 D_us_801812AC[];
+
+void func_us_801C4710(void) {
+    Collider collider;
+
+    s16* dopY;
+    s16* dopX;
+    s32 effects;
+    s32 i;
+    u32* pVramFlag;
+
+    s16 offsetX, offsetY;
+    dopY = &DOPPLEGANGER.posY.i.hi;
+    dopX = &DOPPLEGANGER.posX.i.hi;
+
+    pVramFlag = &g_Dop.vram_flag;
+    effects =
+        g_Dop.unk04 &
+        (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0800 |
+         EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID);
+    if (effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_0800 | EFFECT_UNK_0400 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                    EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID)) {
+        *pVramFlag |= 8;
+        return;
+    }
+
+    for (i = 7; i < 14; i++) {
+        effects = g_Dop.colWall[i].effects &
+                  (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                   EFFECT_UNK_0002 | EFFECT_SOLID);
+        if (effects == (EFFECT_UNK_8000 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0800 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                        EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                        EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0002 | EFFECT_SOLID)) {
+
+            offsetX = *dopX + D_us_801812AC[i].x + g_Dop.colWall[i].unkC + 1;
+            offsetY = *dopY + D_us_801812AC[i].y;
+            g_api.CheckCollision(offsetX, offsetY, &collider, 0);
+
+            if (!(collider.effects & EFFECT_SOLID)) {
+                *pVramFlag |= 8;
+                *dopX += g_Dop.colWall[i].unkC;
+                return;
+            }
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                (EFFECT_UNK_8000 | EFFECT_UNK_4000) &&
+            i != 7 &&
+            ((g_Dop.colWall[7].effects & EFFECT_UNK_0800) ||
+             !(g_Dop.colWall[7].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 8;
+            *dopX += g_Dop.colWall[i].unkC;
+            return;
+        }
+
+        if (((effects &
+              (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+             (EFFECT_UNK_4000 | EFFECT_UNK_0800)) &&
+            i != 13 &&
+            ((g_Dop.colWall[13].effects & EFFECT_UNK_8000) ||
+             !(g_Dop.colWall[13].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 8;
+            *dopX += g_Dop.colWall[i].unkC;
+            return;
+        }
+    }
+}

--- a/src/boss/bo4/unk_45354.c
+++ b/src/boss/bo4/unk_45354.c
@@ -5,7 +5,32 @@ extern PlayerState g_Dop;
 
 // n.b.! this file is the same as rbo5/unk_44954.c
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C5354);
+extern s16 D_us_801D4D6E;
+
+// may be equivalent func_8010DFF0 in DRA
+void func_us_801C5354(s32 resetAnims, s32 arg1) {
+    Primitive* prim;
+
+    if (resetAnims) {
+        g_Entities[E_ID_41].ext.disableAfterImage.unk7D = 1;
+        g_Entities[E_ID_41].animCurFrame = g_Entities[E_ID_42].animCurFrame =
+            g_Entities[E_ID_43].animCurFrame = 0;
+        prim = &g_PrimBuf[g_Entities[1].primIndex];
+        while (prim != NULL) {
+            prim->x1 = 0;
+            prim = prim->next;
+        }
+    }
+    g_Entities[E_ID_41].ext.disableAfterImage.unk7C = 1;
+    g_Entities[E_ID_41].ext.disableAfterImage.unk7E = 0xA;
+    if (arg1 != 0) {
+        if (arg1 < 4) {
+            D_us_801D4D6E = 4;
+        } else {
+            D_us_801D4D6E = arg1;
+        }
+    }
+}
 
 void func_8010E0A8(void) {
     g_Entities[STAGE_ENTITY_START + UNK_ENTITY_1].ext.entSlot1.unk2 = 0;
@@ -144,7 +169,22 @@ void func_8010E6AC(bool forceAnim13) {
     }
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C58E4);
+void func_us_801C58E4(void) {
+    if (CheckMoveDirection() != 0) {
+        SetPlayerAnim(0x1A);
+        SetSpeedX(FIX(3.0 / 2.0));
+        g_Dop.unk44 = 0;
+    } else {
+        SetPlayerAnim(0x16);
+        DOPPLEGANGER.velocityX = 0;
+        g_Dop.unk44 = 4;
+    }
+    DOPPLEGANGER.velocityY = FIX(-4.875);
+    SetPlayerStep(5);
+    if (g_Dop.prev_step == 2) {
+        g_Dop.unk44 |= 0x10;
+    }
+}
 
 void func_us_801C5990(void) {
     DOPPLEGANGER.velocityY = FIX(-4.25);
@@ -165,11 +205,74 @@ void func_us_801C59DC(void) {
     g_Dop.unk44 = 0x10;
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C5A4C);
+void func_us_801C5A4C(void) {
+    if (CheckMoveDirection() != 0) {
+        SetSpeedX(0x30000);
+    } else {
+        DOPPLEGANGER.velocityX = 0;
+    }
+    SetPlayerStep(9);
+    DOPPLEGANGER.velocityY = FIX(-12);
+    SetPlayerAnim(0x21);
+    g_Dop.unk4A = 0;
+    g_Dop.unk44 &= 0xFFFE;
+    CreateEntFactoryFromEntity(g_CurrentEntity, 2, 0);
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010EA54);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C5B68);
+s32 func_us_801C5B68(void) {
+    Entity* entity;
+    s32 i;
+    s32 entityCount;
+    s32 targetCount;
+    s32 animBase;
+    s32 playerAnimOffset;
+    s32 var_s4;
+
+    playerAnimOffset = 0;
+    if (!(g_Dop.padPressed & PAD_UP)) {
+        return 1;
+    }
+    if (g_Dop.vram_flag & 0x20) {
+        playerAnimOffset = 1;
+    }
+
+    targetCount = 3;
+    for (entity = &g_Entities[E_ID_60], i = 0, entityCount = 0; i < 16; i++,
+        entity++) {
+        if (entity->entityId == E_ID_14) {
+            entityCount++;
+        }
+        if (entityCount >= targetCount) {
+            return -1;
+        }
+    }
+
+    CreateEntFactoryFromEntity(g_CurrentEntity, 3, 0);
+
+    g_Dop.timers[10] = 4;
+    if (DOPPLEGANGER.step_s >= 0x40) {
+        return 0;
+    }
+
+    animBase = 0x5D;
+    switch (DOPPLEGANGER.step) {
+    case 1:
+        var_s4 = playerAnimOffset;
+        SetPlayerAnim(animBase + var_s4);
+        break;
+    case 3:
+        var_s4 = 2;
+        if (DOPPLEGANGER.step_s == 2) {
+            var_s4 = playerAnimOffset;
+            SetPlayerStep(1);
+        }
+        SetPlayerAnim(animBase + var_s4);
+        break;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010ED54);
 
@@ -183,11 +286,86 @@ INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6040);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_80111CC0);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6654);
+void func_us_801C6654(void) {
+    s32 anim;
+    u16 var_s0;
+
+    var_s0 = 3;
+    anim = 0;
+    if (g_Dop.vram_flag & 0x20) {
+        anim = 1;
+    }
+
+    if (func_us_801C6040(0x4301C) == 0) {
+        DecelerateX(FIX(0.125));
+        switch (DOPPLEGANGER.step_s) {
+        case 0:
+        case 2:
+            break;
+        case 1:
+            var_s0 = 1;
+            if (!(g_Dop.padPressed & PAD_UP)) {
+                var_s0 = 5;
+            }
+            break;
+        case 3:
+            var_s0 = 0;
+            if (DOPPLEGANGER.animFrameIdx > 3) {
+                var_s0 = 1;
+            }
+            if (DOPPLEGANGER.animFrameIdx > 6 ||
+                DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 7;
+            }
+            break;
+        case 0x40:
+        case 0x41:
+        case 0x42:
+            func_us_801C5354(1, 1);
+            if (DOPPLEGANGER.animFrameIdx < g_Dop.unk54) {
+                var_s0 = 0;
+            } else {
+                g_Dop.unk46 &= 0x7FFF;
+                var_s0 = 0x1B;
+                if (DOPPLEGANGER.animFrameDuration < 0) {
+                    var_s0 = 0xF;
+                }
+            }
+            break;
+        case 0x51:
+
+            func_us_801C5354(1, 1);
+            var_s0 = 0;
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0xF;
+            }
+
+            break;
+        }
+
+        if (var_s0 & 4) {
+            func_8010E570(0);
+            var_s0 |= 0x8000;
+        }
+        if (var_s0 & 2 && g_Dop.padPressed & PAD_UP && !g_Dop.unk48) {
+            SetPlayerAnim(anim);
+            DOPPLEGANGER.step_s = 1;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 1 && CheckMoveDirection() != 0) {
+            func_8010E6AC(0);
+            var_s0 |= 0x8000;
+        }
+        if (var_s0 & 0x8000 && var_s0 & 8) {
+            func_8010FAF4();
+        }
+    }
+}
 
 void PlayerStepWalk(void) {
     if (func_us_801C6040(0x4301C) == 0) {
-        SetSpeedX(0x18000);
+        SetSpeedX(FIX(1.5));
         if (CheckMoveDirection() == 0) {
             func_8010E570(0);
         }
@@ -198,4 +376,100 @@ INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C68D0);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6BA0);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6BE8);
+void func_us_801C6BE8(void) {
+    s32 anim;
+    s16 var_s0;
+    u8 _pad[40]; // any size between 33-40 (inclusive);
+
+    var_s0 = 0;
+    // n.b.! much of this code is copied from `func_us_801C6654`,
+    // but this variable is not used in this version of the function
+    anim = 0;
+    if (g_Dop.vram_flag & 0x20) {
+        anim = 1;
+    }
+
+    if (func_us_801C6040(0x100C) == 0) {
+        DecelerateX(FIX(0.125));
+        switch (DOPPLEGANGER.step_s) {
+        case 0:
+            var_s0 = 6;
+            break;
+
+        case 1:
+            if (!(g_Dop.padPressed & PAD_DOWN)) {
+                // n.b.! var_s0 is set, but never used
+                var_s0 = 1;
+                SetPlayerAnim(0x13);
+                DOPPLEGANGER.step_s = 2;
+                DOPPLEGANGER.animFrameIdx = 1;
+                return;
+            }
+
+            if (DOPPLEGANGER.ext.player.anim == 0x65) {
+                DOPPLEGANGER.step_s = 0;
+            } else if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x20;
+            }
+            break;
+        case 3:
+        case 4:
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x20;
+            }
+            break;
+        case 2:
+            var_s0 = 1;
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                func_8010E570(0);
+            }
+            break;
+        case 0x40:
+        case 0x41:
+        case 0x42:
+            func_us_801C5354(1, 1);
+            if (DOPPLEGANGER.animFrameIdx < g_Dop.unk54) {
+                var_s0 = 0;
+            } else {
+                g_Dop.unk46 &= 0x7FFF;
+                var_s0 = 0xE;
+                if (DOPPLEGANGER.animFrameDuration < 0) {
+                    var_s0 = 0x2E;
+                }
+            }
+            break;
+        case 0x51:
+            func_us_801C5354(1, 1);
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x2E;
+            }
+            break;
+        }
+
+        if (var_s0 & 0x20) {
+            func_8010E470(0, 0);
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 2 && g_Dop.unk4C) {
+            SetPlayerAnim(0x14);
+            DOPPLEGANGER.step_s = 0;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 4 && !(g_Dop.padPressed & 0x4000)) {
+            SetPlayerAnim(0x13);
+            DOPPLEGANGER.step_s = 2;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 1 && CheckMoveDirection()) {
+            func_8010E6AC(0);
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 0x8000 && var_s0 & 8) {
+            func_8010FAF4();
+        }
+    }
+}

--- a/src/boss/bo4/unk_46E7C.c
+++ b/src/boss/bo4/unk_46E7C.c
@@ -197,7 +197,20 @@ INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C8F3C);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C93C4);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C95E4);
+extern s32 D_us_801D3D44;
+
+void PlayerStepSwordWarp(void) {
+    if (DOPPLEGANGER.step_s == 0) {
+        if (g_Entities[E_BOSS_WEAPON].entityId == E_NONE) {
+            D_us_801D3D44 = 0x10;
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(61, 0x15), 0);
+            DOPPLEGANGER.step_s++;
+        }
+    } else if (--D_us_801D3D44 == 0) {
+        DOPPLEGANGER.palette = PAL_OVL(0x200);
+        func_8010E570(0);
+    }
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C9694);
 
@@ -372,7 +385,29 @@ Entity* CreateEntFactoryFromEntity(
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801CA2AC);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801CA748);
+extern EInit D_us_80180434;
+
+void func_us_801CA748(Entity* self) {
+    if (DOPPLEGANGER.step != 6 || DOPPLEGANGER.step_s != 3) {
+        DestroyEntity(self);
+        return;
+    }
+
+    if (self->step == 0) {
+        InitializeEntity(D_us_80180434);
+        if (g_Dop.status & PLAYER_STATUS_POISON) {
+            self->attack /= 2;
+        }
+        self->hitboxOffX = 4;
+        self->step++;
+    }
+
+    self->flags =
+        FLAG_UNK_10000000 | FLAG_POS_CAMERA_LOCKED | FLAG_NOT_AN_ENEMY;
+    self->facingLeft = DOPPLEGANGER.facingLeft;
+    self->posY.i.hi = DOPPLEGANGER.posY.i.hi;
+    self->posX.i.hi = DOPPLEGANGER.posX.i.hi;
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801CA834);
 
@@ -1235,6 +1270,52 @@ INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801D0318);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801D0DE0);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801D162C);
+s32 UpdateUnarmedAnim(s8*, AnimationFrame*);
+extern EInit D_us_80180440;
+extern EInit D_us_8018044C;
+extern DopWeaponAnimation D_us_80184278[];
+
+// Similar to DRA's EntityUnarmedAttack
+void func_us_801D162C(Entity* self) {
+    EInit* var_a0;
+    s16 animIndex;
+    DopWeaponAnimation* anim;
+
+    animIndex = (self->params & 0x7FFF) >> 8;
+    self->posX.val = DOPPLEGANGER.posX.val;
+    self->posY.val = DOPPLEGANGER.posY.val;
+    self->facingLeft = DOPPLEGANGER.facingLeft;
+    anim = &D_us_80184278[animIndex];
+
+    if (DOPPLEGANGER.ext.player.anim < anim->frameStart ||
+        DOPPLEGANGER.ext.player.anim >= (anim->frameStart + 7) ||
+        !g_Dop.unk46) {
+        DestroyEntity(self);
+        return;
+    }
+
+    if (self->step == 0) {
+        var_a0 = &D_us_80180440;
+        if (animIndex != 0) {
+            var_a0 = &D_us_8018044C;
+        }
+        InitializeEntity(*var_a0);
+        if (g_Dop.status & PLAYER_STATUS_POISON) {
+            self->attack /= 2;
+        }
+        self->zPriority = DOPPLEGANGER.zPriority - 2;
+        self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
+        self->flags = FLAG_UNK_10000000 | FLAG_POS_CAMERA_LOCKED;
+        self->step = 1;
+    }
+    self->ext.weapon.anim = DOPPLEGANGER.ext.player.anim - anim->frameStart;
+    if (DOPPLEGANGER.animFrameDuration == 1 &&
+        DOPPLEGANGER.animFrameIdx == anim->soundFrame) {
+        g_api.PlaySfx(anim->soundId);
+    }
+    if (UpdateUnarmedAnim(anim->frameProps, anim->frames) < 0) {
+        DestroyEntity(self);
+    }
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801D17EC);

--- a/src/boss/doppleganger.h
+++ b/src/boss/doppleganger.h
@@ -26,6 +26,12 @@ typedef enum {
     /* 0x1A */ E_ID_1A,
     /* 0x1C */ E_ID_1C = 0x1C,
     /* 0x1D */ E_ID_1D,
+
+    /* 0x41 */ E_ID_41 = 0x41,
+    /* 0x42 */ E_ID_42 = 0x42,
+    /* 0x43 */ E_ID_43 = 0x43,
+
+    /* 0x60 */ E_ID_60 = 0x60,
 } EntityIDs;
 
 typedef enum {
@@ -41,3 +47,13 @@ typedef enum {
 } Doppleganger_Steps;
 
 extern PlayerState g_Dop;
+
+// this is similar to `WeaponAnimation` but
+// with fewer fields.
+typedef struct {
+    AnimationFrame* frames;
+    s8* frameProps;
+    u16 soundId;
+    u8 frameStart;
+    u8 soundFrame;
+} DopWeaponAnimation;

--- a/src/boss/rbo5/doppleganger.c
+++ b/src/boss/rbo5/doppleganger.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "common.h"
+#include "rbo5.h"
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/doppleganger", func_us_801C096C);
 
@@ -17,6 +17,157 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/doppleganger", func_us_801C2EC0);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/doppleganger", func_us_801C34EC);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/doppleganger", func_us_801C3AC8);
+extern Point16 D_us_80181338[];
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/doppleganger", func_us_801C3D10);
+void func_us_801C3AC8(void) {
+    Collider collider;
+
+    s16* dopY;
+    s16* dopX;
+    s32 effects;
+    s32 i;
+    u32* pVramFlag;
+
+    s16 offsetX, offsetY;
+
+    dopY = &DOPPLEGANGER.posY.i.hi;
+    dopX = &DOPPLEGANGER.posX.i.hi;
+
+    pVramFlag = &g_Dop.vram_flag;
+    effects =
+        g_Dop.unk04 & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                       EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID);
+    if (effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID)) {
+        *pVramFlag |= 4;
+        return;
+    }
+
+    for (i = 0; i < 7; i++) {
+        effects = g_Dop.colWall[i].effects &
+                  (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                   EFFECT_UNK_0002 | EFFECT_SOLID);
+        if ((effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                         EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                         EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID)) ||
+            (effects == (EFFECT_UNK_0002 | EFFECT_SOLID))) {
+
+            offsetX = *dopX + D_us_80181338[i].x + g_Dop.colWall[i].unk4 - 1;
+            offsetY = *dopY + D_us_80181338[i].y;
+            g_api.CheckCollision(offsetX, offsetY, &collider, 0);
+
+            if (!(collider.effects & EFFECT_SOLID)) {
+                *pVramFlag |= 4;
+                *dopX += g_Dop.colWall[i].unk4;
+                return;
+            }
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                EFFECT_UNK_8000 &&
+            i != 0 &&
+            ((g_Dop.colWall[0].effects & EFFECT_UNK_0800) ||
+             !(g_Dop.colWall[0].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 4;
+            *dopX += g_Dop.colWall[i].unk4;
+            return;
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                EFFECT_UNK_0800 &&
+            i != 6 &&
+            ((g_Dop.colWall[6].effects & EFFECT_UNK_8000) ||
+             !(g_Dop.colWall[6].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 4;
+            *dopX += g_Dop.colWall[i].unk4;
+            return;
+        }
+    }
+}
+
+void func_us_801C3D10(void) {
+    Collider collider;
+
+    s16* dopY;
+    s16* dopX;
+    s32 effects;
+    s32 i;
+    u32* pVramFlag;
+
+    s16 offsetX, offsetY;
+    dopY = &DOPPLEGANGER.posY.i.hi;
+    dopX = &DOPPLEGANGER.posX.i.hi;
+
+    pVramFlag = &g_Dop.vram_flag;
+    effects =
+        g_Dop.unk04 &
+        (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0800 |
+         EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID);
+    if (effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_0800 | EFFECT_UNK_0400 | EFFECT_UNK_0002 |
+                    EFFECT_SOLID) ||
+        effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                    EFFECT_UNK_0400 | EFFECT_UNK_0002 | EFFECT_SOLID)) {
+        *pVramFlag |= 8;
+        return;
+    }
+
+    for (i = 7; i < 14; i++) {
+        effects = g_Dop.colWall[i].effects &
+                  (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800 |
+                   EFFECT_UNK_0002 | EFFECT_SOLID);
+        if (effects == (EFFECT_UNK_8000 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_8000 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0800 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0800 | EFFECT_UNK_0002 | EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0002 |
+                        EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_4000 | EFFECT_UNK_0800 | EFFECT_UNK_0002 |
+                        EFFECT_SOLID) ||
+            effects == (EFFECT_UNK_0002 | EFFECT_SOLID)) {
+
+            offsetX = *dopX + D_us_80181338[i].x + g_Dop.colWall[i].unkC + 1;
+            offsetY = *dopY + D_us_80181338[i].y;
+            g_api.CheckCollision(offsetX, offsetY, &collider, 0);
+
+            if (!(collider.effects & EFFECT_SOLID)) {
+                *pVramFlag |= 8;
+                *dopX += g_Dop.colWall[i].unkC;
+                return;
+            }
+        }
+
+        if ((effects & (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+                (EFFECT_UNK_8000 | EFFECT_UNK_4000) &&
+            i != 7 &&
+            ((g_Dop.colWall[7].effects & EFFECT_UNK_0800) ||
+             !(g_Dop.colWall[7].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 8;
+            *dopX += g_Dop.colWall[i].unkC;
+            return;
+        }
+
+        if (((effects &
+              (EFFECT_UNK_8000 | EFFECT_UNK_4000 | EFFECT_UNK_0800)) ==
+             (EFFECT_UNK_4000 | EFFECT_UNK_0800)) &&
+            i != 13 &&
+            ((g_Dop.colWall[13].effects & EFFECT_UNK_8000) ||
+             !(g_Dop.colWall[13].effects &
+               (EFFECT_UNK_8000 | EFFECT_UNK_0800 | EFFECT_UNK_0002)))) {
+            *pVramFlag |= 8;
+            *dopX += g_Dop.colWall[i].unkC;
+            return;
+        }
+    }
+}

--- a/src/boss/rbo5/unk_44954.c
+++ b/src/boss/rbo5/unk_44954.c
@@ -5,7 +5,32 @@ extern PlayerState g_Dop;
 
 // n.b.! this file is the same as bo4/unk_45354.c
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C4954);
+extern s16 D_us_801D433E;
+
+// may be equivalent func_8010DFF0 in DRA
+void func_us_801C4954(s32 resetAnims, s32 arg1) {
+    Primitive* prim;
+
+    if (resetAnims) {
+        g_Entities[E_ID_41].ext.disableAfterImage.unk7D = 1;
+        g_Entities[E_ID_41].animCurFrame = g_Entities[E_ID_42].animCurFrame =
+            g_Entities[E_ID_43].animCurFrame = 0;
+        prim = &g_PrimBuf[g_Entities[1].primIndex];
+        while (prim != NULL) {
+            prim->x1 = 0;
+            prim = prim->next;
+        }
+    }
+    g_Entities[E_ID_41].ext.disableAfterImage.unk7C = 1;
+    g_Entities[E_ID_41].ext.disableAfterImage.unk7E = 0xA;
+    if (arg1 != 0) {
+        if (arg1 < 4) {
+            D_us_801D433E = 4;
+        } else {
+            D_us_801D433E = arg1;
+        }
+    }
+}
 
 void func_8010E0A8(void) {
     g_Entities[STAGE_ENTITY_START + UNK_ENTITY_1].ext.entSlot1.unk2 = 0;
@@ -144,7 +169,22 @@ void func_8010E6AC(bool forceAnim13) {
     }
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C4EE4);
+void func_us_801C4EE4(void) {
+    if (CheckMoveDirection() != 0) {
+        SetPlayerAnim(0x1A);
+        SetSpeedX(FIX(3.0 / 2.0));
+        g_Dop.unk44 = 0;
+    } else {
+        SetPlayerAnim(0x16);
+        DOPPLEGANGER.velocityX = 0;
+        g_Dop.unk44 = 4;
+    }
+    DOPPLEGANGER.velocityY = FIX(-4.875);
+    SetPlayerStep(5);
+    if (g_Dop.prev_step == 2) {
+        g_Dop.unk44 |= 0x10;
+    }
+}
 
 void func_us_801C4F90(void) {
     DOPPLEGANGER.velocityY = FIX(-4.25);
@@ -165,11 +205,74 @@ void func_us_801C4FDC(void) {
     g_Dop.unk44 = 0x10;
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C504C);
+void func_us_801C504C(void) {
+    if (CheckMoveDirection() != 0) {
+        SetSpeedX(0x30000);
+    } else {
+        DOPPLEGANGER.velocityX = 0;
+    }
+    SetPlayerStep(9);
+    DOPPLEGANGER.velocityY = FIX(-12);
+    SetPlayerAnim(0x21);
+    g_Dop.unk4A = 0;
+    g_Dop.unk44 &= 0xFFFE;
+    CreateEntFactoryFromEntity(g_CurrentEntity, 2, 0);
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010EA54);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5168);
+s32 func_us_801C5168(void) {
+    Entity* entity;
+    s32 i;
+    s32 entityCount;
+    s32 targetCount;
+    s32 animBase;
+    s32 playerAnimOffset;
+    s32 var_s4;
+
+    playerAnimOffset = 0;
+    if (!(g_Dop.padPressed & PAD_UP)) {
+        return 1;
+    }
+    if (g_Dop.vram_flag & 0x20) {
+        playerAnimOffset = 1;
+    }
+
+    targetCount = 3;
+    for (entity = &g_Entities[E_ID_60], i = 0, entityCount = 0; i < 16; i++,
+        entity++) {
+        if (entity->entityId == E_ID_14) {
+            entityCount++;
+        }
+        if (entityCount >= targetCount) {
+            return -1;
+        }
+    }
+
+    CreateEntFactoryFromEntity(g_CurrentEntity, 24, 0);
+
+    g_Dop.timers[10] = 4;
+    if (DOPPLEGANGER.step_s >= 0x40) {
+        return 0;
+    }
+
+    animBase = 0x5D;
+    switch (DOPPLEGANGER.step) {
+    case 1:
+        var_s4 = playerAnimOffset;
+        SetPlayerAnim(animBase + var_s4);
+        break;
+    case 3:
+        var_s4 = 2;
+        if (DOPPLEGANGER.step_s == 2) {
+            var_s4 = playerAnimOffset;
+            SetPlayerStep(1);
+        }
+        SetPlayerAnim(animBase + var_s4);
+        break;
+    }
+    return 0;
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010ED54);
 
@@ -183,11 +286,86 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5650);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_80111CC0);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5C64);
+void func_us_801C5C64(void) {
+    s32 anim;
+    u16 var_s0;
+
+    var_s0 = 3;
+    anim = 0;
+    if (g_Dop.vram_flag & 0x20) {
+        anim = 1;
+    }
+
+    if (func_us_801C5650(0x4301C) == 0) {
+        DecelerateX(FIX(0.125));
+        switch (DOPPLEGANGER.step_s) {
+        case 0:
+        case 2:
+            break;
+        case 1:
+            var_s0 = 1;
+            if (!(g_Dop.padPressed & PAD_UP)) {
+                var_s0 = 5;
+            }
+            break;
+        case 3:
+            var_s0 = 0;
+            if (DOPPLEGANGER.animFrameIdx > 3) {
+                var_s0 = 1;
+            }
+            if (DOPPLEGANGER.animFrameIdx > 6 ||
+                DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 7;
+            }
+            break;
+        case 0x40:
+        case 0x41:
+        case 0x42:
+            func_us_801C4954(1, 1);
+            if (DOPPLEGANGER.animFrameIdx < g_Dop.unk54) {
+                var_s0 = 0;
+            } else {
+                g_Dop.unk46 &= 0x7FFF;
+                var_s0 = 0x1B;
+                if (DOPPLEGANGER.animFrameDuration < 0) {
+                    var_s0 = 0xF;
+                }
+            }
+            break;
+        case 0x51:
+
+            func_us_801C4954(1, 1);
+            var_s0 = 0;
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0xF;
+            }
+
+            break;
+        }
+
+        if (var_s0 & 4) {
+            func_8010E570(0);
+            var_s0 |= 0x8000;
+        }
+        if (var_s0 & 2 && g_Dop.padPressed & PAD_UP && !g_Dop.unk48) {
+            SetPlayerAnim(anim);
+            DOPPLEGANGER.step_s = 1;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 1 && CheckMoveDirection() != 0) {
+            func_8010E6AC(0);
+            var_s0 |= 0x8000;
+        }
+        if (var_s0 & 0x8000 && var_s0 & 8) {
+            func_8010FAF4();
+        }
+    }
+}
 
 void PlayerStepWalk(void) {
     if (func_us_801C5650(0x4301C) == 0) {
-        SetSpeedX(0x18000);
+        SetSpeedX(FIX(1.5));
         if (CheckMoveDirection() == 0) {
             func_8010E570(0);
         }
@@ -198,4 +376,100 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5EE0);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C61B0);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C61F8);
+void func_us_801C61F8(void) {
+    s32 anim;
+    s16 var_s0;
+    u8 _pad[40]; // any size between 33-40 (inclusive);
+
+    var_s0 = 0;
+    // n.b.! much of this code is copied from `func_us_801C6654`,
+    // but this variable is not used in this version of the function
+    anim = 0;
+    if (g_Dop.vram_flag & 0x20) {
+        anim = 1;
+    }
+
+    if (func_us_801C5650(0x100C) == 0) {
+        DecelerateX(FIX(0.125));
+        switch (DOPPLEGANGER.step_s) {
+        case 0:
+            var_s0 = 6;
+            break;
+
+        case 1:
+            if (!(g_Dop.padPressed & PAD_DOWN)) {
+                // n.b.! var_s0 is set, but never used
+                var_s0 = 1;
+                SetPlayerAnim(0x13);
+                DOPPLEGANGER.step_s = 2;
+                DOPPLEGANGER.animFrameIdx = 1;
+                return;
+            }
+
+            if (DOPPLEGANGER.ext.player.anim == 0x65) {
+                DOPPLEGANGER.step_s = 0;
+            } else if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x20;
+            }
+            break;
+        case 3:
+        case 4:
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x20;
+            }
+            break;
+        case 2:
+            var_s0 = 1;
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                func_8010E570(0);
+            }
+            break;
+        case 0x40:
+        case 0x41:
+        case 0x42:
+            func_us_801C4954(1, 1);
+            if (DOPPLEGANGER.animFrameIdx < g_Dop.unk54) {
+                var_s0 = 0;
+            } else {
+                g_Dop.unk46 &= 0x7FFF;
+                var_s0 = 0xE;
+                if (DOPPLEGANGER.animFrameDuration < 0) {
+                    var_s0 = 0x2E;
+                }
+            }
+            break;
+        case 0x51:
+            func_us_801C4954(1, 1);
+            if (DOPPLEGANGER.animFrameDuration < 0) {
+                var_s0 = 0x2E;
+            }
+            break;
+        }
+
+        if (var_s0 & 0x20) {
+            func_8010E470(0, 0);
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 2 && g_Dop.unk4C) {
+            SetPlayerAnim(0x14);
+            DOPPLEGANGER.step_s = 0;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 4 && !(g_Dop.padPressed & PAD_DOWN)) {
+            SetPlayerAnim(0x13);
+            DOPPLEGANGER.step_s = 2;
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 1 && CheckMoveDirection()) {
+            func_8010E6AC(0);
+            var_s0 |= 0x8000;
+        }
+
+        if (var_s0 & 0x8000 && var_s0 & 8) {
+            func_8010FAF4();
+        }
+    }
+}

--- a/src/boss/rbo5/unk_44954.c
+++ b/src/boss/rbo5/unk_44954.c
@@ -207,7 +207,7 @@ void func_us_801C4FDC(void) {
 
 void func_us_801C504C(void) {
     if (CheckMoveDirection() != 0) {
-        SetSpeedX(0x30000);
+        SetSpeedX(FIX(3));
     } else {
         DOPPLEGANGER.velocityX = 0;
     }

--- a/src/boss/rbo5/unk_4648C.c
+++ b/src/boss/rbo5/unk_4648C.c
@@ -195,7 +195,20 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C854C);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C89D4);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", PlayerStepSwordWarp);
+extern s32 D_us_801D331C;
+
+void PlayerStepSwordWarp(void) {
+    if (DOPPLEGANGER.step_s == 0) {
+        if (g_Entities[E_BOSS_WEAPON].entityId == E_NONE) {
+            D_us_801D331C = 0x10;
+            CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(61, 0x15), 0);
+            DOPPLEGANGER.step_s++;
+        }
+    } else if (--D_us_801D331C == 0) {
+        DOPPLEGANGER.palette = PAL_OVL(0x200);
+        func_8010E570(0);
+    }
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C8CA4);
 
@@ -369,7 +382,29 @@ Entity* CreateEntFactoryFromEntity(
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C98BC);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C9D58);
+extern EInit D_us_80180448;
+
+void func_us_801C9D58(Entity* self) {
+    if (DOPPLEGANGER.step != 6 || DOPPLEGANGER.step_s != 3) {
+        DestroyEntity(self);
+        return;
+    }
+
+    if (self->step == 0) {
+        InitializeEntity(D_us_80180448);
+        if (g_Dop.status & PLAYER_STATUS_POISON) {
+            self->attack /= 2;
+        }
+        self->hitboxOffX = 4;
+        self->step++;
+    }
+
+    self->flags =
+        FLAG_UNK_10000000 | FLAG_POS_CAMERA_LOCKED | FLAG_NOT_AN_ENEMY;
+    self->facingLeft = DOPPLEGANGER.facingLeft;
+    self->posY.i.hi = DOPPLEGANGER.posY.i.hi;
+    self->posX.i.hi = DOPPLEGANGER.posX.i.hi;
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_8011B5A4);
 
@@ -1234,6 +1269,52 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801CF8C4);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801D038C);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801D0BD8);
+s32 UpdateUnarmedAnim(s8*, AnimationFrame*);
+extern EInit D_us_80180454;
+extern EInit D_us_80180460;
+extern DopWeaponAnimation D_us_80184304[];
+
+// Similar to DRA's EntityUnarmedAttack
+void func_us_801D0BD8(Entity* self) {
+    EInit* var_a0;
+    s16 animIndex;
+    DopWeaponAnimation* anim;
+
+    animIndex = (self->params & 0x7FFF) >> 8;
+    self->posX.val = DOPPLEGANGER.posX.val;
+    self->posY.val = DOPPLEGANGER.posY.val;
+    self->facingLeft = DOPPLEGANGER.facingLeft;
+    anim = &D_us_80184304[animIndex];
+
+    if (DOPPLEGANGER.ext.player.anim < anim->frameStart ||
+        DOPPLEGANGER.ext.player.anim >= (anim->frameStart + 7) ||
+        !g_Dop.unk46) {
+        DestroyEntity(self);
+        return;
+    }
+
+    if (self->step == 0) {
+        var_a0 = &D_us_80180454;
+        if (animIndex != 0) {
+            var_a0 = &D_us_80180460;
+        }
+        InitializeEntity(*var_a0);
+        if (g_Dop.status & PLAYER_STATUS_POISON) {
+            self->attack /= 2;
+        }
+        self->zPriority = DOPPLEGANGER.zPriority - 2;
+        self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
+        self->flags = FLAG_UNK_10000000 | FLAG_POS_CAMERA_LOCKED;
+        self->step = 1;
+    }
+    self->ext.weapon.anim = DOPPLEGANGER.ext.player.anim - anim->frameStart;
+    if (DOPPLEGANGER.animFrameDuration == 1 &&
+        DOPPLEGANGER.animFrameIdx == anim->soundFrame) {
+        g_api.PlaySfx(anim->soundId);
+    }
+    if (UpdateUnarmedAnim(anim->frameProps, anim->frames) < 0) {
+        DestroyEntity(self);
+    }
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801D0D98);

--- a/src/dra/6DF70.c
+++ b/src/dra/6DF70.c
@@ -19,7 +19,7 @@ void func_8010DFF0(s32 resetAnims, s32 arg1) {
     s32 i;
 
     if (resetAnims) {
-        g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7E = 1;
+        g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7D = 1;
         g_Entities[UNK_ENTITY_1].animCurFrame =
             g_Entities[UNK_ENTITY_2].animCurFrame =
                 g_Entities[UNK_ENTITY_3].animCurFrame = 0;
@@ -32,7 +32,7 @@ void func_8010DFF0(s32 resetAnims, s32 arg1) {
     }
 
     g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7C = 1;
-    g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk80 = 10;
+    g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7E = 10;
 
     if (arg1) {
         if (arg1 < 4) {

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -3298,7 +3298,7 @@ void PlayerStepSwordWarp(void) {
             PLAYER.step_s++;
         }
     } else if (--D_80138008 == 0) {
-        PLAYER.palette = 0x8100;
+        PLAYER.palette = PAL_OVL(0x100);
         func_8010E570(0);
     }
 }

--- a/src/ric/pl_utils.c
+++ b/src/ric/pl_utils.c
@@ -207,7 +207,7 @@ void DisableAfterImage(s32 resetAnims, s32 arg1) {
     FntPrint("op disable\n");
 #endif
     if (resetAnims) {
-        g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7E = 1;
+        g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7D = 1;
         g_Entities[UNK_ENTITY_1].animCurFrame =
             g_Entities[UNK_ENTITY_2].animCurFrame =
                 g_Entities[UNK_ENTITY_3].animCurFrame = 0;
@@ -218,7 +218,7 @@ void DisableAfterImage(s32 resetAnims, s32 arg1) {
         }
     }
     g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7C = 1;
-    g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk80 = 0xA;
+    g_Entities[UNK_ENTITY_1].ext.disableAfterImage.unk7E = 0xA;
     if (arg1) {
         g_Player.timers[PL_T_AFTERIMAGE_DISABLE] = 4;
     }

--- a/src/st/lib/unk_3B53C.c
+++ b/src/st/lib/unk_3B53C.c
@@ -38,7 +38,7 @@ void func_us_801BB53C(Entity* self) {
             DestroyEntity(self);
             return;
         }
-        tempEntity = &g_Entities[UNK_ENTITY_50];
+        tempEntity = &g_Entities[E_BOSS_WEAPON];
         CreateEntityFromCurrentEntity(E_ID(ID_1F), tempEntity);
         tempEntity->posX.i.hi = 0x200 - g_Tilemap.scrollX.i.hi;
         tempEntity->posY.i.hi = 0x2A0 - g_Tilemap.scrollY.i.hi;


### PR DESCRIPTION
Matching 11 additional functions across both `BO4` and `RBO5`.

A small change to `ET_DisableAfterImage` which appears to be used for Doppleganger as well. The names and comments did not match the offsets.

Some minor cleanup for things encountered while looking for similar or matching code.