### PR TITLE
Consolidating Several Decomp.me Scratches for `BO4` and `RBO5`

### DIFF
--- a/src/boss/bo4/unk_45354.c
+++ b/src/boss/bo4/unk_45354.c
@@ -74,7 +74,16 @@ s32 CheckMoveDirection(void) {
     return 0;
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C55A8);
+s32 func_us_801C55A8(s32 minX, s32 maxX) {
+    if (DOPPLEGANGER.step == 1 && DOPPLEGANGER.step == DOPPLEGANGER.step_s) {
+        if (DOPPLEGANGER.posX.i.hi >= minX) {
+            if (maxX >= DOPPLEGANGER.posX.i.hi) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
 
 #include "../../set_speed_x.h"
 
@@ -85,7 +94,16 @@ void func_8010E3B8(s32 velocityX) {
     DOPPLEGANGER.velocityX = velocityX;
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010E470);
+extern u8 D_us_80181318[][2];
+void func_8010E470(s32 arg0, s32 velocityX) {
+    s32 unused_stack[2];
+
+    DOPPLEGANGER.velocityX = velocityX;
+    DOPPLEGANGER.velocityY = 0;
+    DOPPLEGANGER.step = 3;
+    DOPPLEGANGER.step_s = D_us_80181318[arg0][0];
+    SetPlayerAnim(D_us_80181318[arg0][1]);
+}
 
 extern u8 D_us_80181320[];
 
@@ -219,7 +237,18 @@ void func_us_801C5A4C(void) {
     CreateEntFactoryFromEntity(g_CurrentEntity, 2, 0);
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010EA54);
+extern s16 D_us_8018132C[];
+
+void func_8010EA54(s32 arg0) {
+    s16 temp_hi;
+
+    if (arg0 != 0) {
+        temp_hi = rand() % arg0;
+        if (temp_hi < 4) {
+            g_api.PlaySfx(D_us_8018132C[temp_hi]);
+        }
+    }
+}
 
 s32 func_us_801C5B68(void) {
     Entity* entity;
@@ -274,17 +303,41 @@ s32 func_us_801C5B68(void) {
     return 0;
 }
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010ED54);
+void func_8010ED54(u8 anim) {
+    DOPPLEGANGER.velocityX = DOPPLEGANGER.velocityY = 0;
+    SetPlayerStep(16);
+    SetPlayerAnim(anim);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(61, 20), 0);
+    g_Dop.unk48 = 0;
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C5CF8);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_8010FAF4);
+void func_8010FAF4(void) {
+    Entity* ent = &g_Entities[E_ID_50];
+    DestroyEntity(ent);
+    g_Dop.unk46 = 0;
+}
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C5FDC);
+void func_us_801C5FDC(void) {
+    DOPPLEGANGER.step = 1;
+    DOPPLEGANGER.step_s = 3;
+    SetSpeedX(FIX(-3.5));
+    g_CurrentEntity->velocityY = FIX(0.0);
+    SetPlayerAnim(0xDB);
+    CreateEntFactoryFromEntity(g_CurrentEntity, 0, 0);
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6040);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_80111CC0);
+void func_80111CC0(void) {
+    if (g_Dop.timers[1] != 0) {
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x2C, 0x17), 0);
+    }
+    if (g_Dop.timers[0] != 0) {
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x2C, 0x16), 0);
+    }
+}
 
 void func_us_801C6654(void) {
     s32 anim;
@@ -373,7 +426,14 @@ void PlayerStepWalk(void) {
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C68D0);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_45354", func_us_801C6BA0);
+void func_us_801C6BA0(void) {
+    if (func_us_801C6040(0x9029) == 0) {
+        DecelerateX(FIX(1.0 / 16.0));
+        if (CheckMoveDirection() != 0) {
+            SetSpeedX(FIX(3.0 / 4.0));
+        }
+    }
+}
 
 void func_us_801C6BE8(void) {
     s32 anim;

--- a/src/boss/bo4/unk_46E7C.c
+++ b/src/boss/bo4/unk_46E7C.c
@@ -191,7 +191,14 @@ INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C8224);
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C8CE0);
 
-INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C8EE4);
+s32 func_us_801C8EE4(void) {
+    if ((DOPPLEGANGER.step_s == 0) || !(g_Dop.padTapped & PAD_R2)) {
+        return false;
+    }
+    CheckMoveDirection();
+    SetPlayerStep(15);
+    return true;
+}
 
 INCLUDE_ASM("boss/bo4/nonmatchings/unk_46E7C", func_us_801C8F3C);
 

--- a/src/boss/doppleganger.h
+++ b/src/boss/doppleganger.h
@@ -31,6 +31,8 @@ typedef enum {
     /* 0x42 */ E_ID_42 = 0x42,
     /* 0x43 */ E_ID_43 = 0x43,
 
+    /* 0x50 */ E_ID_50 = 0x50,
+
     /* 0x60 */ E_ID_60 = 0x60,
 } EntityIDs;
 

