### PR TITLE
Partial configuration for BO4 assets

### DIFF
--- a/config/assets.us.yaml
+++ b/config/assets.us.yaml
@@ -573,6 +573,22 @@ files:
           - [0x1308, skip]
           - [0x1424, cutscene, cutscene_data]
           - [0x15DC, skip]
+  - target: disks/us/BOSS/BO4/BO4.BIN
+    asset_path: assets/boss/bo4
+    src_path: src/boss/bo4
+    splat_config_path: config/splat.us.bobo4.yaml
+    segments:
+      - start: 0
+        vram: 0x80180000
+        assets:
+          #- [0x34, sprite_banks, sprite_banks]
+          #- [0x94, paldef, palette_def]
+          - [0xF0, layers, layers]
+          - [0x118, gfx_banks, graphics_banks]
+          - [0x188, layout, entity_layouts]
+          - [0x330, skip]
+          - [0x11CC, rooms, rooms]
+          - [0x11E8, skip]
   - target: disks/us/BOSS/RBO3/RBO3.BIN
     asset_path: assets/boss/rbo3
     src_path: src/boss/rbo3

--- a/config/splat.us.bobo4.yaml
+++ b/config/splat.us.bobo4.yaml
@@ -18,6 +18,7 @@ options:
   use_legacy_include_asm: false
   migrate_rodata_to_functions: true
   asm_jtbl_label_macro: jlabel
+  extensions_path: tools/splat_ext
   symbol_name_format: us_$VRAM
   section_order:
     - .data
@@ -39,13 +40,13 @@ segments:
     align: 4
     subalign: 4
     subsegments:
-      - [0x0, data, header]
-      # - [0x2C, data, header] # sprite_banks
-      # - [0x94, data, header] # pallet_def
-      # - [0xF0, data, header] # layers
-      # - [0x118, data, header] # graphics banks
-      # - [0x188, data, e_laydef]
-      - [0x32C, data, e_init]
+      - [0x0, .data, header]
+      #- [0x34, data, header] # sprite_banks
+      #- [0x94, data, header] # pallet_def
+      #- [0xF0, data, header] # layers
+      #  [0x118, data, header] # graphics banks
+      - [0x188, .data, gen/e_laydef]
+      - [0x330, data, e_init]
       - [0x464, .data, background_block_init]
       - [0x49C, .data, e_red_door_tiles]
       - [0x4BC, .data, e_lock_camera]
@@ -62,12 +63,18 @@ segments:
       - [0xFA4, .data, e_misc]
       - [0x10C0, .data, e_particles]
       - [0x1140, .data, e_room_fg]
-      - [0x11CC, data, rooms]
+      - [0x11CC, .data, gen/rooms]
       - [0x11E8, data, doppleganger]
       - [0x12E4, .data, dop_anim]
       - [0x1318, data]
       - [0x4290, .data, e_life_up]
-      - [0x42E4, data]
+      - [0x42E4, .data, gen/e_layout]
+      - [0x435C, data]
+      - [0x2BEA0, cmp, D_801ABEA0]
+      - [0x2C180, cmp, D_801AC180]
+      - [0x2C288, pal, D_us_801AC288]
+      - [0x2C668, .data, tile_data]
+      - [0x30A78, data]
       - [0x340E4, .rodata, doors]
       - [0x34188, .rodata, unk_365FC]
       - [0x341A8, .rodata, e_red_door]

--- a/config/symbols.us.bobo4.txt
+++ b/config/symbols.us.bobo4.txt
@@ -1,3 +1,7 @@
+BO4_spriteBanks = 0x80180034;
+BO4_cluts = 0x801800E0;
+BO4_rooms_layers = 0x80180110;
+BO4_gfxBanks = 0x80180138;
 BO4_pStObjLayoutHorizontal = 0x80180188;
 BO4_pStObjLayoutVertical = 0x8018025C;
 BO4_EntityUpdates = 0x80180330;

--- a/include/game.h
+++ b/include/game.h
@@ -1302,6 +1302,26 @@ typedef struct {
     /* 8003C79C */ void (*UpdateStageEntities)(void);
 } AbbreviatedOverlay;
 
