### PR TITLE
Update splat to produce a less verbose build

### DIFF
--- a/tools/builds/gen.py
+++ b/tools/builds/gen.py
@@ -598,7 +598,7 @@ with open("build.ninja", "w") as f:
         "splat",
         # 'touch' circumnavigates a bug where splat would not update the
         # mtime of the linker script if it is already up-to-date.
-        command=".venv/bin/splat split $in 2> /dev/null && touch $out",
+        command=".venv/bin/splat split $in > /dev/null && touch $out",
         description="splat $in",
     )
     nw.rule(

--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -8,10 +8,10 @@ mapfile-parser==2.1.4
 tabulate
 requests
 graphviz
-splat64==0.34.0
+splat64==0.34.1
 crunch64
-spimdisasm>=1.33.0
-rabbitizer>=1.12.5
+spimdisasm>=1.35.0
+rabbitizer>=1.13.0
 n64img==0.3.3
 pygfxd
 pillow


### PR DESCRIPTION
This is the only change in 0.34.1: https://github.com/ethteck/splat/pull/460

With this, Ninja will be less verbose when building. And splat will only print warnings or errors.