--- a/src/boss/rbo5/unk_44954.c
+++ b/src/boss/rbo5/unk_44954.c
@@ -74,7 +74,16 @@ s32 CheckMoveDirection(void) {
     return 0;
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C4BA8);
+s32 func_us_801C4BA8(s32 minX, s32 maxX) {
+    if (DOPPLEGANGER.step == 1 && DOPPLEGANGER.step == DOPPLEGANGER.step_s) {
+        if (DOPPLEGANGER.posX.i.hi >= minX) {
+            if (maxX >= DOPPLEGANGER.posX.i.hi) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
 
 #include "../../set_speed_x.h"
 
@@ -85,7 +94,16 @@ void func_8010E3B8(s32 velocityX) {
     DOPPLEGANGER.velocityX = velocityX;
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010E470);
+extern u8 D_us_801813A4[][2];
+void func_8010E470(s32 arg0, s32 velocityX) {
+    s32 unused_stack[2];
+
+    DOPPLEGANGER.velocityX = velocityX;
+    DOPPLEGANGER.velocityY = 0;
+    DOPPLEGANGER.step = 3;
+    DOPPLEGANGER.step_s = D_us_801813A4[arg0][0];
+    SetPlayerAnim(D_us_801813A4[arg0][1]);
+}
 
 extern u8 D_us_801813AC[];
 
@@ -219,7 +237,18 @@ void func_us_801C504C(void) {
     CreateEntFactoryFromEntity(g_CurrentEntity, 2, 0);
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010EA54);
+extern s16 D_us_801813B8[];
+
+void func_8010EA54(s32 arg0) {
+    s16 temp_hi;
+
+    if (arg0 != 0) {
+        temp_hi = rand() % arg0;
+        if (temp_hi < 4) {
+            g_api.PlaySfx(D_us_801813B8[temp_hi]);
+        }
+    }
+}
 
 s32 func_us_801C5168(void) {
     Entity* entity;
@@ -274,17 +303,41 @@ s32 func_us_801C5168(void) {
     return 0;
 }
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010ED54);
+void func_8010ED54(u8 anim) {
+    DOPPLEGANGER.velocityX = DOPPLEGANGER.velocityY = 0;
+    SetPlayerStep(16);
+    SetPlayerAnim(anim);
+    CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(61, 20), 0);
+    g_Dop.unk48 = 0;
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C52F8);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_8010FAF4);
+void func_8010FAF4(void) {
+    Entity* ent = &g_Entities[E_ID_50];
+    DestroyEntity(ent);
+    g_Dop.unk46 = 0;
+}
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C55EC);
+void func_us_801C55EC(void) {
+    DOPPLEGANGER.step = 1;
+    DOPPLEGANGER.step_s = 3;
+    SetSpeedX(FIX(-3.5));
+    g_CurrentEntity->velocityY = FIX(0.0);
+    SetPlayerAnim(0xDB);
+    CreateEntFactoryFromEntity(g_CurrentEntity, 0, 0);
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5650);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_80111CC0);
+void func_80111CC0(void) {
+    if (g_Dop.timers[1] != 0) {
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x2C, 0x17), 0);
+    }
+    if (g_Dop.timers[0] != 0) {
+        CreateEntFactoryFromEntity(g_CurrentEntity, FACTORY(0x2C, 0x16), 0);
+    }
+}
 
 void func_us_801C5C64(void) {
     s32 anim;
@@ -373,7 +426,14 @@ void PlayerStepWalk(void) {
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C5EE0);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_44954", func_us_801C61B0);
+void func_us_801C61B0(void) {
+    if (func_us_801C5650(0x9029) == 0) {
+        DecelerateX(FIX(1.0 / 16.0));
+        if (CheckMoveDirection() != 0) {
+            SetSpeedX(FIX(3.0 / 4.0));
+        }
+    }
+}
 
 void func_us_801C61F8(void) {
     s32 anim;

--- a/src/boss/rbo5/unk_4648C.c
+++ b/src/boss/rbo5/unk_4648C.c
@@ -189,7 +189,14 @@ INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C7834);
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C82F0);
 
-INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C84F4);
+s32 func_us_801C84F4(void) {
+    if ((DOPPLEGANGER.step_s == 0) || !(g_Dop.padTapped & PAD_R2)) {
+        return false;
+    }
+    CheckMoveDirection();
+    SetPlayerStep(15);
+    return true;
+}
 
 INCLUDE_ASM("boss/rbo5/nonmatchings/unk_4648C", func_us_801C854C);
 


### PR DESCRIPTION
Most of this work was done by @PancakeFriday, Bossy Dragonfly (anon), and @joshlory. I just updated symbols based on master and applied the necessary changes for `RBO5` as well.

* `func_8010FAF4` - @PancakeFriday - https://decomp.me/scratch/0QNbK
* `func_us_801C6BA0` - Bossy Dragonfly (anon) - https://decomp.me/scratch/5m4NA
* `func_us_801C55A8` @PancakeFriday - https://decomp.me/scratch/Z2JGN
* `func_us_801C8EE4` - Bossy Dragonfly - https://decomp.me/scratch/31xdM
* `func_8010E470` - @PancakeFriday - https://decomp.me/scratch/H7nCT
* `func_8010ED54` - @PancakeFriday - https://decomp.me/scratch/CgqPe
* `func_us_801C5FDC` - @PancakeFriday - https://decomp.me/scratch/tbs1F
* `func_80111CC0` - @PancakeFriday - https://decomp.me/scratch/RSFqt
* `func_80111CC0` - @PancakeFriday - https://decomp.me/scratch/RSFqt
* `func_8010EA54` - @joshlory - https://decomp.me/scratch/GcA1Y


Co-authored-by: Bossy Dragonfly (anon)