### PR TITLE
Improve Docker support

### DIFF
--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -1,0 +1,18 @@
+name: Build Docker image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+      - 'tools/**'
+      - 'Makefile*'
+  workflow_dispatch:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build image
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,39 @@
-# build container and tag it as sotn-build:latest
-# docker build --tag sotn-build:latest --build-arg USER=$USER .
-
-# launch container and mount current directory under /sotn
-# docker run --rm -it -v $(pwd):/sotn sotn-build /bin/bash
+# HOW TO USE THIS DOCKERFILE
+#
+# 1. build image and tag it as sotn-build:latest
+# docker build --tag sotn-build:latest .
+#
+# 2. launch container and mount current directory under /sotn
+# docker run --name sotn-work -it -v $(pwd):/sotn -v sotn_venv:/sotn/.venv -v sotn_build:/sotn/build sotn-build
+#
+# 3. inside the container, sym-link the .venv dir and perform an update
+# python3 -m venv .venv
+# source .venv/bin/activate
+# make update-dependencies
+#
+# 4. you now prepared an image that can help you build and work SOTN
+# make -j extract && make -j -O build && make expected
+#
+# 5. from now on, to re-use the same container execute the following:
+# docker start -ai sotn-work
 
 # make extract -j && make build -j
-FROM ubuntu:22.04
-ADD /tools/requirements-debian.txt /tools/requirements-debian.txt
-RUN apt-get update && apt-get install -y $(cat /tools/requirements-debian.txt)
+FROM ubuntu:noble
+COPY /tools/requirements-debian.txt /tools/requirements-debian.txt
+RUN apt-get update && \
+    apt-get install -y $(cat /tools/requirements-debian.txt) && \
+    git clone --depth 1 https://github.com/sozud/dosemu-deb.git /dosemu && \
+    dpkg -i /dosemu/fdpp_1.6-1_amd64.deb && \
+    dpkg -i /dosemu/fdpp-dev_1.6-1_amd64.deb && \
+    dpkg -i /dosemu/comcom32_0.1~alpha3-1_all.deb && \
+    dpkg -i /dosemu/dosemu2_2.0~pre9-1_amd64.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /sotn
-ARG USER
-RUN adduser ${USER}
-ENV VENV_PATH=/tools/.venv
-RUN mkdir -p ${VENV_PATH}
-RUN chown ${USER} /sotn ${VENV_PATH}
-USER ${USER}
-# this is similar to `make python-dependencies`, however,
-# the Makefile is not available until a container has
-# been created.
-ADD tools/requirements-python.txt /tools/requirements-python.txt
-RUN python3 -m venv ${VENV_PATH} && \
-    . ${VENV_PATH}/bin/activate && \
-    pip install -r /tools/requirements-python.txt
+RUN chown ubuntu:ubuntu /sotn
+USER ubuntu
+RUN mkdir -p /sotn/.venv /sotn/build
+
 RUN git config --global --add safe.directory /sotn
+ENTRYPOINT ["/bin/bash"]

--- a/tools/requirements-debian.txt
+++ b/tools/requirements-debian.txt
@@ -8,6 +8,7 @@ coreutils
 curl
 gcc-mipsel-linux-gnu
 git
+libelf-dev
 make
 p7zip-full
 python3-pip
@@ -15,4 +16,3 @@ python3-venv
 unzip
 wget
 xfonts-utils
-./tools/dosemu-deb/*.deb


### PR DESCRIPTION
Enhance the SOTN Decomp experience with Docker. This is a full break-down of the changes:
* Enhance the instruction steps to build the image.
* Use default `ubuntu:ubuntu` user. It should map directly to 1000:1000 from the host, without messing with new users and permissions. There was a problem where the container used a mix of two users, causing various "permission denied".
* The installation of dosemu2 was broken, it is now fixed.
* The Python set-up step is now removed from the build image step and moved in a later stage. This is now done in the container itself with `make update-dependencies`.
* Added a `/sotn/.venv` overlay, so it will not conflict with the native `.venv` folder (if this is present). This allows me to use concurrently both .venv from Arch Linux and the containerised one from Ubuntu without them to collide.
* Added a `/sotn/build` overlay to avoid back and forth between the host and the container. This improves the build speed on macOS and Windows, as Docker Desktop uses a VM under the hood.
* Make clear that a container can be stopped and resumed any time, without having to re-configure it again from scratch.