### PR TITLE
Allow empty layer to fall to BSS on PSP

### DIFF
--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -253,8 +253,8 @@ func buildLayers(inputDir string, fileName string, outputDir string) error {
 		sb.WriteString(fmt.Sprintf("extern TileDefinition %s[];\n", symbol))
 	}
 
-	sb.WriteString("LayerDef layer_empty = { NULL, NULL, 0, 0, 0 };\n")
-	sb.WriteString("LayerDef layers[] = {\n")
+	sb.WriteString("static LayerDef layer_empty = { NULL, NULL, 0, 0, 0 };\n")
+	sb.WriteString("static LayerDef layers[] = {\n")
 	for _, l := range layers[1:] {
 		sb.WriteString(fmt.Sprintf("    { %s, %s, {%d, %d, %d, %d, 0x%02X}, 0x%02X, 0x%04X},\n",
 			makeSymbolFromFileName(l["data"].(string)),


### PR DESCRIPTION
Relevant discussion: https://discord.com/channels/1079389589950705684/1079395311350452255/1383964608548573234

```c
LayerDef layer_empty = { NULL, NULL, 0, 0, 0 };
LayerDef layers[] = {
    { tilemap_18838, tiledef_2EA58, {2, 38, 3, 40, 0x01}, 0x60, 0x0003},
    { tilemap_19438, tiledef_2EA58, {0, 0, 0, 0, 0x00}, 0x20, 0x0003},
```