### PR TITLE
Give "opacity" name to Entity.unk6C

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -306,8 +306,7 @@ typedef enum {
     FLAG_DRAW_ROTX = 0x01,
     FLAG_DRAW_ROTY = 0x02,
     FLAG_DRAW_ROTZ = 0x04,
-    FLAG_DRAW_UNK8 = 0x08, // Salem Witch uses this for shadows
-                           // Looks like semi-transparency?
+    FLAG_DRAW_OPACITY = 0x08,
     FLAG_DRAW_UNK10 = 0x10,
     FLAG_DRAW_UNK20 = 0x20,
     FLAG_DRAW_UNK40 = 0x40,
@@ -855,8 +854,7 @@ typedef struct Entity {
     /* 0x64 */ s32 primIndex;
     /* 0x68 */ u16 unk68; // Appears to be set for entities with parallax
     /* 0x6A */ u16 hitEffect;
-    /* 0x6C */ u8 unk6C; // Salem Witch: timer to destroy its shadows.
-                         // Thornweed: timer before spawning death explosion
+    /* 0x6C */ u8 opacity;
     /* 0x6D */ u8 unk6D[11];
     /* 0x78 */ s32 unk78;
     /* 0x7C */ Ext ext;

--- a/src/boss/bo4/doors.c
+++ b/src/boss/bo4/doors.c
@@ -192,11 +192,11 @@ void func_us_801B5040(Entity* self) {
     case 0:
         InitializeEntity(D_us_80180458);
         self->drawFlags |=
-            FLAG_DRAW_UNK8 | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
-            self->unk6C = 0x20;
+            self->opacity = 0x20;
         } else {
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
         }
         self->rotX = D_us_801805C0[self->params & 0xF];
         self->rotY = self->rotX;
@@ -298,15 +298,15 @@ void func_us_801B5040(Entity* self) {
             }
         }
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C++;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity++;
         }
         break;
 
     case 5:
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C += 2;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity += 2;
         }
         magnitude = self->ext.et_801BDA0C.unk80 / 0x10000;
         xOffset = (rcos(self->rotZ - 0x400) * magnitude) >> 0xC;

