### PR TITLE
Decompile `main` FntFlush

### DIFF
--- a/config/splat.us.main.yaml
+++ b/config/splat.us.main.yaml
@@ -38,7 +38,7 @@ segments:
     subalign: 4
     subsegments:
       - [0x800, .rodata, main]
-      - [0x874, .rodata, psxsdk/libgpu/font]
+      - [0x85C, .rodata, psxsdk/libgpu/font]
       - [0x8F8, .rodata, psxsdk/libgpu/prim]
       - [0x9C8, .rodata, psxsdk/libgpu/sys]
       - [0xBC4, .rodata, psxsdk/libetc/vsync] # aVsyncTimeout

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -73,5 +73,3 @@ void main(void) {
     }
     g_MainGame();
 }
-
-const char a0123456789abcd[] = "0123456789ABCDEF\0\0\0\0";

--- a/src/main/psxsdk/libgpu/font.c
+++ b/src/main/psxsdk/libgpu/font.c
@@ -4,12 +4,12 @@
 const char a0123456789abcd[] = "0123456789ABCDEF";
 
 typedef struct {
-  /* 0x00 */ TILE tile;
-  /* 0x10 */ DR_MODE draw_mode;
-  /* 0x1C */ u32 capacity;
-  /* 0x20 */ SPRT_8* sprites;
-  /* 0x24 */ char* buffer;
-  /* 0x28 */ s32 written;
+    /* 0x00 */ TILE tile;
+    /* 0x10 */ DR_MODE draw_mode;
+    /* 0x1C */ u32 capacity;
+    /* 0x20 */ SPRT_8* sprites;
+    /* 0x24 */ char* buffer;
+    /* 0x28 */ s32 written;
 } FntStream;
 
 extern s32 D_8002B810;

--- a/src/main/psxsdk/libgpu/font.c
+++ b/src/main/psxsdk/libgpu/font.c
@@ -1,20 +1,15 @@
 #include "common.h"
 #include <libgpu.h>
 
+const char a0123456789abcd[] = "0123456789ABCDEF";
+
 typedef struct {
-    u32 unk00;
-    u32 unk04;
-    s16 x;
-    s16 y;
-    s16 w;
-    s16 h;
-    u32 unk10;
-    u32 unk14;
-    u32 unk18;
-    u32 unk1C;
-    u32 unk20;
-    u32 unk24;
-    u32 unk28;
+  /* 0x00 */ TILE tile;
+  /* 0x10 */ DR_MODE draw_mode;
+  /* 0x1C */ u32 capacity;
+  /* 0x20 */ SPRT_8* sprites;
+  /* 0x24 */ char* buffer;
+  /* 0x28 */ s32 written;
 } FntStream;
 
 extern s32 D_8002B810;
@@ -42,6 +37,95 @@ void FntLoad(s32 tx, s32 ty) {
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntOpen);
 
-INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntFlush);
+u_long* FntFlush(s32 id) {
+    DR_MODE* dr;
+    s32 x, y;
+    s32 max_x, max_y;
+    s32 len;
+    bool line_break;
+    s32 ch;
+    char* buf;
+    FntStream* font;
+    SPRT_8* sprt;
+    u8 u, v;
+
+    if (id < 0 || id >= D_8002B810) {
+        id = D_8002B814;
+        if (Font[id].buffer == NULL) {
+            return NULL;
+        }
+    }
+    font = &Font[id];
+    dr = &font->draw_mode;
+    buf = font->buffer;
+    sprt = font->sprites;
+    len = font->capacity;
+    x = font->tile.x0;
+    y = font->tile.y0;
+    max_x = x + font->tile.w;
+    max_y = y + font->tile.h;
+    TermPrim(dr);
+    while (*buf != 0) {
+        if (len == 0) {
+            break;
+        }
+        line_break = false;
+        switch (*buf) {
+        case '\n':
+            line_break = true;
+            break;
+
+        case '\t':
+            x += 0x20;
+            if (x >= max_x) {
+                line_break = true;
+            }
+            break;
+
+        case ' ':
+            x += 8;
+            if (x >= max_x) {
+                line_break = true;
+            }
+            break;
+
+        default:
+            if (*buf >= 'a' && *buf <= 'z') {
+                ch = *buf - 0x40;
+            } else {
+                ch = *buf - 0x20;
+            }
+            u = (ch % 16) * 8;
+            v = (ch / 16) * 8;
+            sprt->u0 = u;
+            sprt->v0 = v;
+            sprt->x0 = x;
+            sprt->y0 = y;
+            AddPrim(dr, &sprt->tag);
+            x += 8;
+            if (x >= max_x) {
+                line_break = true;
+            }
+            break;
+        }
+        if (line_break) {
+            x = font->tile.x0;
+            y += 8;
+            if (y >= max_y) {
+                break;
+            }
+        }
+        sprt++;
+        buf++;
+        len--;
+    }
+    if (font->tile.code != 0) {
+        AddPrim(dr, &font->tile.tag);
+    }
+    DrawOTag((u_long*)dr);
+    font->written = 0;
+    *font->buffer = 0;
+    return (u_long*)dr;
+}
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libgpu/font", FntPrint);

--- a/tools/builds/gen.py
+++ b/tools/builds/gen.py
@@ -87,7 +87,7 @@ def add_c_psx(
         return
     entries[output] = {}
     rule = "psx-cc"
-    if file_name == "src/main/psxsdk/libgpu/sys.c":
+    if file_name == "src/main/psxsdk/libgpu/sys.c" or file_name == "src/main/psxsdk/libgpu/font.c":
         rule = "psx-cc-2_21"
     nw.build(
         rule=rule,

--- a/tools/builds/gen.py
+++ b/tools/builds/gen.py
@@ -87,7 +87,10 @@ def add_c_psx(
         return
     entries[output] = {}
     rule = "psx-cc"
-    if file_name == "src/main/psxsdk/libgpu/sys.c" or file_name == "src/main/psxsdk/libgpu/font.c":
+    if (
+        file_name == "src/main/psxsdk/libgpu/sys.c"
+        or file_name == "src/main/psxsdk/libgpu/font.c"
+    ):
         rule = "psx-cc-2_21"
     nw.build(
         rule=rule,


### PR DESCRIPTION
Strongly based off other scratches of FntFlush I found on decomp.me .

Thanks to @sozud for the hint about libgpu which was required to fix the mismatch in https://decomp.me/scratch/WFtbz