### PR TITLE
Dockerfile: reduce the number of steps to set-up a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+__pycache__/
+.venv/
+.idea/
+.vscode/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,19 @@
 # 2. launch container and mount current directory under /sotn
 # docker run --name sotn-work -it -v $(pwd):/sotn -v sotn_venv:/sotn/.venv -v sotn_build:/sotn/build sotn-build
 #
-# 3. inside the container, sym-link the .venv dir and perform an update
-# python3 -m venv .venv
-# source .venv/bin/activate
-# make update-dependencies
-#
-# 4. you now prepared an image that can help you build and work SOTN
+# 3. you are now ready to build and work on SOTN
 # make expected
 #
-# 5. from now on, to re-use the same container execute the following:
+# 4. from now on, to re-use the same container execute the following:
 # docker start -ai sotn-work
 
 FROM ubuntu:noble
+
 COPY /tools/requirements-debian.txt /tools/requirements-debian.txt
+COPY /tools/requirements-python.txt /tools/requirements-python.txt
+COPY --from=golang:1.24-bookworm /usr/local/go/ /usr/local/go/
+
+WORKDIR /sotn
 RUN apt-get update && \
     apt-get install -y $(cat /tools/requirements-debian.txt) && \
     git clone --depth 1 https://github.com/sozud/dosemu-deb.git /dosemu && \
@@ -27,12 +27,17 @@ RUN apt-get update && \
     dpkg -i /dosemu/comcom32_0.1~alpha3-1_all.deb && \
     dpkg -i /dosemu/dosemu2_2.0~pre9-1_amd64.deb && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /dosemu && \
+    chown ubuntu:ubuntu /sotn
 
-WORKDIR /sotn
-RUN chown ubuntu:ubuntu /sotn
 USER ubuntu
-RUN mkdir -p /sotn/.venv /sotn/build
+RUN mkdir -p /sotn/.venv /sotn/build && \
+    mkdir -p ~/go/bin && \
+    ln -s /usr/local/go/bin/go ~/go/bin/go && \
+    git config --global --add safe.directory /sotn && \
+    python3 -m venv .venv && \
+    . .venv/bin/activate && \
+    pip3 install -r /tools/requirements-python.txt
 
-RUN git config --global --add safe.directory /sotn
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This greatly simplify how developers interact with SOTN using a Docker container. This essentially skips the need of performing a `make update-dependencies` the first time a container is created:

* Go is installed inside the image
* Python dependencies and the .venv are installed inside the image

Once the image is built, you can run it by mounting the volumes as usual and you can get an :ok: by just running `make`. Super simple! 

After this PR I plan on adding a CI step to push the image on Docker Hub, so anyone can pull it to further minimize the development set-up.