### PR TITLE
[Asset Tool] Add better PSP support

### DIFF
--- a/tools/sotn-assets/asset_config.go
+++ b/tools/sotn-assets/asset_config.go
@@ -135,6 +135,7 @@ func enqueueExtractAssetEntry(
 			AssetDir:    assetDir,
 			SrcDir:      srcDir,
 			RamBase:     ramBase,
+			Boundaries:  ramBase.Boundaries(),
 			Name:        name,
 			Args:        args,
 			SplatConfig: splatConfig,

--- a/tools/sotn-assets/assets/assets.go
+++ b/tools/sotn-assets/assets/assets.go
@@ -16,6 +16,7 @@ type ExtractArgs struct {
 	Args        []string
 	SplatConfig *splat.Config
 	RamBase     psx.Addr
+	Boundaries  psx.Offsets
 	Symbol      func(addr psx.Addr) string
 }
 type Extractor interface {
@@ -35,6 +36,7 @@ type Builder interface {
 type InfoArgs struct {
 	StageFilePath string
 	StageData     []byte
+	Boundaries    psx.Offsets
 }
 type InfoAssetEntry struct {
 	DataRange datarange.DataRange

--- a/tools/sotn-assets/assets/gfxbanks/handler.go
+++ b/tools/sotn-assets/assets/gfxbanks/handler.go
@@ -115,7 +115,8 @@ func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
 	if err != nil {
 		return assets.InfoResult{}, err
 	}
-	gfx, headerDataRange, err := ReadGraphics(r, psx.RamStageBegin, header.Graphics, func(addr psx.Addr) string {
+	boundaries := header.Graphics.Boundaries()
+	gfx, headerDataRange, err := ReadGraphics(r, boundaries.StageBegin, header.Graphics, func(addr psx.Addr) string {
 		return ""
 	})
 	if err != nil {

--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -57,8 +57,8 @@ func (l *layerDef) tilemapFileSize() int {
 
 func (l *layerDef) unpack() layerUnpacked {
 	return layerUnpacked{
-		Data:          tilemapFileName(l.Data),
-		Tiledef:       tiledefFileName(l.Tiledef),
+		Data:          tilemapFileName(int(l.Data)),
+		Tiledef:       tiledefFileName(int(l.Tiledef)),
 		Left:          int((l.PackedInfo >> 0) & 0x3F),
 		Top:           int((l.PackedInfo >> 6) & 0x3F),
 		Right:         int((l.PackedInfo >> 12) & 0x3F),
@@ -84,11 +84,11 @@ func (r roomLayers) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func readLayers(r io.ReadSeeker, off psx.Addr) ([]roomLayers, datarange.DataRange, error) {
+func readLayers(r io.ReadSeeker, off, baseAddr psx.Addr) ([]roomLayers, datarange.DataRange, error) {
 	if off == 0 {
 		return nil, datarange.DataRange{}, nil
 	}
-	if err := off.MoveFile(r, psx.RamStageBegin); err != nil {
+	if err := off.MoveFile(r, baseAddr); err != nil {
 		return nil, datarange.DataRange{}, err
 	}
 
@@ -99,8 +99,8 @@ func readLayers(r io.ReadSeeker, off psx.Addr) ([]roomLayers, datarange.DataRang
 		if err := binary.Read(r, binary.LittleEndian, layersOff); err != nil {
 			return nil, datarange.DataRange{}, err
 		}
-		if layersOff[0] <= psx.RamStageBegin || layersOff[0] >= off ||
-			layersOff[1] <= psx.RamStageBegin || layersOff[1] >= off {
+		if layersOff[0] <= baseAddr || layersOff[0] >= off ||
+			layersOff[1] <= baseAddr || layersOff[1] >= off {
 			break
 		}
 		layerOffsets = append(layerOffsets, layersOff...)
@@ -114,7 +114,7 @@ func readLayers(r io.ReadSeeker, off psx.Addr) ([]roomLayers, datarange.DataRang
 			continue
 		}
 
-		if err := layerOffset.MoveFile(r, psx.RamStageBegin); err != nil {
+		if err := layerOffset.MoveFile(r, baseAddr); err != nil {
 			return nil, datarange.DataRange{}, err
 		}
 		var l layerDef

--- a/tools/sotn-assets/assets/layer/tile_map.go
+++ b/tools/sotn-assets/assets/layer/tile_map.go
@@ -7,8 +7,8 @@ import (
 	"io"
 )
 
-func readTilemap(r io.ReadSeeker, layer *layerDef) ([]byte, datarange.DataRange, error) {
-	if err := layer.Data.MoveFile(r, psx.RamStageBegin); err != nil {
+func readTilemap(r io.ReadSeeker, baseAddr psx.Addr, layer *layerDef) ([]byte, datarange.DataRange, error) {
+	if err := layer.Data.MoveFile(r, baseAddr); err != nil {
 		return nil, datarange.DataRange{}, err
 	}
 	data := make([]byte, layer.tilemapFileSize())
@@ -18,13 +18,13 @@ func readTilemap(r io.ReadSeeker, layer *layerDef) ([]byte, datarange.DataRange,
 	return data, datarange.FromAddr(layer.Data, len(data)), nil
 }
 
-func readAllTileMaps(r io.ReadSeeker, roomLayers []roomLayers) (map[psx.Addr][]byte, datarange.DataRange, error) {
+func readAllTileMaps(r io.ReadSeeker, baseAddr psx.Addr, roomLayers []roomLayers) (map[psx.Addr][]byte, datarange.DataRange, error) {
 	var ranges []datarange.DataRange
 	processed := map[psx.Addr][]byte{}
 	for _, rl := range roomLayers {
 		if rl.fg != nil {
 			if _, found := processed[rl.fg.Data]; !found {
-				td, r, err := readTilemap(r, rl.fg)
+				td, r, err := readTilemap(r, baseAddr, rl.fg)
 				if err != nil {
 					return nil, datarange.DataRange{}, fmt.Errorf("unable to read fg tilemap: %w", err)
 				}
@@ -34,7 +34,7 @@ func readAllTileMaps(r io.ReadSeeker, roomLayers []roomLayers) (map[psx.Addr][]b
 		}
 		if rl.bg != nil {
 			if _, found := processed[rl.bg.Data]; !found {
-				td, r, err := readTilemap(r, rl.bg)
+				td, r, err := readTilemap(r, baseAddr, rl.bg)
 				if err != nil {
 					return nil, datarange.DataRange{}, fmt.Errorf("unable to read fg tilemap: %w", err)
 				}

--- a/tools/sotn-assets/assets/layout/layout.go
+++ b/tools/sotn-assets/assets/layout/layout.go
@@ -102,8 +102,8 @@ func hydrateYOrderFields(x layouts, y layouts) error {
 	return nil
 }
 
-func readEntityLayout(r io.ReadSeeker, ovlName string, off psx.Addr, count int, isX bool) (layouts, []datarange.DataRange, error) {
-	if err := off.MoveFile(r, psx.RamStageBegin); err != nil {
+func readEntityLayout(r io.ReadSeeker, ovlName string, off, baseAddr psx.Addr, count int, isX bool) (layouts, []datarange.DataRange, error) {
+	if err := off.MoveFile(r, baseAddr); err != nil {
 		return layouts{}, nil, err
 	}
 
@@ -119,7 +119,7 @@ func readEntityLayout(r io.ReadSeeker, ovlName string, off psx.Addr, count int, 
 	var blocks [][]layoutEntry
 	var xRanges []datarange.DataRange
 	for _, blockOffset := range util.SortUniqueOffsets(blockOffsets) {
-		if err := blockOffset.MoveFile(r, psx.RamStageBegin); err != nil {
+		if err := blockOffset.MoveFile(r, baseAddr); err != nil {
 			return layouts{}, nil, err
 		}
 		var entries []layoutEntry
@@ -155,7 +155,7 @@ func readEntityLayout(r io.ReadSeeker, ovlName string, off psx.Addr, count int, 
 
 	endOfArray := off.Sum(count * 4)
 	if isX { // we want to do the same thing with the vertically aligned layout
-		yLayouts, yRanges, err := readEntityLayout(r, ovlName, endOfArray, count, false)
+		yLayouts, yRanges, err := readEntityLayout(r, ovlName, endOfArray, baseAddr, count, false)
 		if err != nil {
 			return layouts{}, nil, fmt.Errorf("readEntityLayout failed on Y: %w", err)
 		}

--- a/tools/sotn-assets/assets/rooms/handler.go
+++ b/tools/sotn-assets/assets/rooms/handler.go
@@ -35,7 +35,7 @@ func (h *handler) Name() string { return "rooms" }
 
 func (h *handler) Extract(e assets.ExtractArgs) error {
 	r := bytes.NewReader(e.Data)
-	rooms, _, err := readRooms(r, e.RamBase.Sum(e.Start))
+	rooms, _, err := readRooms(r, e.RamBase.Sum(e.Start), e.RamBase)
 	if err != nil {
 		return fmt.Errorf("failed to read rooms: %w", err)
 	}
@@ -75,7 +75,7 @@ func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
 	if err != nil {
 		return assets.InfoResult{}, err
 	}
-	_, dataRange, err := readRooms(r, header.Rooms)
+	_, dataRange, err := readRooms(r, header.Rooms, header.Rooms.Boundaries().StageBegin)
 	if err != nil {
 		return assets.InfoResult{}, err
 	}
@@ -108,11 +108,11 @@ func (r Room) isTerminator() bool {
 	return r.Left == 0x40
 }
 
-func readRooms(r io.ReadSeeker, off psx.Addr) ([]Room, datarange.DataRange, error) {
+func readRooms(r io.ReadSeeker, off psx.Addr, baseAddr psx.Addr) ([]Room, datarange.DataRange, error) {
 	if off == 0 {
 		return nil, datarange.DataRange{}, nil
 	}
-	if err := off.MoveFile(r, psx.RamStageBegin); err != nil {
+	if err := off.MoveFile(r, baseAddr); err != nil {
 		return nil, datarange.DataRange{}, err
 	}
 

--- a/tools/sotn-assets/assets/spritebanks/handler.go
+++ b/tools/sotn-assets/assets/spritebanks/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/datarange"
-	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/sotn"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/util"
 	"path/filepath"
@@ -41,7 +40,8 @@ func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
 	if err != nil {
 		return assets.InfoResult{}, err
 	}
-	_, dataRange, err := ReadSpritesBanks(r, psx.RamStageBegin, header.Sprites)
+	boundaries := header.Sprites.Boundaries()
+	_, dataRange, err := ReadSpritesBanks(r, boundaries.StageBegin, header.Sprites)
 	if err != nil {
 		return assets.InfoResult{}, err
 	}

--- a/tools/sotn-assets/assets/spritebanks/spritebanks.go
+++ b/tools/sotn-assets/assets/spritebanks/spritebanks.go
@@ -24,11 +24,11 @@ func ReadSpritesBanks(r io.ReadSeeker, baseAddr, addr psx.Addr) (SpriteBanks, da
 	if err := addr.MoveFile(r, baseAddr); err != nil {
 		return SpriteBanks{}, datarange.DataRange{}, err
 	}
-
+	boundaries := baseAddr.Boundaries()
 	offBanks := make([]psx.Addr, 0, banksCount)
 	for {
 		addr := psx.ReadAddr(r)
-		if addr != psx.RamNull && !addr.InRange(baseAddr, psx.RamGameEnd) {
+		if addr != psx.RamNull && !addr.InRange(baseAddr, boundaries.GameEnd) {
 			break
 		}
 		offBanks = append(offBanks, addr)

--- a/tools/sotn-assets/assets/spriteset/handler.go
+++ b/tools/sotn-assets/assets/spriteset/handler.go
@@ -18,6 +18,9 @@ var Handler = &handler{}
 func (h *handler) Name() string { return "spriteset" }
 
 func (h *handler) Extract(e assets.ExtractArgs) error {
+	if e.AssetDir == "assets/maria" {
+		e.AssetDir = e.AssetDir
+	}
 	var sprites []*spriteParts
 	var err error
 	if e.Start != e.End {

--- a/tools/sotn-assets/assets/spriteset/spriteset.go
+++ b/tools/sotn-assets/assets/spriteset/spriteset.go
@@ -17,11 +17,12 @@ func ReadSpriteSet(r io.ReadSeeker, baseAddr, addr psx.Addr) (SpriteSet, dataran
 	}
 
 	// the end of the Sprite array is the beginning of the earliest Sprite offset
-	earliestSpriteOff := psx.RamStageEnd
+	boundaries := baseAddr.Boundaries()
+	earliestSpriteOff := boundaries.GameEnd
 	currentOff := addr
 	var spriteOffsets []psx.Addr
 	for {
-		if currentOff == earliestSpriteOff {
+		if currentOff >= earliestSpriteOff {
 			break
 		}
 		currentOff += 4
@@ -32,7 +33,7 @@ func ReadSpriteSet(r io.ReadSeeker, baseAddr, addr psx.Addr) (SpriteSet, dataran
 		}
 		spriteOffsets = append(spriteOffsets, spriteOffset)
 		if spriteOffset != psx.RamNull {
-			if !spriteOffset.InRange(baseAddr, psx.RamGameEnd) {
+			if !spriteOffset.InRange(baseAddr, boundaries.GameEnd) {
 				err := fmt.Errorf("sprite offset %s is not valid", spriteOffset)
 				return nil, datarange.DataRange{}, err
 			}

--- a/tools/sotn-assets/sotn/version.go
+++ b/tools/sotn-assets/sotn/version.go
@@ -1,6 +1,7 @@
 package sotn
 
 import (
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
 	"os"
 	"strings"
 )
@@ -32,4 +33,15 @@ func GetPlatform() Platform {
 		return PlatformPSP
 	}
 	return PlatformPSX
+}
+
+func (p Platform) GetBoundaries() psx.Offsets {
+	switch p {
+	case PlatformPSX:
+		return psx.Addr(0x80000000).Boundaries()
+	case PlatformPSP:
+		return psx.Addr(0x08000000).Boundaries()
+	default:
+		panic("unsupported platform " + string(p))
+	}
 }


### PR DESCRIPTION
Removes every reference from `psx.RamStageBegin`, which was hardcoded to `0x80180000`. This prevented to add PSP-specific assets to the decomp.

It attempts to fix #2676 .