### PR TITLE
Couple of NO4 functions

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -3015,6 +3015,14 @@ typedef struct {
     /* 0x88 */ s16 unk88;
 } ET_801C801C;
 
+typedef struct {
+    /* 0x7C */ u16 waterHeight;
+    /* 0x7E */ struct Entity* entity7E;
+    /* 0x82 */ struct Entity* entity82;
+    /* 0x86 */ u8 pad86[8];
+    /* 0x90 */ u16 unk90;
+} ET_WaterAlcove;
+
 typedef union { // offset=0x7C
     struct Primitive* prim;
     ET_Placeholder ILLEGAL;
@@ -3276,6 +3284,7 @@ typedef union { // offset=0x7C
     ET_Fishhead fishhead;
     ET_KillerFish killerFish;
     ET_801C801C et_801C801C;
+    ET_WaterAlcove et_waterAlcove;
 } Ext;
 
 #define SYNC_FIELD(struct1, struct2, field)                                    \

--- a/include/entity.h
+++ b/include/entity.h
@@ -3005,6 +3005,16 @@ typedef struct {
     /* 0x80 */ u32 swimCount;
 } ET_KillerFish;
 
+typedef struct {
+    /* 0x7C */ s16 unk7C;
+    /* 0x7E */ s16 unk7E;
+    /* 0x80 */ s16 unk80;
+    /* 0x82 */ s16 : 16;
+    /* 0x84 */ s16 : 16;
+    /* 0x86 */ s16 : 16;
+    /* 0x88 */ s16 unk88;
+} ET_801C801C;
+
 typedef union { // offset=0x7C
     struct Primitive* prim;
     ET_Placeholder ILLEGAL;
@@ -3265,6 +3275,7 @@ typedef union { // offset=0x7C
     ET_FrogToad frogToad;
     ET_Fishhead fishhead;
     ET_KillerFish killerFish;
+    ET_801C801C et_801C801C;
 } Ext;
 
 #define SYNC_FIELD(struct1, struct2, field)                                    \

--- a/include/sfx.h
+++ b/include/sfx.h
@@ -290,6 +290,7 @@ enum SfxModes {
 // STAGE NO4
 #define SFX_TOAD_CROAK 0x71A
 #define SFX_FROG_CROAK 0x71B
+#define SFX_WATER_BUBBLE 0x7C4
 
 // BOSS BO4 - Doppleganger10 / RBO5 - Doppleganger40
 #define SFX_BO4_UNK_7D7 0x7D7

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -41,7 +41,6 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4738);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4980);
 
-
 void func_us_801C4BD8(Entity* self) {
     Tilemap* tmap;
     s16* dataPtr;
@@ -80,7 +79,6 @@ void func_us_801C4BD8(Entity* self) {
     g_api_PlaySfxVolPan(0x797, offsetX, *dataPtr++);
     D_us_80181108 = 1;
 }
-
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4D2C);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -151,7 +151,62 @@ void func_us_801C5518(Entity* self) {
     }
 }
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C5628);
+extern s32 D_80072F20; // Player's collision detection
+extern Primitive D_us_80181644;
+
+// Function that runs when the player is in the switch room to activate the
+// skeleton ape that can destroy the bridge in underground caverns. Location
+// here (X: 21, Y: 33)
+// https://guides.gamercorner.net/sotn/areas/underground-caverns
+void func_us_801C5628(Entity* self) {
+    Entity* newEnt;
+
+    if (self->step == 0) {
+        InitializeEntity(g_EInitInteractable);
+        self->animSet = ANIMSET_OVL(1);
+        self->animCurFrame = 40;
+        if (g_CastleFlags[NO4_SKELETON_APE_AND_BRIDGE] == 0) {
+            self->posX.i.hi = 52;
+        } else {
+            self->posX.i.hi = 44;
+        }
+    }
+
+    // Idk why it wants to store the entity before but it works so ¯\_(ツ)_/¯
+    newEnt = g_Entities;
+
+    if ((((GetPlayerCollisionWith(self, 8, 16, 5) & 1) && (D_80072F20 & 1)) &&
+         (g_pads->pressed & PAD_LEFT)) &&
+        (PLAYER.step == 1)) {
+        if (self->ext.skeletonApe.unk7C != 0) { // ext.xxx.unk7C
+            self->ext.skeletonApe.unk7C--;
+        } else {
+            if (self->posX.i.hi >= 45) {
+                self->posX.i.hi--;
+                PLAYER.posX.i.hi--;
+                if (self->posX.i.hi == 44) {
+                    g_CastleFlags[NO4_SKELETON_APE_AND_BRIDGE] = 1;
+                    PlaySfxPositional(SFX_SWITCH_CLICK);
+                    self->step++;
+                }
+            }
+            self->ext.skeletonApe.unk7C = 2;
+        }
+    }
+
+    if ((self->step == 2) && (newEnt->posX.i.hi >= 129)) {
+        g_api.PlaySfxVolPan(SFX_WALL_DEBRIS_A, 127, 8);
+        newEnt = AllocEntity(&g_Entities[224], &g_Entities[256]);
+        if (newEnt != 0) {
+            CreateEntityFromCurrentEntity(14, newEnt);
+            newEnt->posX.i.hi = 128;
+            newEnt->posY.i.hi = 176;
+            newEnt->ext.prim = &D_us_80181644;
+            newEnt->params = 0x100;
+        }
+        self->step++;
+    }
+}
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C582C);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -37,7 +37,81 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4228);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4520);
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4738);
+extern s16 D_us_801811D6;  // Final water level's surface height
+extern s16 D_us_801812B8;  // Final water level's background height
+extern u8 D_us_80181588[]; // Water flow animation that needs to be blocked by
+                           // the crate
+
+// Does something with the water level that kills the 4 spear guards in the
+// alcove
+void func_us_801C4738(Entity* self) {
+    Entity* newEnt;
+
+    if (self->step == 0) {
+        InitializeEntity(g_EInitInteractable);
+        self->animSet = ANIMSET_OVL(1);
+        self->palette = 68;
+        self->drawFlags = FLAG_DRAW_UNK10;
+        self->posX.i.hi = 0x711 - g_Tilemap.scrollX.i.hi;
+        if (g_CastleFlags[NO4_WATER_BLOCKED] != 0) {
+            self->ext.et_waterAlcove.waterHeight = 64;
+        } else {
+            newEnt = AllocEntity(&g_Entities[224], &g_Entities[256]);
+            if (newEnt != NULL) {
+                CreateEntityFromCurrentEntity(39, newEnt);
+                newEnt->params = 1;
+            }
+            self->ext.et_waterAlcove.entity7E = newEnt;
+
+            newEnt = AllocEntity(newEnt, &g_Entities[256]);
+            if (newEnt != NULL) {
+                CreateEntityFromCurrentEntity(38, newEnt);
+                newEnt->params = 1;
+            }
+            self->ext.et_waterAlcove.entity82 = newEnt;
+            self->ext.et_waterAlcove.waterHeight = 0;
+        }
+    }
+
+    // Animates the small flow of water that needs to be blocked by the crate
+    AnimateEntity(D_us_80181588, self);
+
+    if (g_CastleFlags[NO4_WATER_BLOCKED] != 0) {
+        if (self->ext.et_waterAlcove.waterHeight < 64) {
+            if (!(self->ext.et_waterAlcove.unk90 & 0x7)) {
+                if (self->ext.et_waterAlcove.waterHeight == 0) {
+                    g_api_PlaySfx(SFX_WATER_BUBBLE);
+                }
+                self->ext.et_waterAlcove.waterHeight++;
+                if (self->ext.et_waterAlcove.waterHeight == 20) {
+                    g_CastleFlags[NO4_WATER_BLOCKED]++;
+                }
+                if (self->ext.et_waterAlcove.waterHeight == 52) {
+                    g_CastleFlags[NO4_WATER_BLOCKED]++;
+                }
+            }
+            self->ext.et_waterAlcove.unk90++;
+        }
+
+        if (self->ext.et_waterAlcove.entity7E != 0) {
+            DestroyEntity(self->ext.et_waterAlcove.entity7E);
+            self->ext.et_waterAlcove.entity7E = NULL;
+        }
+
+        if (self->ext.et_waterAlcove.entity82 != 0) {
+            DestroyEntity(self->ext.et_waterAlcove.entity82);
+            self->ext.et_waterAlcove.entity82 = NULL;
+        }
+        self->animCurFrame = 0;
+    }
+
+    D_us_801812B8 = 177 - self->ext.et_waterAlcove.waterHeight;
+    D_us_801811D6 = 176 - self->ext.et_waterAlcove.waterHeight;
+
+    if (self->ext.et_waterAlcove.waterHeight >= 64) {
+        DestroyEntity(self);
+    }
+}
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4980);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -155,9 +155,10 @@ extern s32 D_80072F20; // Player's collision detection
 extern Primitive D_us_80181644;
 
 // Function that runs when the player is in the switch room to activate the
