### PR TITLE
assets spritesheet: ensure directory is created

### DIFF
--- a/tools/sotn-assets/assets/spritesheet/handler.go
+++ b/tools/sotn-assets/assets/spritesheet/handler.go
@@ -215,7 +215,11 @@ func (h *handler) Build(e assets.BuildArgs) error {
 	}
 	sbHeader.WriteString("};\n")
 
-	f, err := os.Create(sourcePath(e.SrcDir, e.Name))
+	dstFile := sourcePath(e.SrcDir, e.Name)
+	if err := os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	f, err := os.Create(dstFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes an issue where the spritesheet handler from sotn-assets did not ensure the `src\ric\gen` directory gets created before creating the destination file. This was causing occasional failures on the CI: https://github.com/Xeeynamo/sotn-decomp/actions/runs/15240843512/job/42860744361?pr=2603