--- a/src/boss/bo4/doors.c
+++ b/src/boss/bo4/doors.c
@@ -191,8 +191,8 @@ void func_us_801B5040(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(D_us_80180458);
-        self->drawFlags |=
-            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+        self->drawFlags |= FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY |
+                           FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
             self->opacity = 0x20;
         } else {

--- a/src/boss/bo4/unk_46E7C.c
+++ b/src/boss/bo4/unk_46E7C.c
@@ -81,7 +81,7 @@ void DopplegangerStepHighJump(void) {
             DOPPLEGANGER.step_s = 4;
             DOPPLEGANGER.drawFlags &=
                 FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                 FLAG_DRAW_ROTX;
             DOPPLEGANGER.facingLeft = (DOPPLEGANGER.facingLeft + 1) & 1;
         }
@@ -694,7 +694,7 @@ void DopplegangerStepStone(s32 arg0) {
             DOPPLEGANGER.step_s = 2;
             DOPPLEGANGER.drawFlags &=
                 FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                 FLAG_DRAW_ROTX;
         } else {
             DOPPLEGANGER.rotPivotX = 0;
@@ -1269,7 +1269,7 @@ void DopEntityHitByDark(Entity* self) {
             self->drawMode = DRAW_TPAGE;
         }
         D_us_801D3D9C++;
-        self->unk6C = 0xFF;
+        self->opacity = 0xFF;
         self->drawFlags =
             FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20;
         self->rotX = self->rotY = 0x40;
@@ -1281,8 +1281,8 @@ void DopEntityHitByDark(Entity* self) {
         self->step++;
         break;
     case 1:
-        if (self->unk6C > 16) {
-            self->unk6C -= 8;
+        if (self->opacity > 16) {
+            self->opacity -= 8;
         }
         self->posY.val += self->velocityY;
         self->rotX += 8;
@@ -1660,8 +1660,8 @@ void EntityWingSmashTrail(Entity* self) {
         self->unk5A = 8;
         self->zPriority = DOPPLEGANGER.zPriority - 2;
         self->drawFlags = DOPPLEGANGER.drawFlags |
-                          (FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
-        self->unk6C = 0x80; // a lifetime counter
+                          (FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+        self->opacity = 0x80; // a lifetime counter
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         self->rotZ = DOPPLEGANGER.rotZ;
         self->facingLeft = DOPPLEGANGER.facingLeft;
@@ -1674,10 +1674,8 @@ void EntityWingSmashTrail(Entity* self) {
     self->rotX -= 8;
     self->rotY -= 8;
     self->animCurFrame = DOPPLEGANGER.animCurFrame | ANIM_FRAME_LOAD;
-    // Unclear why we count down by 5's instead of just making unk6C start
-    // smaller
-    if (self->unk6C >= 5) {
-        self->unk6C -= 5;
+    if (self->opacity >= 5) {
+        self->opacity -= 5;
     } else {
         DestroyEntity(self);
     }

--- a/src/boss/mar/clock_room.c
+++ b/src/boss/mar/clock_room.c
@@ -124,7 +124,7 @@ void EntityClockRoomController(Entity* self) {
         self[shadow].animCurFrame = 23;
         self[shadow].zPriority = 0x40;
         self[shadow].palette = 0x804B;
-        self[shadow].drawFlags = FLAG_DRAW_UNK8;
+        self[shadow].drawFlags = FLAG_DRAW_OPACITY;
         self[shadow].drawMode = DRAW_TPAGE;
         self[shadow].flags = FLAG_DESTROY_IF_OUT_OF_CAMERA |
                              FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA;

--- a/src/boss/rbo3/rbo3.c
+++ b/src/boss/rbo3/rbo3.c
@@ -724,8 +724,8 @@ void func_us_80192998(Entity* self) {
 
     case 1:
         if (self->step_s == 0) {
-            self->drawFlags = FLAG_DRAW_UNK8;
-            self->unk6C = 0xC0;
+            self->drawFlags = FLAG_DRAW_OPACITY;
+            self->opacity = 0xC0;
             self->facingLeft = Random() & 1;
             self->velocityX = (Random() << 8) - FIX(1.0 / 2.0);
             self->velocityY = FIX(-0.75);
@@ -734,7 +734,7 @@ void func_us_80192998(Entity* self) {
         }
         MoveEntity();
         self->velocityY += self->ext.e_80192998.accelY;
-        self->unk6C += 255;
+        self->opacity += 255;
         if (AnimateEntity(self->ext.e_80192998.anim, self) == 0) {
             DestroyEntity(self);
         }

--- a/src/boss/rbo5/doors.c
+++ b/src/boss/rbo5/doors.c
@@ -203,8 +203,8 @@ void func_us_801B3B0C(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(D_us_8018046C);
-        self->drawFlags |=
-            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+        self->drawFlags |= FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY |
+                           FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
             self->opacity = 0x20;
         } else {

--- a/src/boss/rbo5/doors.c
+++ b/src/boss/rbo5/doors.c
@@ -204,11 +204,11 @@ void func_us_801B3B0C(Entity* self) {
     case 0:
         InitializeEntity(D_us_8018046C);
         self->drawFlags |=
-            FLAG_DRAW_UNK8 | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
-            self->unk6C = 0x20;
+            self->opacity = 0x20;
         } else {
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
         }
         self->rotX = D_us_801805D8[self->params & 0xF];
         self->rotY = self->rotX;
@@ -310,15 +310,15 @@ void func_us_801B3B0C(Entity* self) {
             }
         }
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C++;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity++;
         }
         break;
 
     case 5:
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C += 2;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity += 2;
         }
         magnitude = self->ext.et_801BDA0C.unk80 / 0x10000;
         xOffset = (rcos(self->rotZ - 0x400) * magnitude) >> 0xC;

--- a/src/boss/rbo5/unk_4648C.c
+++ b/src/boss/rbo5/unk_4648C.c
@@ -81,7 +81,7 @@ void DopplegangerStepHighJump(void) {
             DOPPLEGANGER.step_s = 4;
             DOPPLEGANGER.drawFlags &=
                 FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                 FLAG_DRAW_ROTX;
             DOPPLEGANGER.facingLeft = (DOPPLEGANGER.facingLeft + 1) & 1;
         }
@@ -694,7 +694,7 @@ void DopplegangerStepStone(s32 arg0) {
             DOPPLEGANGER.step_s = 2;
             DOPPLEGANGER.drawFlags &=
                 FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                 FLAG_DRAW_ROTX;
         } else {
             DOPPLEGANGER.rotPivotX = 0;
@@ -1267,7 +1267,7 @@ void DopEntityHitByDark(Entity* self) {
             self->drawMode = DRAW_TPAGE;
         }
         D_us_801D3374++;
-        self->unk6C = 0xFF;
+        self->opacity = 0xFF;
         self->drawFlags =
             FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20;
         self->rotX = self->rotY = 0x40;
@@ -1279,8 +1279,8 @@ void DopEntityHitByDark(Entity* self) {
         self->step++;
         break;
     case 1:
-        if (self->unk6C > 16) {
-            self->unk6C -= 8;
+        if (self->opacity > 16) {
+            self->opacity -= 8;
         }
         self->posY.val += self->velocityY;
         self->rotX += 8;
@@ -1661,8 +1661,8 @@ void EntityWingSmashTrail(Entity* self) {
         self->unk5A = 8;
         self->zPriority = DOPPLEGANGER.zPriority - 2;
         self->drawFlags = DOPPLEGANGER.drawFlags |
-                          (FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
-        self->unk6C = 0x80; // a lifetime counter
+                          (FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+        self->opacity = 0x80; // a lifetime counter
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         self->rotZ = DOPPLEGANGER.rotZ;
         self->facingLeft = DOPPLEGANGER.facingLeft;
@@ -1675,10 +1675,8 @@ void EntityWingSmashTrail(Entity* self) {
     self->rotX -= 8;
     self->rotY -= 8;
     self->animCurFrame = DOPPLEGANGER.animCurFrame | ANIM_FRAME_LOAD;
-    // Unclear why we count down by 5's instead of just making unk6C start
-    // smaller
-    if (self->unk6C >= 5) {
-        self->unk6C -= 5;
+    if (self->opacity >= 5) {
+        self->opacity -= 5;
     } else {
         DestroyEntity(self);
     }

--- a/src/dra/4B758.c
+++ b/src/dra/4B758.c
@@ -313,10 +313,10 @@ void RenderEntities(void) {
                 poly->b3 = plDraw->b3;
                 setShadeTex(poly, false);
             } else {
-                if (r->eDrawFlags & FLAG_DRAW_UNK8) {
+                if (r->eDrawFlags & FLAG_DRAW_OPACITY) {
                     poly->r0 = poly->g0 = poly->b0 = poly->r1 = poly->g1 =
                         poly->b1 = poly->r2 = poly->g2 = poly->b2 = poly->r3 =
-                            poly->g3 = poly->b3 = entity->unk6C;
+                            poly->g3 = poly->b3 = entity->opacity;
                     if (r->eDrawFlags & FLAG_DRAW_UNK10) {
                         poly->r0 = poly->r1 = poly->r2 = poly->r3 = 0x80;
                     }
@@ -483,10 +483,10 @@ void RenderEntities(void) {
                 } else {
                     setSemiTrans(poly, false);
                 }
-                if (r->eDrawFlags & FLAG_DRAW_UNK8) {
+                if (r->eDrawFlags & FLAG_DRAW_OPACITY) {
                     poly->r0 = poly->g0 = poly->b0 = poly->r1 = poly->g1 =
                         poly->b1 = poly->r2 = poly->g2 = poly->b2 = poly->r3 =
-                            poly->g3 = poly->b3 = entity->unk6C;
+                            poly->g3 = poly->b3 = entity->opacity;
                     if (r->eDrawFlags & FLAG_DRAW_UNK10) {
                         poly->r0 = poly->r1 = poly->r2 = poly->r3 = 0x80;
                     }
@@ -811,10 +811,10 @@ void RenderEntitiesPSP(void) {
                 poly->b3 = plDraw->b3;
                 setShadeTex(poly, false);
             } else {
-                if (r->eDrawFlags & FLAG_DRAW_UNK8) {
+                if (r->eDrawFlags & FLAG_DRAW_OPACITY) {
                     poly->r0 = poly->g0 = poly->b0 = poly->r1 = poly->g1 =
                         poly->b1 = poly->r2 = poly->g2 = poly->b2 = poly->r3 =
-                            poly->g3 = poly->b3 = entity->unk6C;
+                            poly->g3 = poly->b3 = entity->opacity;
                     if (r->eDrawFlags & FLAG_DRAW_UNK10) {
                         poly->r0 = poly->r1 = poly->r2 = poly->r3 = 0x80;
                     }
@@ -987,10 +987,10 @@ void RenderEntitiesPSP(void) {
                 } else {
                     setSemiTrans(poly, false);
                 }
-                if (r->eDrawFlags & FLAG_DRAW_UNK8) {
+                if (r->eDrawFlags & FLAG_DRAW_OPACITY) {
                     poly->r0 = poly->g0 = poly->b0 = poly->r1 = poly->g1 =
                         poly->b1 = poly->r2 = poly->g2 = poly->b2 = poly->r3 =
-                            poly->g3 = poly->b3 = entity->unk6C;
+                            poly->g3 = poly->b3 = entity->opacity;
                     if (r->eDrawFlags & FLAG_DRAW_UNK10) {
                         poly->r0 = poly->r1 = poly->r2 = poly->r3 = 0x80;
                     }

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -1089,7 +1089,7 @@ void PlayerStepHighJump(void) {
             SetPlayerAnim(0x2D);
             PLAYER.drawFlags &=
                 (FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40 |
-                 FLAG_BLINK | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
             PLAYER.rotZ = 0;
             PLAYER.facingLeft += 1;
             PLAYER.facingLeft &= 1;
@@ -1751,7 +1751,7 @@ void PlayerStepStoned(s32 arg0) {
             PLAYER.step_s = 2;
             PLAYER.drawFlags &=
                 (FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40 |
-                 FLAG_BLINK | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
         } else {
             PLAYER.rotPivotX = 0;
             PLAYER.drawFlags |= FLAG_DRAW_ROTZ;

--- a/src/dra/71830.c
+++ b/src/dra/71830.c
@@ -1089,7 +1089,8 @@ void PlayerStepHighJump(void) {
             SetPlayerAnim(0x2D);
             PLAYER.drawFlags &=
                 (FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40 |
-                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
+                 FLAG_DRAW_ROTX);
             PLAYER.rotZ = 0;
             PLAYER.facingLeft += 1;
             PLAYER.facingLeft &= 1;
@@ -1751,7 +1752,8 @@ void PlayerStepStoned(s32 arg0) {
             PLAYER.step_s = 2;
             PLAYER.drawFlags &=
                 (FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40 |
-                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+                 FLAG_BLINK | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
+                 FLAG_DRAW_ROTX);
         } else {
             PLAYER.rotPivotX = 0;
             PLAYER.drawFlags |= FLAG_DRAW_ROTZ;

--- a/src/dra/7879C.c
+++ b/src/dra/7879C.c
@@ -3349,8 +3349,9 @@ void EntityWingSmashTrail(Entity* entity) {
         entity->animSet = PLAYER.animSet;
         entity->animCurFrame = PLAYER.animCurFrame | ANIM_FRAME_LOAD;
         entity->zPriority = PLAYER.zPriority - 2;
-        entity->drawFlags = PLAYER.drawFlags |
-                            (FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+        entity->drawFlags =
+            PLAYER.drawFlags |
+            (FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
         entity->opacity = 0x80; // a lifetime counter
         entity->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         entity->rotZ = PLAYER.rotZ;

--- a/src/dra/7879C.c
+++ b/src/dra/7879C.c
@@ -3350,8 +3350,8 @@ void EntityWingSmashTrail(Entity* entity) {
         entity->animCurFrame = PLAYER.animCurFrame | ANIM_FRAME_LOAD;
         entity->zPriority = PLAYER.zPriority - 2;
         entity->drawFlags = PLAYER.drawFlags |
-                            (FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
-        entity->unk6C = 0x80; // a lifetime counter
+                            (FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX);
+        entity->opacity = 0x80; // a lifetime counter
         entity->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         entity->rotZ = PLAYER.rotZ;
         entity->facingLeft = PLAYER.facingLeft;
@@ -3364,10 +3364,8 @@ void EntityWingSmashTrail(Entity* entity) {
     entity->rotX -= 8;
     entity->rotY -= 8;
     entity->animCurFrame = PLAYER.animCurFrame | ANIM_FRAME_LOAD;
-    // Unclear why we count down by 5's instead of just making unk6C start
-    // smaller
-    if (entity->unk6C >= 5) {
-        entity->unk6C -= 5;
+    if (entity->opacity >= 5) {
+        entity->opacity -= 5;
     } else {
         DestroyEntity(entity);
     }

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -572,7 +572,7 @@ void func_8011F074(Entity* self) {
             self->drawMode = DRAW_TPAGE;
         }
         D_8013808C++;
-        self->unk6C = 0xFF;
+        self->opacity = 0xFF;
         self->drawFlags =
             FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20;
         self->rotX = self->rotY = 0x40;
@@ -584,8 +584,8 @@ void func_8011F074(Entity* self) {
         self->step++;
         break;
     case 1:
-        if (self->unk6C > 16) {
-            self->unk6C -= 8;
+        if (self->opacity > 16) {
+            self->opacity -= 8;
         }
         self->posY.val += self->velocityY;
         self->rotX += 8;
@@ -2149,8 +2149,8 @@ void UnknownEntId49(Entity* self) {
             FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_POS_PLAYER_LOCKED | FLAG_UNK_20000;
         self->step++;
     }
-    self->drawFlags = PLAYER.drawFlags & FLAG_DRAW_UNK8;
-    self->unk6C = PLAYER.unk6C;
+    self->drawFlags = PLAYER.drawFlags & FLAG_DRAW_OPACITY;
+    self->opacity = PLAYER.opacity;
 
     if (abs(PLAYER.rotZ) == 0x200) {
         x_offset = -0x10;

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -1039,7 +1039,7 @@ void func_8012F894(Entity* self) {
         if (var_s1 > 0x80) {
             var_s1 = 0x80;
         }
-        PLAYER.unk6C = self->unk6C = 0xFF - var_s1;
+        PLAYER.opacity = self->opacity = 0xFF - var_s1;
     } else {
         self->drawFlags &= ~DRAW_HIDE;
         PLAYER.drawFlags = self->drawFlags;
@@ -1496,15 +1496,15 @@ void func_80130618(Entity* self) {
     }
     self->palette = PLAYER.palette;
     self->drawMode = DRAW_DEFAULT;
-    self->drawFlags &= ~FLAG_DRAW_UNK8;
+    self->drawFlags &= ~FLAG_DRAW_OPACITY;
     if (abs(PLAYER.velocityX) > FIX(3)) {
-        self->drawFlags |= FLAG_DRAW_UNK8;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
         self->drawMode = FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40;
         temp_s1 = (abs(PLAYER.velocityX) - FIX(3)) >> 12;
         if (temp_s1 > 0xA0) {
             temp_s1 = 0xA0;
         }
-        self->unk6C = 0xFF - temp_s1;
+        self->opacity = 0xFF - temp_s1;
     }
 }
 
@@ -1825,15 +1825,15 @@ void func_80130E94(Entity* self) {
     self->posY.val = sp3c - rsin(var_s3) * var_s7 * 0x10;
     self->palette = PLAYER.palette;
     self->drawMode = DRAW_DEFAULT;
-    self->drawFlags &= ~FLAG_DRAW_UNK8;
+    self->drawFlags &= ~FLAG_DRAW_OPACITY;
     if (abs(PLAYER.velocityX) > FIX(3)) {
-        self->drawFlags |= FLAG_DRAW_UNK8;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
         self->drawMode = FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20 | FLAG_DRAW_UNK40;
         temp_s2 = (abs(PLAYER.velocityX) - FIX(3)) >> 12;
         if (temp_s2 > 0x80) {
             temp_s2 = 0x80;
         }
-        self->unk6C = 0xFF - temp_s2;
+        self->opacity = 0xFF - temp_s2;
     }
 }
 

--- a/src/maria/80.c
+++ b/src/maria/80.c
@@ -1418,9 +1418,9 @@ void func_pspeu_092AB1C0(Entity* self) {
         self->rotY = 0;
         self->drawFlags |= FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
         self->drawMode |= DRAW_TPAGE;
-        self->drawFlags |= FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
+        self->drawFlags |= FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
         self->rotZ = 0;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->hitboxWidth = 48;
         self->hitboxHeight = 48;
         self->hitboxOffX = 0;

--- a/src/maria/maria.h
+++ b/src/maria/maria.h
@@ -446,4 +446,4 @@ void MarStepDead(
     s32 damageEffects, s32 damageKind, s32 prevStep, s32 prevStepS);
 Entity* MarCreateEntFactoryFromEntity(Entity* entity, u32 arg1, s32 arg2);
 s32 func_pspeu_092BEAB0(s16);
-void func_pspeu_092BEA38(Entity* entity, s32 setUnk6C);
+void func_pspeu_092BEA38(Entity* entity, s32 opacity);

--- a/src/maria/pl_blueprints.c
+++ b/src/maria/pl_blueprints.c
@@ -640,8 +640,8 @@ void MarEntitySmokePuff(Entity* self) {
         self->zPriority = PLAYER.zPriority + 2;
         self->flags = FLAG_POS_CAMERA_LOCKED | FLAG_UNK_100000 | FLAG_UNK_10000;
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
         posX = pos_x_80154C50[paramsLo];
         if (paramsHi == 0) {
             posX += 6;
@@ -732,7 +732,7 @@ void MarEntitySmokePuff(Entity* self) {
         self->step++;
         break;
     case 1:
-        self->unk6C -= 2;
+        self->opacity -= 2;
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         if (self->poseTimer < 0) {
@@ -2689,11 +2689,11 @@ void MarEntityTeleport(Entity* self) {
 void func_pspeu_092BEA38(Entity* entity, s32 opacity) {
     if (opacity >= 128) {
         entity->drawMode = entity->drawFlags = FLAG_DRAW_DEFAULT;
-        entity->unk6C = 128;
+        entity->opacity = 128;
     } else {
         entity->drawMode = DRAW_TPAGE | DRAW_TPAGE2;
-        entity->drawFlags = FLAG_DRAW_UNK8;
-        entity->unk6C = opacity;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
+        entity->opacity = opacity;
     }
 }
 

--- a/src/ric/2F8E8.c
+++ b/src/ric/2F8E8.c
@@ -818,8 +818,8 @@ void RicEntityVibhutiCrashCloud(Entity* entity) {
         entity->palette = PAL_OVL(0x19E);
         entity->anim = D_80155EA8;
         entity->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        entity->drawFlags = FLAG_DRAW_UNK8;
-        entity->unk6C = 0x60;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
+        entity->opacity = 0x60;
         entity->hitboxWidth = 8;
         entity->hitboxHeight = 8;
         angle = (rand() % 512) + 0x300;

--- a/src/ric/pl_blueprints.c
+++ b/src/ric/pl_blueprints.c
@@ -299,7 +299,7 @@ void RicEntityHitByDark(Entity* entity) {
             entity->drawMode = DRAW_TPAGE;
         }
         D_80174FFC++;
-        entity->unk6C = 0xFF;
+        entity->opacity = 0xFF;
         entity->drawFlags =
             FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK10 | FLAG_DRAW_UNK20;
         entity->rotX = entity->rotY = 0x40;
@@ -310,8 +310,8 @@ void RicEntityHitByDark(Entity* entity) {
         entity->step++;
         break;
     case 1:
-        if (entity->unk6C > 16) {
-            entity->unk6C -= 8;
+        if (entity->opacity > 16) {
+            entity->opacity -= 8;
         }
         entity->posY.val += entity->velocityY;
         entity->rotX += 8;
@@ -858,8 +858,8 @@ void RicEntitySmokePuff(Entity* self) {
         self->zPriority = PLAYER.zPriority + 2;
         self->flags = FLAG_POS_CAMERA_LOCKED | FLAG_UNK_100000 | FLAG_UNK_10000;
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
         posX = pos_x_80154C50[paramsLo];
         if (paramsHi == 0) {
             posX += 6;
@@ -950,7 +950,7 @@ void RicEntitySmokePuff(Entity* self) {
         self->step++;
         break;
     case 1:
-        self->unk6C -= 2;
+        self->opacity -= 2;
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         if (self->poseTimer < 0) {

--- a/src/ric/pl_whip.c
+++ b/src/ric/pl_whip.c
@@ -478,7 +478,7 @@ void RicEntityWhip(Entity* self) {
     if (sp4A) {
         if (psp_s4 != 7) {
             angle = (((g_GameTimer >> 2) & 7) + D_80155C98[psp_s4]) * 512;
-            self->unk6C = (rsin(angle) >> 6) + 0x80;
+            self->opacity = (rsin(angle) >> 6) + 0x80;
             self->drawFlags |= DRAW_HIDE;
             self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         }

--- a/src/servant/tt_001/ghost.c
+++ b/src/servant/tt_001/ghost.c
@@ -421,7 +421,7 @@ void UpdateServantDefault(Entity* self) {
         self->flags =
             FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_UNK_20000;
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_UNK8;
+        self->drawFlags = FLAG_DRAW_OPACITY;
         SetEntityAnimation(self, &g_DefaultGhostAnimationFrame);
         self->ext.ghost.maxAngle = 512;
         self->ext.ghost.opacity = 128;
@@ -644,10 +644,10 @@ void UpdateServantDefault(Entity* self) {
         self->ext.ghost.opacityAdjustmentAmount *= -1;
     }
 
-    // unk6C is used in conjunction with self->drawFlags = FLAG_DRAW_UNK8 to set
+    // opacity is used in conjunction with self->drawFlags = FLAG_DRAW_OPACITY to set
     // the alpha/saturation.  When it's zero, it's invisible, when it's 255,
     // it's at the opacity of the sprite itself and is "bright".
-    self->unk6C = self->ext.ghost.opacity;
+    self->opacity = self->ext.ghost.opacity;
     ProcessEvent(self, 0);
     unused_1560(self);
     g_api.UpdateAnim(NULL, g_GhostAnimationFrames);

--- a/src/servant/tt_001/ghost.c
+++ b/src/servant/tt_001/ghost.c
@@ -644,9 +644,9 @@ void UpdateServantDefault(Entity* self) {
         self->ext.ghost.opacityAdjustmentAmount *= -1;
     }
 
-    // opacity is used in conjunction with self->drawFlags = FLAG_DRAW_OPACITY to set
-    // the alpha/saturation.  When it's zero, it's invisible, when it's 255,
-    // it's at the opacity of the sprite itself and is "bright".
+    // opacity is used in conjunction with self->drawFlags = FLAG_DRAW_OPACITY
+    // to set the alpha/saturation.  When it's zero, it's invisible, when it's
+    // 255, it's at the opacity of the sprite itself and is "bright".
     self->opacity = self->ext.ghost.opacity;
     ProcessEvent(self, 0);
     unused_1560(self);

--- a/src/st/chi/en_gremlin.c
+++ b/src/st/chi/en_gremlin.c
@@ -256,8 +256,8 @@ void EntityGremlinEffect(Entity* self) {
         // Glow init
         self->step = GLOW;
         self->drawMode = DRAW_TPAGE | DRAW_TPAGE2;
-        self->unk6C = 0xC0;
-        self->drawFlags = FLAG_DRAW_UNK8;
+        self->opacity = 0xC0;
+        self->drawFlags = FLAG_DRAW_OPACITY;
         break;
 
     case GLOW:

--- a/src/st/chi/en_salem_witch.c
+++ b/src/st/chi/en_salem_witch.c
@@ -577,12 +577,12 @@ void EntitySalemWitch(Entity* self) {
         self->hitboxState = 0;
         self->animCurFrame = self->params;
         self->drawMode = DRAW_TPAGE | DRAW_TPAGE2;
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = ShadowDuration;
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = ShadowDuration;
         // fallthrough
     case SHADOW_WAIT:
-        self->unk6C -= ShadowTickSpeed;
-        if (self->unk6C < ShadowDestroyThreshold) {
+        self->opacity -= ShadowTickSpeed;
+        if (self->opacity < ShadowDestroyThreshold) {
             DestroyEntity(self);
         }
         return;
@@ -856,8 +856,8 @@ void EntitySalemWitchTriboltLaunch(Entity* self) {
         self->animSet = 5;
         self->palette = PAL_OVL(0x2EB);
         self->drawMode = DRAW_TPAGE | DRAW_TPAGE2;
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
 
         PlaySfxPositional(SFX_CANDLE_HIT);
         // fallthrough
@@ -872,8 +872,8 @@ void EntitySalemWitchTriboltLaunch(Entity* self) {
         self->unk5A = 0x4B;
         self->drawFlags |= FLAG_DRAW_ROTX | FLAG_DRAW_ROTY;
         self->rotX = self->rotY = BurstStartRotation;
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C = 0x80;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity = 0x80;
         self->step++;
 
         PlaySfxPositional(SFX_FIREBALL_SHOT_A);
@@ -889,7 +889,7 @@ void EntitySalemWitchTriboltLaunch(Entity* self) {
         // fallthrough
     case BURST:
         self->rotX = self->rotY += BurstRotateSpeed;
-        self->unk6C -= 4;
+        self->opacity -= 4;
         if (AnimateEntity(&AnimFrames_TriboltBurst, self) == 0) {
             SetStep(CLEANUP);
         }
@@ -986,12 +986,12 @@ void EntitySalemWitchTriboltProjectile(Entity* self) {
         self->drawMode = DRAW_TPAGE | DRAW_TPAGE2;
         self->drawFlags = FLAG_DRAW_ROTZ;
         self->drawFlags |= FLAG_DRAW_ROTX;
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
         self->pose = self->animCurFrame;
         // fallthrough
     case TRAIL_UPDATE:
-        self->unk6C -= 4;
+        self->opacity -= 4;
         if (AnimateEntity(&AnimFrames_TriboltTrail, self) == 0) {
             DestroyEntity(self);
         }

--- a/src/st/clock_room_entities.h
+++ b/src/st/clock_room_entities.h
@@ -14,7 +14,7 @@ void EntityClockHands(Entity* self) {
 
         // Create hand shadows
         CreateEntityFromCurrentEntity(E_CLOCK_ROOM_SHADOW, handShadow);
-        handShadow->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTZ;
+        handShadow->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ;
         handShadow->drawMode = DRAW_TPAGE;
         handShadow->animSet = ANIMSET_OVL(1);
         handShadow->animCurFrame = params + 25;
@@ -49,14 +49,14 @@ void EntityBirdcageDoor(Entity* self) {
         self->zPriority = 0x3C;
         self->rotX = self->rotY = 0x100;
         self->ext.birdcage.prevState = self->ext.birdcage.state;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->posX.i.hi = bird_cage_pos_x[params] - g_Tilemap.scrollX.i.hi;
         self->posY.i.hi = bird_cage_pos_y[params] - g_Tilemap.scrollY.i.hi;
         break;
 
     case 1:
         if (self->ext.birdcage.prevState != self->ext.birdcage.state) {
-            self->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->ext.birdcage.timer = 64;
             self->ext.birdcage.prevState = self->ext.birdcage.state;
             self->step++;
@@ -66,7 +66,7 @@ void EntityBirdcageDoor(Entity* self) {
 
     case 2:
         self->rotX = self->rotY -= 2;
-        self->unk6C += 0xFF;
+        self->opacity += 0xFF;
         if (--self->ext.birdcage.timer == 0) {
             self->ext.birdcage.timer = 64;
             self->zPriority = 0;
@@ -99,7 +99,7 @@ void EntityBirdcageDoor(Entity* self) {
 
     case 5:
         self->rotX = self->rotY += 2;
-        self->unk6C += 1;
+        self->opacity += 1;
         if (--self->ext.birdcage.timer == 0) {
             self->drawFlags = FLAG_DRAW_DEFAULT;
             self->step = 1;
@@ -163,7 +163,7 @@ void EntityStatue(Entity* self) {
         entity->animSet = ANIMSET_OVL(1);
         entity->animCurFrame = params + 10;
         entity->zPriority = 0x3F;
-        entity->drawFlags = FLAG_DRAW_UNK8;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
         entity->drawMode = DRAW_TPAGE;
 #ifndef STAGE_IS_NO0
         entity->flags = FLAG_DESTROY_IF_OUT_OF_CAMERA | FLAG_POS_CAMERA_LOCKED |

--- a/src/st/clock_room_entities.h
+++ b/src/st/clock_room_entities.h
@@ -56,7 +56,8 @@ void EntityBirdcageDoor(Entity* self) {
 
     case 1:
         if (self->ext.birdcage.prevState != self->ext.birdcage.state) {
-            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->drawFlags =
+                FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->ext.birdcage.timer = 64;
             self->ext.birdcage.prevState = self->ext.birdcage.state;
             self->step++;

--- a/src/st/e_explosion_puff_opaque.h
+++ b/src/st/e_explosion_puff_opaque.h
@@ -73,8 +73,8 @@ void EntityExplosionPuffOpaque(Entity* self) {
         }
         switch (self->step_s) {
         case 0:
-            self->drawFlags = FLAG_DRAW_UNK8;
-            self->unk6C = 0x80;
+            self->drawFlags = FLAG_DRAW_OPACITY;
+            self->opacity = 0x80;
             self->step_s++;
             break;
 
@@ -85,7 +85,7 @@ void EntityExplosionPuffOpaque(Entity* self) {
             break;
 
         case 2:
-            self->unk6C -= 4;
+            self->opacity -= 4;
             break;
         }
 

--- a/src/st/e_merman2.h
+++ b/src/st/e_merman2.h
@@ -295,7 +295,7 @@ void EntityMerman2(Entity* self) {
                     self->flags &= ~FLAG_HAS_PRIMS;
                     self->drawFlags &=
                         FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                        FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                        FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                         FLAG_DRAW_ROTX;
                     SetStep(MERMAN2_WALKING_TO_PLAYER);
                 }
@@ -472,7 +472,7 @@ void EntityMerman2(Entity* self) {
                 self->posY.i.hi -= 10;
                 self->drawFlags &=
                     FLAG_BLINK | FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                    FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY |
+                    FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY |
                     FLAG_DRAW_ROTX;
                 SetStep(MERMAN2_WALKING_TO_PLAYER);
             }
@@ -818,8 +818,8 @@ void EntityHighWaterSplash(Entity* self) {
         self->drawFlags |= FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
         self->palette = PAL_OVL(0x18);
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C = 0xA0;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity = 0xA0;
         self->rotX = 0x100;
         self->rotY = 0x1A0;
         self->ext.mermanWaterSplash.unk84 = self->params;
@@ -870,14 +870,14 @@ void EntityDeadMerman(Entity* self) {
         self->hitboxState = 0;
         self->velocityY = FIX(0.0625);
         self->palette = self->params + 0xE;
-        self->unk6C = 0x80;
-        self->drawFlags |= FLAG_DRAW_UNK8;
+        self->opacity = 0x80;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
         self->flags |= FLAG_UNK_2000;
         return;
     }
     MoveEntity();
     self->velocityY += FIX(0.0625);
-    self->unk6C += 0xFE;
+    self->opacity += 0xFE;
     if (--self->ext.merman.timer == 0) {
         DestroyEntity(self);
     }

--- a/src/st/e_misc.h
+++ b/src/st/e_misc.h
@@ -67,7 +67,7 @@ void func_801966B0(u16* sensors) {
         g_CurrentEntity->hitboxState = 0;
         g_CurrentEntity->zPriority -= 0x10;
         g_CurrentEntity->drawFlags |= DRAW_HIDE;
-        g_CurrentEntity->unk6C = 0;
+        g_CurrentEntity->opacity = 0;
         g_CurrentEntity->step_s++;
         break;
     case 1:
@@ -77,8 +77,8 @@ void func_801966B0(u16* sensors) {
         }
         break;
     case 2:
-        g_CurrentEntity->unk6C += 2;
-        if (g_CurrentEntity->unk6C == 0xC0) {
+        g_CurrentEntity->opacity += 2;
+        if (g_CurrentEntity->opacity == 0xC0) {
             g_CurrentEntity->drawFlags = FLAG_DRAW_DEFAULT;
             g_CurrentEntity->drawMode = DRAW_DEFAULT;
             g_CurrentEntity->hitEffect = g_CurrentEntity->palette;

--- a/src/st/e_skeleton.h
+++ b/src/st/e_skeleton.h
@@ -299,9 +299,9 @@ void UnusedSkeletonEntity(Entity* self) {
         InitializeEntity(g_EInitSkeleton);
         self->rotX = 0x120;
         self->rotY = 0x200;
-        self->unk6C = 0;
+        self->opacity = 0;
         self->hitboxState = 0;
-        self->drawFlags |= FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+        self->drawFlags |= FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
         return;
     }
 

--- a/src/st/e_spear_guard.h
+++ b/src/st/e_spear_guard.h
@@ -135,8 +135,8 @@ void EntitySpearGuard(Entity* self) {
         SetStep(12);
         self->hitboxState = 0;
         self->ext.spearGuard.unk7C = 0x40;
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = 0x7F;
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = 0x7F;
     }
     switch (self->step) {
     case 0:
@@ -344,11 +344,11 @@ void EntitySpearGuard(Entity* self) {
 
     case 12:
         AnimateEntity(D_us_80183008, self);
-        if (self->unk6C) {
-            self->unk6C--;
+        if (self->opacity) {
+            self->opacity--;
         }
-        if (self->unk6C) {
-            self->unk6C--;
+        if (self->opacity) {
+            self->opacity--;
         }
         if (!--self->ext.spearGuard.unk7C) {
             DestroyEntity(self);

--- a/src/st/en_thornweed_corpseweed.h
+++ b/src/st/en_thornweed_corpseweed.h
@@ -162,11 +162,11 @@ void EntityThornweed(Entity* self) {
             entity = self + 1;
             entity->flags |= FLAG_DEAD;
             self->hitboxState = 0;
-            self->unk6C = DeathExplosionDelay;
-            self->drawFlags |= FLAG_DRAW_UNK8;
+            self->opacity = DeathExplosionDelay;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
             self->step_s++;
         }
-        if (!--self->unk6C) {
+        if (!--self->opacity) {
             entity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (entity != NULL) {
                 CreateEntityFromEntity(E_EXPLOSION, self, entity);

--- a/src/st/entity_big_red_fireball.h
+++ b/src/st/entity_big_red_fireball.h
@@ -12,9 +12,9 @@ void EntityBigRedFireball(Entity* self) {
         InitializeEntity(g_EInitParticle);
         self->animSet = ANIMSET_DRA(2);
         self->palette = PAL_OVL(0x1B6);
-        self->unk6C = 0x70;
+        self->opacity = 0x70;
         self->zPriority = 192;
-        self->drawFlags |= (FLAG_DRAW_ROTZ + FLAG_DRAW_UNK8);
+        self->drawFlags |= (FLAG_DRAW_ROTZ + FLAG_DRAW_OPACITY);
         self->drawMode |= (DRAW_TPAGE + DRAW_TPAGE2);
 
         switch (self->ext.bigredfireball.switch_control) {

--- a/src/st/initialize_unk_entity.h
+++ b/src/st/initialize_unk_entity.h
@@ -6,7 +6,7 @@ static u8 g_UnkEntityAnimData[] = {
 void InitializeUnkEntity(Entity* self) {
     if (!self->step) {
         InitializeEntity(g_EInitParticle);
-        self->unk6C = 0xF0;
+        self->opacity = 0xF0;
         self->rotX = 0x01A0;
         self->rotY = 0x01A0;
         self->animSet = ANIMSET_DRA(8);

--- a/src/st/lib/e_candle_table.c
+++ b/src/st/lib/e_candle_table.c
@@ -38,8 +38,8 @@ void EntityCandleTable(Entity* self) {
         }
         if (self->params & 0x100) {
             self->drawMode = DRAW_UNK_40 | DRAW_TPAGE2 | DRAW_TPAGE;
-            self->drawFlags = FLAG_DRAW_UNK8;
-            self->unk6C = 0xC0;
+            self->drawFlags = FLAG_DRAW_OPACITY;
+            self->opacity = 0xC0;
         } else {
             self->zPriority += 4;
             self->hitboxWidth = 8;

--- a/src/st/lib/e_dhuron.c
+++ b/src/st/lib/e_dhuron.c
@@ -457,9 +457,9 @@ void func_us_801CC984(Entity* self) {
         posX = tempEntity->posX.i.hi;
         self->posY.i.hi = posY + 0x18;
         self->posX.i.hi = posX;
-        self->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY;
+        self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY;
         self->rotY = 0x180;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->drawMode = DRAW_UNK_40 | DRAW_TPAGE2 | DRAW_TPAGE;
         self->palette = PAL_OVL(0x15B);
         self->unk5A = 0x4E;
@@ -478,8 +478,8 @@ void func_us_801CC984(Entity* self) {
 
     case 4:
         self->posY.val -= FIX(0.25);
-        self->unk6C -= 8;
-        if (!self->unk6C) {
+        self->opacity -= 8;
+        if (!self->opacity) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/lib/e_lesser_demon.c
+++ b/src/st/lib/e_lesser_demon.c
@@ -58,8 +58,8 @@ void func_us_801BB8DC(s16* unkArg) {
         g_CurrentEntity->hitboxState = 0;
         g_CurrentEntity->zPriority -= 0x10;
         g_CurrentEntity->ext.lesserDemon.unkB2 = g_CurrentEntity->palette;
-        g_CurrentEntity->drawFlags |= FLAG_DRAW_UNK8;
-        g_CurrentEntity->unk6C = 2;
+        g_CurrentEntity->drawFlags |= FLAG_DRAW_OPACITY;
+        g_CurrentEntity->opacity = 2;
         g_CurrentEntity->step_s++;
         g_CurrentEntity->flags |= FLAG_UNK_2000;
         g_CurrentEntity->flags &= ~(FLAG_UNK_800 | FLAG_UNK_400);
@@ -76,8 +76,8 @@ void func_us_801BB8DC(s16* unkArg) {
         break;
 
     case 2:
-        g_CurrentEntity->unk6C += 4;
-        if (g_CurrentEntity->unk6C > 0xA0) {
+        g_CurrentEntity->opacity += 4;
+        if (g_CurrentEntity->opacity > 0xA0) {
             g_CurrentEntity->drawFlags = FLAG_DRAW_DEFAULT;
             g_CurrentEntity->drawMode = DRAW_DEFAULT;
             g_CurrentEntity->ext.lesserDemon.unkB0 = 0x20;
@@ -316,16 +316,16 @@ void EntityLesserDemonSpit(Entity* self) {
     case 6:
         self->rotY -= 0x20;
         if (!AnimateEntity(D_us_80181BE8, self)) {
-            self->drawFlags |= FLAG_DRAW_UNK8;
-            self->unk6C = 0x80;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
+            self->opacity = 0x80;
             self->step++;
         }
         break;
 
     case 7:
         self->rotY -= 0x10;
-        self->unk6C -= 0x10;
-        if (!self->unk6C) {
+        self->opacity -= 0x10;
+        if (!self->opacity) {
             DestroyEntity(self);
             return;
         }
@@ -1480,9 +1480,9 @@ void EntityLesserDemon(Entity* self) {
             if (!AnimateEntity(D_us_80181BAC, self) || hit) {
                 self->pose = 0;
                 self->poseTimer = 0;
-                self->drawFlags = FLAG_DRAW_UNK8;
+                self->drawFlags = FLAG_DRAW_OPACITY;
                 self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-                self->unk6C = 0x80;
+                self->opacity = 0x80;
                 self->ext.lesserDemon.unk80 = 0x40;
                 self->step_s++;
             }
@@ -1490,7 +1490,7 @@ void EntityLesserDemon(Entity* self) {
 
         case 3:
             AnimateEntity(D_us_80181BBC, self);
-            self->unk6C -= 2;
+            self->opacity -= 2;
             if (g_Timer % 5 == 0) {
                 tempEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (tempEntity != NULL) {

--- a/src/st/no0/42A34.c
+++ b/src/st/no0/42A34.c
@@ -21,8 +21,8 @@ void func_us_801C2A34(Entity* self) {
         self->zPriority = 0x50;
         self->unk5A = 0;
         self->palette = 0;
-        self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
     }
     angle = rsin((((g_Timer % 120) << 0xC) + 0x3C) / 120);
     if (!angle) {

--- a/src/st/no0/clock_room.c
+++ b/src/st/no0/clock_room.c
@@ -172,7 +172,7 @@ void EntityClockRoomController(Entity* self) {
         entity->animCurFrame = 23;
         entity->zPriority = 0x40;
         entity->palette = PAL_OVL(0x4B);
-        entity->drawFlags = FLAG_DRAW_UNK8;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
         entity->drawMode = DRAW_TPAGE;
         entity->posY.i.hi += 4;
 

--- a/src/st/no0/e_ctulhu.c
+++ b/src/st/no0/e_ctulhu.c
@@ -770,15 +770,15 @@ void EntityCtulhuIceShockwave(Entity* self) {
         }
 
         if (self->flags & FLAG_DEAD) {
-            self->drawFlags |= FLAG_DRAW_UNK8;
-            self->unk6C = 128;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
+            self->opacity = 128;
             self->hitboxState = 0;
             self->step++;
         }
         break;
     case 2:
         MoveEntity();
-        self->unk6C -= 8;
+        self->opacity -= 8;
         self->rotY += 24;
         self->velocityX -= self->velocityX / 8;
 
@@ -788,7 +788,7 @@ void EntityCtulhuIceShockwave(Entity* self) {
             self->animCurFrame = 44;
         }
 
-        if (!self->unk6C) {
+        if (!self->opacity) {
             DestroyEntity(self);
             return;
         }
@@ -878,10 +878,10 @@ void EntityCtulhuDeath(Entity* self) {
         self->animSet = 14;
         self->unk5A = 121;
         self->palette = PAL_OVL(0x2CE);
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = 16;
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = 16;
         if (self->params) {
-            self->unk6C = 16;
+            self->opacity = 16;
             self->drawMode = DRAW_UNK_40 | DRAW_TPAGE;
             self->flags &= ~FLAG_POS_CAMERA_LOCKED;
         } else {

--- a/src/st/no1/e_armor_lord.c
+++ b/src/st/no1/e_armor_lord.c
@@ -1023,7 +1023,8 @@ void func_us_801D348C(Entity* self) {
             self->step = 2;
             self->animCurFrame = 0x20;
             self->opacity = 0x60;
-            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->drawFlags =
+                FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->rotX = 0x1C8;
             self->rotY = 0x1C8;
         }
@@ -1031,7 +1032,8 @@ void func_us_801D348C(Entity* self) {
             self->step = 3;
             self->animCurFrame = 0x21;
             self->opacity = 0x60;
-            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->drawFlags =
+                FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->rotX = 0x1B8;
             self->rotY = 0x1B8;
         }

--- a/src/st/no1/e_armor_lord.c
+++ b/src/st/no1/e_armor_lord.c
@@ -480,8 +480,8 @@ s32 func_us_801D1DAC(void) {
         g_CurrentEntity->ext.armorLord.unk8A = 0;
         g_CurrentEntity->ext.armorLord.unk88 = 0;
         g_CurrentEntity->ext.armorLord.unk8C = 0;
-        g_CurrentEntity->drawFlags |= FLAG_DRAW_UNK8;
-        g_CurrentEntity->unk6C = 0x80;
+        g_CurrentEntity->drawFlags |= FLAG_DRAW_OPACITY;
+        g_CurrentEntity->opacity = 0x80;
         g_CurrentEntity->step_s++;
         break;
 
@@ -492,8 +492,8 @@ s32 func_us_801D1DAC(void) {
         LOW(prim->r1) = LOW(prim->r0);
         LOW(prim->r2) = LOW(prim->r0);
         LOW(prim->r3) = LOW(prim->r0);
-        g_CurrentEntity->unk6C += 0xFE;
-        if (!g_CurrentEntity->unk6C) {
+        g_CurrentEntity->opacity += 0xFE;
+        if (!g_CurrentEntity->opacity) {
             g_CurrentEntity->animCurFrame = 0;
             prim->drawMode = DRAW_COLORS | DRAW_UNK02;
             g_CurrentEntity->ext.armorLord.unk8D += 1;
@@ -1015,23 +1015,23 @@ void func_us_801D348C(Entity* self) {
     case 0:
         InitializeEntity(D_us_80180AE8);
         self->drawMode |= DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags |= FLAG_DRAW_UNK8;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
         self->animCurFrame = 0;
         break;
     case 1:
         if (parent->animCurFrame == 0x10 && parent->step == 6) {
             self->step = 2;
             self->animCurFrame = 0x20;
-            self->unk6C = 0x60;
-            self->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->opacity = 0x60;
+            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->rotX = 0x1C8;
             self->rotY = 0x1C8;
         }
         if (parent->animCurFrame == 0x15) {
             self->step = 3;
             self->animCurFrame = 0x21;
-            self->unk6C = 0x60;
-            self->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            self->opacity = 0x60;
+            self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             self->rotX = 0x1B8;
             self->rotY = 0x1B8;
         }
@@ -1041,7 +1041,7 @@ void func_us_801D348C(Entity* self) {
         if (!--self->ext.armorLord.unk80) {
             self->animCurFrame = 0;
         } else {
-            self->unk6C -= 0x20;
+            self->opacity -= 0x20;
         }
         if (parent->animCurFrame != 0x10) {
             self->step = 1;
@@ -1051,7 +1051,7 @@ void func_us_801D348C(Entity* self) {
         if (!--self->ext.armorLord.unk80) {
             self->animCurFrame = 0;
         } else {
-            self->unk6C -= 0x20;
+            self->opacity -= 0x20;
         }
         if (parent->animCurFrame != 0x15) {
             self->step = 1;

--- a/src/st/no1/e_sword_lord.c
+++ b/src/st/no1/e_sword_lord.c
@@ -388,7 +388,7 @@ void EntitySwordLord(Entity* self) {
                        FLAG_UNK_00200000 | FLAG_UNK_2000;
         self->ext.et_801CF850.unk80 = D_us_80182B34[self->params];
         self->zPriority--;
-        self->unk6C = 0xA0;
+        self->opacity = 0xA0;
         break;
 
     case 8:
@@ -415,7 +415,7 @@ void EntitySwordLord(Entity* self) {
                 DestroyEntity(self);
             }
         } else if (collider.effects != EFFECT_NONE) {
-            self->drawFlags |= FLAG_DRAW_UNK8;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
             self->step++;
         }
         break;
@@ -438,8 +438,8 @@ void EntitySwordLord(Entity* self) {
                 tempEntity->posY.i.hi = posY;
             }
         }
-        self->unk6C += 0xFC;
-        if (!self->unk6C) {
+        self->opacity += 0xFC;
+        if (!self->opacity) {
             DestroyEntity(self);
         }
         break;

--- a/src/st/no1/unk_381E8.c
+++ b/src/st/no1/unk_381E8.c
@@ -406,8 +406,8 @@ void func_us_801B9028(Entity* self) {
         InitializeEntity(D_us_80180A4C);
         self->animCurFrame = self->params + 1;
         self->zPriority = D_us_8018142C[self->params];
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = D_us_80181440[self->params];
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = D_us_80181440[self->params];
         return;
     case 1:
         break;

--- a/src/st/no1/unk_3D8AC.c
+++ b/src/st/no1/unk_3D8AC.c
@@ -89,8 +89,8 @@ void func_us_801BDA0C(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(D_us_801809C8);
-        self->drawFlags |=
-            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+        self->drawFlags |= FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY |
+                           FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
             self->opacity = 0x20;
         } else {

--- a/src/st/no1/unk_3D8AC.c
+++ b/src/st/no1/unk_3D8AC.c
@@ -90,11 +90,11 @@ void func_us_801BDA0C(Entity* self) {
     case 0:
         InitializeEntity(D_us_801809C8);
         self->drawFlags |=
-            FLAG_DRAW_UNK8 | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
+            FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
         if ((self->params & 0xF) > 1) {
-            self->unk6C = 0x20;
+            self->opacity = 0x20;
         } else {
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
         }
         self->rotX = D_us_8018158C[self->params & 0xF];
         self->rotY = self->rotX;
@@ -195,15 +195,15 @@ void func_us_801BDA0C(Entity* self) {
             }
         }
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C++;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity++;
         }
         break;
 
     case 5:
         tempEntity = self + 2;
-        if (tempEntity->unk6C < 0x80) {
-            tempEntity->unk6C += 2;
+        if (tempEntity->opacity < 0x80) {
+            tempEntity->opacity += 2;
         }
         magnitude = self->ext.et_801BDA0C.unk80 / 0x10000;
         xOffset = (rcos(self->rotZ - 0x400) * magnitude) >> 0xC;

--- a/src/st/no3/e_death.c
+++ b/src/st/no3/e_death.c
@@ -630,13 +630,13 @@ void EntityDeathScytheShadow(Entity* self) {
         self->palette = 0x2D6;
         self->unk5A = 0x44;
         if (self->params) {
-            self->drawFlags = FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_OPACITY;
             self->ext.deathScythe.timer = 0x40;
         } else {
-            self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
             self->ext.deathScythe.timer = 0x20;
         }
-        self->unk6C = 0x40;
+        self->opacity = 0x40;
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         break;
 
@@ -646,9 +646,9 @@ void EntityDeathScytheShadow(Entity* self) {
             break;
         }
         if (self->params) {
-            self->unk6C--;
+            self->opacity--;
         } else {
-            self->unk6C -= 2;
+            self->opacity -= 2;
         }
         break;
     }

--- a/src/st/no3/e_fire_warg.c
+++ b/src/st/no3/e_fire_warg.c
@@ -652,8 +652,8 @@ void EntityFireWarg(Entity* self) {
         switch (self->step_s) {
         case 0:
             if (UnkCollisionFunc3(&D_801829DC) & 1) {
-                self->drawFlags = FLAG_DRAW_UNK8;
-                self->unk6C = 0x80;
+                self->drawFlags = FLAG_DRAW_OPACITY;
+                self->opacity = 0x80;
                 self->ext.fireWarg.unk80 = 0;
                 SetSubStep(1);
                 self->ext.fireWarg.unk80++;
@@ -672,21 +672,21 @@ void EntityFireWarg(Entity* self) {
         case 1:
             AnimateEntity(&D_80182900, self);
             self->ext.fireWarg.unk80 += 1;
-            self->unk6C -= 2;
-            if (self->unk6C == 0x40) {
+            self->opacity -= 2;
+            if (self->opacity == 0x40) {
                 PlaySfxPositional(SFX_WARG_DEATH_HOWL);
             }
-            if (!self->unk6C) {
+            if (!self->opacity) {
                 self->drawMode = DRAW_UNK_40 | DRAW_TPAGE;
                 self->palette = 0x15F;
-                self->unk6C = 0x80;
+                self->opacity = 0x80;
                 self->step_s += 1;
             }
             break;
         case 2:
             AnimateEntity(&D_80182900, self);
-            self->unk6C -= 2;
-            if (!self->unk6C) {
+            self->opacity -= 2;
+            if (!self->opacity) {
                 DestroyEntity(self);
                 DestroyEntity(self + 1);
                 return;

--- a/src/st/no3/e_outdoor_ents.c
+++ b/src/st/no3/e_outdoor_ents.c
@@ -182,7 +182,7 @@ void EntityForegroundTree(Entity* self) {
                 ent->posY.i.hi = var_s3 & 255;
                 ent->unk68 = var_s4;
                 if (self->params) {
-                    ent->unk6C = 0x60;
+                    ent->opacity = 0x60;
                 }
             } else {
                 ptrParams += 2;
@@ -204,28 +204,28 @@ void EntityForegroundTree(Entity* self) {
                 ent->posY.i.hi = var_s3 & 255;
                 ent->unk68 = var_s4;
                 if (self->params) {
-                    ent->unk6C = 0x60;
+                    ent->opacity = 0x60;
                 } else if (self->ext.utimer.t == 7) {
                     ent2 = AllocEntity(&g_Entities[192], &g_Entities[256]);
                     CreateEntityFromEntity(E_BACKGROUND_BLOCK, ent, ent2);
                     ent2->params = 0x12;
                     ent2->posY.i.hi -= 16;
                     ent2->unk68 = var_s4;
-                    ent2->unk6C = 0x40;
+                    ent2->opacity = 0x40;
                 } else if (self->ext.utimer.t == 10) {
                     ent2 = AllocEntity(&g_Entities[192], &g_Entities[256]);
                     CreateEntityFromEntity(E_BACKGROUND_BLOCK, ent, ent2);
                     ent2->params = 0x13;
                     ent2->posY.i.hi += 48;
                     ent2->unk68 = var_s4;
-                    ent2->unk6C = 0x40;
+                    ent2->opacity = 0x40;
                 } else if (self->ext.utimer.t == 15) {
                     ent2 = AllocEntity(&g_Entities[192], &g_Entities[256]);
                     CreateEntityFromEntity(E_BACKGROUND_BLOCK, ent, ent2);
                     ent2->params = 0x14;
                     ent2->posY.i.hi += 4;
                     ent2->unk68 = var_s4;
-                    ent2->unk6C = 0x40;
+                    ent2->opacity = 0x40;
                 }
             }
             self->ext.utimer.t++;
@@ -903,15 +903,15 @@ void EntityFlyingOwlAndLeaves(Entity* self) {
         self->animSet = ANIMSET_OVL(1);
         self->animCurFrame = 56;
         if (self->params) {
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_OPACITY;
             self->rotX = 0x180;
             self->rotY = 0x180;
-            self->unk6C = 0x60;
+            self->opacity = 0x60;
             self->posY.i.hi = -16;
             self->zPriority = 0xC1;
         } else {
-            self->drawFlags = FLAG_DRAW_UNK8;
-            self->unk6C = 0x20;
+            self->drawFlags = FLAG_DRAW_OPACITY;
+            self->opacity = 0x20;
             self->zPriority = 0xBF;
         }
         self->unk68 = 0x1C0;
@@ -972,8 +972,8 @@ void EntityFlyingOwlAndLeaves(Entity* self) {
         }
         animFlag = AnimateEntity(owlAnim1, self);
         MoveEntity();
-        if (self->unk6C < 0x78) {
-            self->unk6C += 2;
+        if (self->opacity < 0x78) {
+            self->opacity += 2;
         }
         if (self->posX.i.hi > 288 || self->posY.i.hi < -16) {
             DestroyEntity(self);

--- a/src/st/no3/e_outdoor_ents.c
+++ b/src/st/no3/e_outdoor_ents.c
@@ -903,7 +903,8 @@ void EntityFlyingOwlAndLeaves(Entity* self) {
         self->animSet = ANIMSET_OVL(1);
         self->animCurFrame = 56;
         if (self->params) {
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_OPACITY;
+            self->drawFlags =
+                FLAG_DRAW_ROTX | FLAG_DRAW_ROTY | FLAG_DRAW_OPACITY;
             self->rotX = 0x180;
             self->rotY = 0x180;
             self->opacity = 0x60;

--- a/src/st/no3/e_warg.c
+++ b/src/st/no3/e_warg.c
@@ -373,23 +373,23 @@ void EntityWarg(Entity* self) {
         switch (self->step_s) {
         case 0:
             if (UnkCollisionFunc3(D_8018327C) & 1) {
-                self->drawFlags = FLAG_DRAW_UNK8;
-                self->unk6C = 0x80;
+                self->drawFlags = FLAG_DRAW_OPACITY;
+                self->opacity = 0x80;
                 SetSubStep(1);
             }
             break;
         case 1:
             AnimateEntity(D_801831A0, self);
-            self->unk6C -= 2;
-            if (self->unk6C == 0x40) {
+            self->opacity -= 2;
+            if (self->opacity == 0x40) {
                 g_api.PlaySfx(SFX_WARG_DEATH_HOWL);
             }
-            if (self->unk6C) {
+            if (self->opacity) {
                 break;
             }
 
             self->palette = 0x15F;
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             primIndex = g_api.AllocPrimitives(4, 3);
             // That's weird, it should do == -1, right?
             if (!primIndex) {
@@ -464,8 +464,8 @@ void EntityWarg(Entity* self) {
             self->posX.i.hi = 0x40;
             self->posY.i.hi = 0x40;
             self->zPriority = 0x40;
-            self->unk6C -= 2;
-            if (!self->unk6C) {
+            self->opacity -= 2;
+            if (!self->opacity) {
                 DestroyEntity(self);
                 DestroyEntity(self + 1);
                 return;
@@ -575,10 +575,10 @@ void EntityWargExplosionPuffTransparent(Entity* entity) {
         entity->unk5A = 0x79;
         entity->palette = 0xD0;
         entity->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        entity->drawFlags = FLAG_DRAW_UNK8;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
         entity->pose = 0;
         entity->poseTimer = 0;
-        entity->unk6C = 0x60;
+        entity->opacity = 0x60;
         temp_v0 = entity->params & 0xFF00;
         if (temp_v0 != 0) {
             entity->zPriority = temp_v0 >> 8;

--- a/src/st/no4/e_frozen_shade.c
+++ b/src/st/no4/e_frozen_shade.c
@@ -153,9 +153,9 @@ void EntityFrozenShade(Entity* self) {
     if (self->step && !(self->flags & FLAG_DEAD)) {
         self->ext.frozenShade.unk7C++;
         if (self->ext.frozenShade.unk7C & 0x40) {
-            self->unk6C = (u8)(self->ext.frozenShade.unk7C & 0x3F) + 0x40;
+            self->opacity = (u8)(self->ext.frozenShade.unk7C & 0x3F) + 0x40;
         } else {
-            self->unk6C = 0x80 - (u8)(self->ext.frozenShade.unk7C & 0x3F);
+            self->opacity = 0x80 - (u8)(self->ext.frozenShade.unk7C & 0x3F);
         }
     }
     tempEntity = &PLAYER;
@@ -284,10 +284,10 @@ void EntityFrozenShade(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(g_EInitFrozenShade);
-        self->unk6C = 0x40;
+        self->opacity = 0x40;
         self->palette += self->params;
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_UNK8;
+        self->drawFlags = FLAG_DRAW_OPACITY;
         self->ext.frozenShade.unk7C = 0;
         if (self->posX.val < tempEntity->posX.val) {
             self->facingLeft = true;

--- a/src/st/no4/e_killer_fish.c
+++ b/src/st/no4/e_killer_fish.c
@@ -139,8 +139,8 @@ void EntityKillerFishDeathPuff(Entity* self) {
         self->unk5A = 0x79;
         self->palette = PAL_DRA(0x2E8);
         self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = 0x60;
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = 0x60;
         if (self->params & 0xFF00) {
             self->zPriority = (self->params & 0xFF00) >> 8;
         }

--- a/src/st/np3/gaibon.c
+++ b/src/st/np3/gaibon.c
@@ -756,9 +756,9 @@ void EntityLargeGaibonProjectile(Entity* self) {
         } else {
             self->animSet = ANIMSET_DRA(14);
             self->unk5A = 0x79;
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
             self->rotX = 0x100;
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             self->palette = PAL_OVL(0x1F3);
             self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
             self->step = 2;
@@ -782,7 +782,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
         break;
 
     case 2:
-        self->unk6C += 0xFE;
+        self->opacity += 0xFE;
         self->rotX -= 4;
         if (AnimateEntity(D_801815FC, self) == 0) {
             DestroyEntity(self);

--- a/src/st/np3/gaibon.c
+++ b/src/st/np3/gaibon.c
@@ -756,7 +756,8 @@ void EntityLargeGaibonProjectile(Entity* self) {
         } else {
             self->animSet = ANIMSET_DRA(14);
             self->unk5A = 0x79;
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
+            self->drawFlags =
+                FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
             self->rotX = 0x100;
             self->opacity = 0x80;
             self->palette = PAL_OVL(0x1F3);

--- a/src/st/nz0/gaibon.c
+++ b/src/st/nz0/gaibon.c
@@ -654,9 +654,9 @@ void EntityLargeGaibonProjectile(Entity* self) {
         } else {
             self->animSet = ANIMSET_DRA(14);
             self->unk5A = 0x79;
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
             self->rotX = 0x100;
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             self->palette = PAL_OVL(0x1F3);
             self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
             self->step = 2;
@@ -680,7 +680,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
         break;
 
     case 2:
-        self->unk6C += 0xFE;
+        self->opacity += 0xFE;
         self->rotX -= 4;
         if (AnimateEntity(D_80181388, self) == 0) {
             DestroyEntity(self);

--- a/src/st/nz0/gaibon.c
+++ b/src/st/nz0/gaibon.c
@@ -654,7 +654,8 @@ void EntityLargeGaibonProjectile(Entity* self) {
         } else {
             self->animSet = ANIMSET_DRA(14);
             self->unk5A = 0x79;
-            self->drawFlags = FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
+            self->drawFlags =
+                FLAG_DRAW_ROTX | FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
             self->rotX = 0x100;
             self->opacity = 0x80;
             self->palette = PAL_OVL(0x1F3);

--- a/src/st/st0/2A8DC.c
+++ b/src/st/st0/2A8DC.c
@@ -78,8 +78,8 @@ void EntitySecretButton(Entity* self) {
     case 4:
         switch (self->step_s) {
         case 0:
-            self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
-            self->unk6C = 0x60;
+            self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
+            self->opacity = 0x60;
             self->velocityX = 0;
             self->velocityY = 0;
             self->step_s++;

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -344,7 +344,7 @@ static s32 func_801ABBBC(s32 step, Entity* dracula) {
             }
 
             dracula->drawFlags = DRAW_HIDE;
-            dracula->unk6C = 0;
+            dracula->opacity = 0;
             dracula->ext.dracula.unkA0 = 1;
             step++;
         }
@@ -367,9 +367,9 @@ static s32 func_801ABBBC(s32 step, Entity* dracula) {
         break;
 
     case 8:
-        dracula->unk6C += 10;
-        if (dracula->unk6C >= 0x80) {
-            dracula->unk6C = 0x80;
+        dracula->opacity += 10;
+        if (dracula->opacity >= 0x80) {
+            dracula->opacity = 0x80;
             dracula->drawFlags = FLAG_DRAW_DEFAULT;
             step++;
         }
@@ -728,8 +728,8 @@ void EntityDracula(Entity* self) {
         case 3:
             self->ext.dracula.unk94 = 0x40;
             self->ext.dracula.unk98 = 0;
-            self->unk6C = 0x80;
-            self->drawFlags |= FLAG_DRAW_UNK8;
+            self->opacity = 0x80;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
             prim = self->ext.dracula.prim;
             prim->type = PRIM_G4;
             prim->x0 = prim->x2 = self->posX.i.hi;
@@ -819,8 +819,8 @@ void EntityDracula(Entity* self) {
             prim->x0 = prim->x2 = xOffset;
             prim->x1 = prim->x3 = xOffset + 0x30;
 
-            if (self->unk6C) {
-                self->unk6C -= 8;
+            if (self->opacity) {
+                self->opacity -= 8;
             }
 
             if (self->ext.dracula.unk94 < 0xF0) {

--- a/src/st/st0/2DAC8.c
+++ b/src/st/st0/2DAC8.c
@@ -260,7 +260,7 @@ void EntityDraculaFinalForm(Entity* self) {
         if (D_80180910 != 0) {
             self->animCurFrame = 1;
             self->hitboxState = 3;
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             self->drawFlags = FLAG_DRAW_DEFAULT;
             SetStep(2);
         }
@@ -548,9 +548,9 @@ void EntityDraculaFinalForm(Entity* self) {
                     self->unk5A = 0x5E;
                     self->palette = PAL_OVL(0x15F);
                     self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
-                    self->drawFlags = FLAG_DRAW_UNK8;
+                    self->drawFlags = FLAG_DRAW_OPACITY;
                     self->drawFlags |= FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
-                    self->unk6C = 0x10;
+                    self->opacity = 0x10;
                     self->rotX = self->rotY = 0x400;
                     g_api.PlaySfx(0x880);
                     self->step_s++;
@@ -571,23 +571,23 @@ void EntityDraculaFinalForm(Entity* self) {
                     self->animCurFrame = 1;
                     self->unk5A = 0x50;
                     self->palette = PAL_OVL(0x15F);
-                    self->drawFlags = FLAG_DRAW_UNK8;
-                    self->unk6C = 0;
+                    self->drawFlags = FLAG_DRAW_OPACITY;
+                    self->opacity = 0;
                     self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
                     self->step_s++;
                 }
                 break;
             case 4:
-                self->unk6C += 4;
+                self->opacity += 4;
                 self->animCurFrame = entity->animCurFrame;
-                if (self->unk6C > 0x60) {
+                if (self->opacity > 0x60) {
                     self->step_s++;
                 }
                 break;
             case 5:
-                self->unk6C -= 4;
+                self->opacity -= 4;
                 self->animCurFrame = entity->animCurFrame;
-                if (!self->unk6C) {
+                if (!self->opacity) {
                     self->animCurFrame = 0;
                     self->drawMode = DRAW_DEFAULT;
                     self->drawFlags = FLAG_DRAW_DEFAULT;

--- a/src/st/st0/3AB08.c
+++ b/src/st/st0/3AB08.c
@@ -1118,10 +1118,10 @@ void EntityCutscenePhotographFire(Entity* entity) {
         entity->unk5A = 0x57;
         entity->palette = PAL_OVL(0x285);
         entity->flags &= ~FLAG_POS_CAMERA_LOCKED;
-        entity->drawFlags = FLAG_DRAW_UNK8;
-        entity->unk6C = 0x40;
+        entity->drawFlags = FLAG_DRAW_OPACITY;
+        entity->opacity = 0x40;
         if (entity->params) {
-            entity->unk6C = 0x10;
+            entity->opacity = 0x10;
             entity->zPriority = 0x1FB;
             entity->drawMode = DRAW_UNK_40 | DRAW_TPAGE;
         } else {

--- a/src/weapon/w_011.c
+++ b/src/weapon/w_011.c
@@ -450,9 +450,9 @@ static void func_ptr_80170024(Entity* self) {
         if (self->params & 0x7F00) {
             self->flags = FLAG_POS_CAMERA_LOCKED;
             self->animCurFrame = self->ext.shield.parent->animCurFrame;
-            self->drawFlags = FLAG_DRAW_UNK8;
+            self->drawFlags = FLAG_DRAW_OPACITY;
             self->drawMode = DRAW_TPAGE;
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             self->poseTimer = 0x18;
             self->zPriority -= 2;
             self->step = 4;
@@ -619,7 +619,7 @@ static void func_ptr_80170024(Entity* self) {
         }
         break;
     case 4:
-        self->unk6C -= 2;
+        self->opacity -= 2;
         if (--self->poseTimer < 0) {
             DestroyEntity(self);
             return;

--- a/src/weapon/w_012.c
+++ b/src/weapon/w_012.c
@@ -459,13 +459,13 @@ static void func_ptr_80170008(Entity* self) {
         self->flags =
             FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_UNK_20000;
         self->palette = self->ext.weapon.parent->palette;
-        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_UNK8;
+        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
         self->rotZ = self->ext.weapon.parent->rotZ;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->step++;
     }
-    if (self->unk6C >= 48) {
-        self->unk6C -= 8;
+    if (self->opacity >= 48) {
+        self->opacity -= 8;
         return;
     }
     DestroyEntity(self);

--- a/src/weapon/w_012.c
+++ b/src/weapon/w_012.c
@@ -459,7 +459,8 @@ static void func_ptr_80170008(Entity* self) {
         self->flags =
             FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_UNK_20000;
         self->palette = self->ext.weapon.parent->palette;
-        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
+        self->drawFlags =
+            self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
         self->rotZ = self->ext.weapon.parent->rotZ;
         self->opacity = 0x80;
         self->step++;

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -229,13 +229,13 @@ s32 func_ptr_80170004(Entity* self) {
         self->flags =
             FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_UNK_20000;
         self->palette = self->ext.weapon.parent->ext.weapon.childPalette;
-        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_UNK8;
+        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
         self->rotZ = self->ext.weapon.parent->rotZ;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->step++;
     }
-    if (self->unk6C >= 48) {
-        self->unk6C -= 8;
+    if (self->opacity >= 48) {
+        self->opacity -= 8;
         return;
     }
     DestroyEntity(self);

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -229,7 +229,8 @@ s32 func_ptr_80170004(Entity* self) {
         self->flags =
             FLAG_POS_CAMERA_LOCKED | FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_UNK_20000;
         self->palette = self->ext.weapon.parent->ext.weapon.childPalette;
-        self->drawFlags = self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
+        self->drawFlags =
+            self->ext.weapon.parent->drawFlags + FLAG_DRAW_OPACITY;
         self->rotZ = self->ext.weapon.parent->rotZ;
         self->opacity = 0x80;
         self->step++;

--- a/src/weapon/w_015.c
+++ b/src/weapon/w_015.c
@@ -119,12 +119,12 @@ s32 func_ptr_80170004(Entity* self) {
         self->unk5A = self->ext.weapon.parent->unk5A;
         self->ext.timer.t = 10;
         self->drawMode = DRAW_TPAGE;
-        self->drawFlags = FLAG_DRAW_UNK8;
-        self->unk6C = 0x80;
+        self->drawFlags = FLAG_DRAW_OPACITY;
+        self->opacity = 0x80;
         self->step++;
     }
-    if (self->unk6C >= 0x30) {
-        self->unk6C += 0xF8;
+    if (self->opacity >= 0x30) {
+        self->opacity += 0xF8;
     }
 
     if (--self->ext.timer.t == 0) {

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -118,18 +118,18 @@ s32 func_ptr_80170004(Entity* self) {
         self->palette = self->ext.weapon.parent->palette;
         self->unk5A = self->ext.weapon.parent->unk5A;
         self->ext.weapon.lifetime = 0x16;
-        self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_UNK8;
+        self->drawFlags = FLAG_DRAW_ROTZ | FLAG_DRAW_OPACITY;
         self->drawMode = DRAW_TPAGE;
         self->rotZ = self->ext.weapon.parent->rotZ;
-        self->unk6C = 0x80;
+        self->opacity = 0x80;
         self->step++;
     }
     if (--self->ext.weapon.lifetime == 0) {
         DestroyEntity(self);
         return;
     }
-    if (self->unk6C >= 48) {
-        self->unk6C -= 8;
+    if (self->opacity >= 48) {
+        self->opacity -= 8;
     }
 }
 

--- a/src/weapon/w_019.c
+++ b/src/weapon/w_019.c
@@ -88,9 +88,9 @@ void EntityWeaponAttack(Entity* self) {
             self->drawMode = DRAW_TPAGE2 | DRAW_TPAGE;
         }
         if (self->pose == 5) {
-            self->unk6C = 0x80;
+            self->opacity = 0x80;
             self->flags &= ~FLAG_POS_PLAYER_LOCKED;
-            self->drawFlags |= FLAG_DRAW_UNK8;
+            self->drawFlags |= FLAG_DRAW_OPACITY;
             self->step++;
         }
         break;
@@ -98,8 +98,8 @@ void EntityWeaponAttack(Entity* self) {
         self->rotX += 0x10;
         self->rotY = self->rotX;
         self->rotZ += 0x40;
-        if (self->unk6C >= 5) {
-            self->unk6C += 0xFE;
+        if (self->opacity >= 5) {
+            self->opacity += 0xFE;
         }
         if (self->poseTimer < 0) {
             DestroyEntity(self);

--- a/src/weapon/w_020.c
+++ b/src/weapon/w_020.c
@@ -184,7 +184,7 @@ static void EntityWeaponAttack(Entity* self) {
                 self->animCurFrame = 0x1D;
                 self->flags &= ~(FLAG_POS_CAMERA_LOCKED | FLAG_UNK_100000);
                 self->ext.karmacoin.timer = 0xE0;
-                self->unk6C = 0x80;
+                self->opacity = 0x80;
                 g_api.func_80118C28(8);
                 g_api.PlaySfx(SFX_TRANSFORM_3X);
                 prim = &g_PrimBuf[self->primIndex];
@@ -329,10 +329,10 @@ static void EntityWeaponAttack(Entity* self) {
         prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 = prim->b3;
         break;
     case 8:
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C--;
-        if (self->unk6C < 4) {
-            self->unk6C = 4;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity--;
+        if (self->opacity < 4) {
+            self->opacity = 4;
         }
         prim = &g_PrimBuf[self->primIndex];
         if (prim->b1 > 8) {
@@ -349,10 +349,10 @@ static void EntityWeaponAttack(Entity* self) {
         }
         break;
     case 9:
-        self->drawFlags |= FLAG_DRAW_UNK8;
-        self->unk6C -= 2;
-        if (self->unk6C < 4) {
-            self->unk6C = 4;
+        self->drawFlags |= FLAG_DRAW_OPACITY;
+        self->opacity -= 2;
+        if (self->opacity < 4) {
+            self->opacity = 4;
         }
         prim = &g_PrimBuf[self->primIndex];
         if (prim->b1 >= 9) {

--- a/src/weapon/w_029.c
+++ b/src/weapon/w_029.c
@@ -178,13 +178,13 @@ s32 func_ptr_80170004(Entity* self) {
         self->ext.weapon.unk80 = self->ext.weapon.parent->ext.weapon.unk80;
         self->animCurFrame = self->ext.weapon.parent->animCurFrame;
         self->flags = FLAG_POS_CAMERA_LOCKED;
-        self->drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_UNK10;
-        self->unk6C = 0x80;
+        self->drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_UNK10;
+        self->opacity = 0x80;
         self->ext.weapon.unk7E = 0x14;
         self->step++;
     } else {
-        if (self->unk6C >= 7) {
-            self->unk6C -= 7;
+        if (self->opacity >= 7) {
+            self->opacity -= 7;
         }
 
         if (--self->ext.weapon.unk7E == 0) {

--- a/src/weapon/w_030.c
+++ b/src/weapon/w_030.c
@@ -721,7 +721,7 @@ void func_ptr_80170008(Entity* self) {
             }
             self->step = 3;
             self->drawFlags &= FLAG_DRAW_UNK40 | FLAG_DRAW_UNK20 |
-                               FLAG_DRAW_UNK10 | FLAG_DRAW_UNK8 |
+                               FLAG_DRAW_UNK10 | FLAG_DRAW_OPACITY |
                                FLAG_DRAW_ROTZ | FLAG_DRAW_ROTY | FLAG_DRAW_ROTX;
             break;
         }

--- a/src/weapon/w_045.c
+++ b/src/weapon/w_045.c
@@ -325,8 +325,8 @@ static s32 func_ptr_80170010(Entity* self) {
         }
         return;
     case 2:
-        PLAYER.drawFlags = FLAG_DRAW_UNK8 | FLAG_DRAW_ROTZ;
-        PLAYER.unk6C = (rsin(D_13F000_8017B3BC) >> 7) - 0x40;
+        PLAYER.drawFlags = FLAG_DRAW_OPACITY | FLAG_DRAW_ROTZ;
+        PLAYER.opacity = (rsin(D_13F000_8017B3BC) >> 7) - 0x40;
         if (!(g_Player.vram_flag & 1)) {
             PLAYER.step = Player_AxearmorJump;
             PLAYER.step_s = 0;

--- a/tools/lints/sotn-lint/src/drawflags.rs
+++ b/tools/lints/sotn-lint/src/drawflags.rs
@@ -12,7 +12,7 @@ lazy_static! {
         (1 << 0, "FLAG_DRAW_ROTX"),
         (1 << 1, "FLAG_DRAW_ROTY"),
         (1 << 2, "FLAG_DRAW_ROTZ"),
-        (1 << 3, "FLAG_DRAW_UNK8"),
+        (1 << 3, "FLAG_DRAW_OPACITY"),
         (1 << 4, "FLAG_DRAW_UNK10"),
         (1 << 5, "FLAG_DRAW_UNK20"),
         (1 << 6, "FLAG_DRAW_UNK40"),
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn test_equality() {
         let input_line = "if (self->drawFlags == 8) {";
-        let expected_line = "if (self->drawFlags == FLAG_DRAW_UNK8) {";
+        let expected_line = "if (self->drawFlags == FLAG_DRAW_OPACITY) {";
         let result = FT.transform_line(input_line);
         assert_eq!(result, expected_line)
     }
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn test_inequality() {
         let input_line = "if (self->drawFlags != 8) {";
-        let expected_line = "if (self->drawFlags != FLAG_DRAW_UNK8) {";
+        let expected_line = "if (self->drawFlags != FLAG_DRAW_OPACITY) {";
         let result = FT.transform_line(input_line);
         assert_eq!(result, expected_line)
     }


### PR DESCRIPTION
Turns out this was already discovered in a comment in `ghost.c`. Named now, both the entity member and the draw flag.

Mostly a find and replace, but not a fully automatic one; I checked as I went to make sure the member didn't get renamed in any other structs, so this should just be entities.