-// skeleton ape that can destroy the bridge in underground caverns. Location
-// here (X: 21, Y: 33)
+// skeleton ape that can destroy the bridge in underground caverns.
+// Location (X: 21, Y: 33)
 // https://guides.gamercorner.net/sotn/areas/underground-caverns
+
 void func_us_801C5628(Entity* self) {
     Entity* newEnt;
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -37,8 +37,8 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4228);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4520);
 
-extern s16 D_us_801811D6;  // Final water level's surface height
-extern s16 D_us_801812B8;  // Final water level's background height
+extern s16 D_us_801811D6;  // water surface sprite height
+extern s16 D_us_801812B8;  // water background sprite height
 extern u8 D_us_80181588[]; // Water flow animation that needs to be blocked by
                            // the crate
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -151,7 +151,6 @@ void func_us_801C5518(Entity* self) {
     }
 }
 
-extern s32 D_80072F20; // Player's collision detection
 extern Primitive D_us_80181644;
 
 // Function that runs when the player is in the switch room to activate the
@@ -176,11 +175,12 @@ void func_us_801C5628(Entity* self) {
     // Idk why it wants to store the entity before but it works so ¯\_(ツ)_/¯
     newEnt = g_Entities;
 
-    if ((((GetPlayerCollisionWith(self, 8, 16, 5) & 1) && (D_80072F20 & 1)) &&
+    if ((((GetPlayerCollisionWith(self, 0x8, 16, 5) & 0x1) &&
+          (g_Player.vram_flag & 0x1)) &&
          (g_pads->pressed & PAD_LEFT)) &&
         (PLAYER.step == 1)) {
-        if (self->ext.skeletonApe.unk7C != 0) { // ext.xxx.unk7C
-            self->ext.skeletonApe.unk7C--;
+        if (self->ext.timer.t != 0) { // ext.xxx.unk7C
+            self->ext.timer.t--;
         } else {
             if (self->posX.i.hi >= 45) {
                 self->posX.i.hi--;
@@ -191,7 +191,7 @@ void func_us_801C5628(Entity* self) {
                     self->step++;
                 }
             }
-            self->ext.skeletonApe.unk7C = 2;
+            self->ext.timer.t = 2;
         }
     }
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -85,13 +85,13 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4D2C);
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C5020);
 
 void func_us_801C50FC(void) {
-    u16* tileIdx;
+    u16* tile;
     s16 i;
 
-    tileIdx = &g_Tilemap.fg[691];
+    tile = &g_Tilemap.fg[691];
 
-    for (i = 0; i < 10; i++, tileIdx++) {
-        *tileIdx = 0;
+    for (i = 0; i < 10; i++, tile++) {
+        *tile = 0;
     }
 }
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -301,7 +301,68 @@ void func_us_801C7FAC(void) {
     }
 }
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C801C);
+void func_us_801C801C(Entity* self) {
+    Entity* newEnt;
+    s16 offsetY;
+
+    switch (self->step) {
+    case 0:
+        InitializeEntity(g_EInitCommon);
+        self->animSet = ANIMSET_OVL(1);
+        if (g_CastleFlags[BOATMAN_GATE_OPEN] != 0) {
+            func_us_801C7FAC();
+            DestroyEntity(self);
+            return;
+        }
+        self->animCurFrame = 24;
+        return;
+    case 1:
+        if (g_CastleFlags[BOATMAN_GATE_OPEN] != 0) {
+            GetPlayerCollisionWith(self, 16, 56, 3);
+            func_us_801C7FAC();
+            self->ext.et_801C801C.unk80 = 0;
+            self->step++;
+            return;
+        }
+        break;
+    case 2:
+        if (!(self->ext.et_801C801C.unk80++ & 0xF)) {
+            PlaySfxPositional(SFX_STONE_MOVE_C);
+        }
+
+        self->posY.i.hi--;
+        offsetY = self->posY.i.hi + g_Tilemap.scrollY.i.hi;
+
+        if (offsetY >= 125) {
+            if (self->ext.et_801C801C.unk7C != 0) {
+                self->ext.et_801C801C.unk7C--;
+            } else {
+                newEnt = AllocEntity(&g_Entities[224], &g_Entities[256]);
+                if (newEnt != NULL) {
+                    CreateEntityFromCurrentEntity(24, newEnt);
+                    newEnt->posY.i.hi = 176 - g_Tilemap.scrollY.i.hi;
+                    newEnt->posX.i.hi = (s16)(newEnt->posX.i.hi - 16) +
+                                        (self->ext.et_801C801C.unk7E * 8);
+                    newEnt->params = 0x8000;
+                    newEnt->ext.et_801C801C.unk88 = 23;
+                    newEnt->zPriority = 155;
+                }
+
+                self->ext.et_801C801C.unk7E++;
+                if (self->ext.et_801C801C.unk7E >= 5) {
+                    self->ext.et_801C801C.unk7E = 0;
+                }
+                self->ext.et_801C801C.unk7C = 1;
+            }
+        }
+
+        GetPlayerCollisionWith(self, 16, 60, 3);
+
+        if (offsetY < 36) {
+            DestroyEntity(self);
+        }
+    }
+}
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C8248);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -84,7 +84,16 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4D2C);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C5020);
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C50FC);
+void func_us_801C50FC(void) {
+    u16* tileIdx;
+    s16 i;
+
+    tileIdx = &g_Tilemap.fg[691];
+
+    for (i = 0; i < 10; i++, tileIdx++) {
+        *tileIdx = 0;
+    }
+}
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C5134);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -157,7 +157,39 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C582C);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C5868);
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C58A0);
+void func_us_801C58A0(Entity* self) {
+    Entity* newEnt;
+
+    switch (self->step) {
+    case 0:
+        InitializeEntity(g_EInitCommon);
+        if (g_CastleFlags[NO4_SKELETON_APE_AND_BRIDGE] != 0) {
+            func_us_801C5868();
+            DestroyEntity(self);
+        }
+        break;
+    case 1:
+        if (g_CastleFlags[NO4_SKELETON_APE_AND_BRIDGE] != 0) {
+            newEnt = AllocEntity(&g_Entities[160], &g_Entities[192]);
+            if (newEnt != NULL) {
+                CreateEntityFromCurrentEntity(E_SKELETON_APE, newEnt);
+                newEnt->params = 2;
+                newEnt->posY.i.hi = newEnt->posY.i.hi - 96;
+                newEnt->posX.i.hi = newEnt->posX.i.hi + 96;
+                self->ext.prim = (Primitive*)(newEnt + 2); // I dont like this
+            }
+            self->step += 1;
+        }
+        break;
+    case 2:
+        if (self->ext.prim->x3 == 4U) {
+            func_us_801C5868();
+            func_us_801C5134();
+            DestroyEntity(self);
+        }
+        break;
+    }
+}
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C59E0);
 

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -41,7 +41,46 @@ INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4738);
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4980);
 
-INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4BD8);
+
+void func_us_801C4BD8(Entity* self) {
+    Tilemap* tmap;
+    s16* dataPtr;
+    s32 offsetX;
+
+    if (self->step == 0) {
+        InitializeEntity(g_EInitInteractable);
+        self->animSet = 0;
+    }
+
+    tmap = &g_Tilemap;
+    dataPtr = &D_us_8018159C[self->params * 4];
+
+    offsetX = (PLAYER.posX.i.hi + tmap->scrollX.i.hi - *dataPtr++);
+    offsetX = (offsetX * *dataPtr++) / 4096;
+    offsetX += *dataPtr++;
+
+    if (offsetX < 0) {
+        offsetX = 0;
+    } else if (offsetX >= 0x80) {
+        offsetX = 0x7F;
+    }
+
+    if (offsetX == 0) {
+        if (D_us_80181108 != 0) {
+            D_us_80181108 = 0;
+            g_api_PlaySfx(0xA6);
+            return;
+        }
+    }
+    if (D_us_80181108 != 0) {
+        g_api_func_80134678(offsetX, *dataPtr++);
+        return;
+    }
+
+    g_api_PlaySfxVolPan(0x797, offsetX, *dataPtr++);
+    D_us_80181108 = 1;
+}
+
 
 INCLUDE_ASM("st/no4/nonmatchings/first_c_file", func_us_801C4D2C);
 

--- a/src/st/no4/no4.h
+++ b/src/st/no4/no4.h
@@ -133,6 +133,9 @@ extern EInit g_EInitSkeletonApeBarrel;
 extern EInit g_EInitSkeletonApePunch;
 extern EInit g_EInitKillerFish;
 
+extern void (*g_api_func_80134678)(s32, s16);
+extern s32 D_us_80181108;
+extern s16 D_us_8018159C[];
 extern s16 D_us_801DF788;
 extern s16 D_us_801DF78A;
 extern s8 D_us_801DF78E;


### PR DESCRIPTION
Got some time on my hand so here is a couple of functions for the underground caverns,

~I'm unsure if `func_us_801C5628` uses `ext.skeletonApe.unk7C`, and it only uses the 0x7C offset in the entire function, any suggestion ? something temporary ?~ 
edit : switched it to `ext.timer.t` for now.

~`D_80072F20` is the ground collision detection byte, is there a name/array already given for that functionality somewhere ?~ 
edit : used the correct `g_Player.vram_flag`

~also checking if the PSP build works, otherwise I'll close the PR in the meantime and find a way to get the PSP version working.~
edit: seems like it's working