### PR TITLE
Push sotn-build image to Docker Hub

### DIFF
--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -6,8 +6,8 @@ on:
       - master
     paths:
       - 'Dockerfile'
-      - 'tools/**'
-      - 'Makefile*'
+      - 'tools/requirements-debian.txt'
+      - 'tools/requirements-python.txt'
   workflow_dispatch:
 
 jobs:
@@ -18,5 +18,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-      - name: Build image
-        run: docker build .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/sotn-build:latest


### PR DESCRIPTION
Depending to #2684 . The goal here is to have an image ready to be pulled that can be used to build SOTN with the minimum amount of steps possible. This will also be used to build #2638 in a 5yo step-by-step guide.

I am not sure if we can use this image for our GitHub CI. I plan to experiment on it on a different pull request.

I decided to use Docker Hub as a registry as it is the default one Docker and Docker Desktop use. If we ever want to use a Docker image on GHA, I will also upload it to GitHub Registry to prevent inbound traffic and the Docker Hub pull limit.