+/*
+ * A second type of abbreviated overlay which allows
+ * two spritebanks and provides no cutscene handler.
+ */
+typedef struct {
+    /* 8003C774 */ void (*Update)(void);
+    /* 8003C778 */ void (*HitDetection)(void);
+    /* 8003C77C */ void (*UpdateRoomPosition)(void);
+    /* 8003C780 */ void (*InitRoomEntities)(s32 layoutId);
+    /* 8003C784 */ RoomHeader* rooms;
+    /* 8003C788 */ SpriteParts** spriteBanks;
+    /* 8003C78C */ u_long** cluts;
+    /* 8003C790 */ void* objLayoutHorizontal;
+    /* 8003C794 */ RoomDef* tileLayers;
+    /* 8003C798 */ GfxBank** gfxBanks;
+    /* 8003C79C */ void (*UpdateStageEntities)(void);
+    /* 8003C7A0 */ u8** unk2C; // sprite bank 1
+    /* 8003C7A4 */ u8** unk30; // sprite bank 2
+} AbbreviatedOverlay2;
+
 typedef enum {
     EFFECT_NONE = 0,
     EFFECT_SOLID = 1 << 0,

--- a/src/boss/bo4/header.c
+++ b/src/boss/bo4/header.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "bo4.h"
+
+extern RoomHeader OVL_EXPORT(rooms)[];
+extern s16** OVL_EXPORT(spriteBanks)[];
+extern u_long* OVL_EXPORT(cluts)[];
+extern LayoutEntity* OVL_EXPORT(pStObjLayoutHorizontal)[];
+extern RoomDef OVL_EXPORT(rooms_layers)[];
+extern u_long* OVL_EXPORT(gfxBanks)[];
+void UpdateStageEntities();
+
+extern u8* g_SpriteSheet[0x34C];
+extern u8* g_PlOvlDopBatSpritesheet[6];
+
+AbbreviatedOverlay2 OVL_EXPORT(Overlay) = {
+    .Update = Update,
+    .HitDetection = HitDetection,
+    .UpdateRoomPosition = UpdateRoomPosition,
+    .InitRoomEntities = InitRoomEntities,
+    .rooms = OVL_EXPORT(rooms),
+    .spriteBanks = OVL_EXPORT(spriteBanks),
+    .cluts = OVL_EXPORT(cluts),
+    .objLayoutHorizontal = BO4_pStObjLayoutHorizontal,
+    .tileLayers = OVL_EXPORT(rooms_layers),
+    .gfxBanks = OVL_EXPORT(gfxBanks),
+    .UpdateStageEntities = UpdateStageEntities,
+    .unk2C = g_SpriteSheet,
+    .unk30 = g_PlOvlDopBatSpritesheet,
+};
+
+extern s16* D_us_801B0A78[];
+extern s16* D_us_801B159C[];
+extern s16* D_us_801B1664[];
+extern s16* D_us_801B2068[];
+extern s16* D_us_801B252C[];
+
+s16** OVL_EXPORT(spriteBanks)[] = {
+    NULL, D_us_801B0A78, D_us_801B159C, D_us_801B1664, D_us_801B2068, NULL,
+    NULL, NULL,          NULL,          NULL,          NULL,          NULL,
+    NULL, NULL,          NULL,          D_us_801B252C, NULL,          NULL,
+    NULL, NULL,          NULL,          NULL,          NULL,          NULL,
+};
+
+extern s16* D_us_801AC288[0x180];
+
+static u_long* D_us_80180094[] = {
+    MAKE_PAL_OP(PAL_BULK_COPY, 0),
+    PAL_BULK(0x2000, D_us_801AC288),
+    PAL_TERMINATE(),
+};
+
+static u_long* D_us_801800A8[] = {
+    PAL_COPY_INFO(),
+    PAL_COPY_DATA_(0x20F0, g_Clut + 0x20A0, 16),
+};
+
+static u_long* D_us_801800B8[] = {
+    MAKE_PAL_OP(PAL_UNK_OP2, 2),
+    PAL_COPY_DATA_(0x20F0, g_Clut + 0x20C0, 16),
+    PAL_TERMINATE(),
+};
+
+static u_long* D_us_801800CC[] = {
+    MAKE_PAL_OP(PAL_UNK_OP2, 2),
+    PAL_COPY_DATA_(0x20F0, g_Clut + 0x2000, 16),
+    PAL_TERMINATE(),
+};
+
+u_long* OVL_EXPORT(cluts)[] = {
+    D_us_80180094,
+    D_us_801800B8,
+    D_us_801800CC,
+    D_us_801800A8,
+};
+
+#include "gen/layers.h"
+#include "gen/graphics_banks.h"

--- a/src/boss/bo4/tile_data.c
+++ b/src/boss/bo4/tile_data.c
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <stage.h>
+
+#include "gen/tilemap_2C668.h"
+#include "gen/tiledef_30A68.h"


### PR DESCRIPTION
BO4 is the first of several overlays which use yet another `Overlay` struct. This follows the same layout as `Overlay` and `AbbreviatedOverlay`, but contains only two sprite banks and no cutscene handler. There are a few other overlays that use this structure that haven't been started yet.

`sotn-assets` is having trouble with the sprite banks (possibly because of this new overlay struct), as well as the palette definitions, so those are imported in code. Everything else is extracted as assets.