### PR TITLE
Decompile `main` CD_cw

### DIFF
--- a/src/main/psxsdk/libcd/bios.c
+++ b/src/main/psxsdk/libcd/bios.c
@@ -2,28 +2,155 @@
 #include "../libspu/libspu_internal.h"
 #include <common.h>
 
+typedef struct {
+    unsigned char sync;  // sync state
+    unsigned char ready; // ready state
+    unsigned char c;
+} CD_flush_struct;
+
+typedef struct Alarm_t {
+    int unk0;
+    int unk4;
+    char* unk8;
+} Alarm_t;
+
+extern volatile unsigned char* D_80032D68;
+extern volatile unsigned char* D_80032D6C;
+extern volatile unsigned char* D_80032D70;
+extern volatile unsigned char* D_80032D74;
+extern volatile int* D_80032D78;
+extern volatile CD_flush_struct D_80032D80;
+extern union SpuUnion* D_80032D7C;
+// TODO: CD_status is a word here, but a byte in sys.c
+extern int CD_status;
+extern int CD_status1;
+extern volatile unsigned char D_80032D84;
+extern int* D_80032D9C;
+extern int* D_80032DA0;
+extern int* D_80032DA4;
+extern int* D_80032DA8;
+extern volatile int* D_80032DAC;
+extern int CD_TestParmNum;
+extern char D_80039260[];
+extern char D_80039268[];
+extern volatile Alarm_t Alarm;
+extern u8 CD_pos[];
+extern s32 D_80032AB0;
+extern char* D_80032AC8[];
+extern char* D_80032B48[];
+extern s32 D_80032BE8[];
+extern s32 D_80032CE8[];
+extern s8 aCdTimeout;
+
 // this is a string constant in several of the
 // uncompiled functions below
 const char D_800106B4[] = "%s:(%s) Sync=%s, Ready=%s\n";
 
-int getintr();
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", getintr);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_sync);
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_ready);
 
-int CD_cw(
-    unsigned char arg0, unsigned char* arg1, unsigned char* arg2, int arg3);
-INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_cw);
+static inline void _memcpy(void* _dst, void* _src, u32 _size) {
+    char* pDst = (char*)_dst;
+    char* pSrc = (char*)_src;
+
+    if (pDst == 0) {
+        return;
+    }
+
+    while (_size--) {
+        *pDst++ = *pSrc++;
+    }
+}
+
+static inline void callback(void) {
+    int interrupt;
+    unsigned char temp_s1;
+
+    temp_s1 = *D_80032D68 & 3;
+
+    while (true) {
+        interrupt = getintr();
+        if (interrupt == 0) {
+            break;
+        }
+
+        if (interrupt & 4 && CD_cbready != NULL) {
+            CD_cbready(D_80032D80.ready, &D_80039268);
+        }
+        if (interrupt & 2 && (CD_cbsync != NULL)) {
+            CD_cbsync(D_80032D80.sync, &D_80039260);
+        }
+    }
+    *D_80032D68 = temp_s1;
+}
+
+s32 CD_cw(u8 com, u8* param, u8* arg2, s32 arg3) {
+    s32 i;
+    s32 var_v0_2;
+
+    if (D_80032AB0 > 1) {
+        printf("%s...\n", D_80032AC8[com]);
+    }
+    if ((D_80032CE8[com] != 0) && (param == NULL)) {
+        if (D_80032AB0 > 0) {
+            printf("%s: no param\n", D_80032AC8[com]);
+        }
+        return -2;
+    }
+    CD_sync(0, 0);
+    if (com == CdlSetloc) {
+        for (i = 0; i < 4; i++) {
+            CD_pos[i] = param[i];
+        }
+    }
+    D_80032D80.sync = 0;
+    if (D_80032BE8[com] != 0) {
+        D_80032D80.ready = 0;
+    }
+    *D_80032D68 = 0;
+    for (i = 0; i < D_80032BE8[com + 0x40]; i++) {
+        *D_80032D70 = param[i];
+    }
+    CD_com = com;
+    *D_80032D6C = com;
+    if (arg3 != 0) {
+        return 0;
+    }
+    ((Alarm_t*)&Alarm)->unk0 = VSync(-1) + 0x3C0;
+    ((Alarm_t*)&Alarm)->unk4 = 0;
+    ((Alarm_t*)&Alarm)->unk8 = "CD_cw";
+    while (D_80032D80.sync == 0) {
+        if (((Alarm_t*)&Alarm)->unk0 < VSync(-1) ||
+            ((Alarm_t*)&Alarm)->unk4++ > 0x3C0000) {
+            puts(&aCdTimeout);
+            printf(D_800106B4, ((Alarm_t*)&Alarm)->unk8, D_80032AC8[CD_com],
+                   D_80032B48[D_80032D80.sync], D_80032B48[D_80032D80.ready]);
+            CD_flush();
+            var_v0_2 = -1;
+        } else {
+            var_v0_2 = 0;
+        }
+        if (var_v0_2 != 0) {
+            return -1;
+        }
+        if (CheckCallback()) {
+            callback();
+        }
+    }
+    if ((D_80032D80.sync == 2) && (com == CdlSetmode)) {
+        CD_mode = *param;
+    }
+
+    _memcpy(arg2, D_80039260, 8);
+
+    return -(D_80032D80.sync == 5);
+}
 
 const char aIdBiosCV177199[] =
     "$Id: bios.c,v 1.77 1996/05/13 06:58:16 suzu Exp $";
-
-extern unsigned char* D_80032D6C;
-extern volatile unsigned char* D_80032D68;
-extern volatile unsigned char* D_80032D70;
-extern volatile unsigned char* D_80032D74;
 
 int CD_vol(CdlATV* vol) {
     *D_80032D68 = 2;
@@ -35,16 +162,6 @@ int CD_vol(CdlATV* vol) {
     *D_80032D74 = 0x20;
     return 0;
 }
-
-extern volatile int* D_80032D78;
-
-typedef struct {
-    unsigned char sync;  // sync state
-    unsigned char ready; // ready state
-    unsigned char c;
-} CD_flush_struct;
-
-extern volatile CD_flush_struct D_80032D80;
 
 int CD_flush(void) {
     *D_80032D68 = 1;
@@ -60,8 +177,6 @@ int CD_flush(void) {
     *D_80032D74 = 0;
     *D_80032D78 = 0x1325;
 }
-
-extern union SpuUnion* D_80032D7C;
 
 int CD_initvol(void) {
     CdlATV vol;
@@ -89,12 +204,6 @@ int CD_initvol(void) {
     return 0;
 }
 
-int ResetCallback(void);
-// TODO: CD_status is a word here, but a byte in sys.c
-extern int CD_status;
-extern int CD_status1;
-void callback(void);
-
 void CD_initintr(void) {
     CD_cbready = NULL;
     CD_cbsync = NULL;
@@ -103,8 +212,6 @@ void CD_initintr(void) {
     ResetCallback();
     InterruptCallback(2, callback);
 }
-
-extern volatile unsigned char D_80032D84;
 
 int CD_init(void) {
     puts("CD_init:");
@@ -153,12 +260,6 @@ int CD_init(void) {
 
 INCLUDE_ASM("main/nonmatchings/psxsdk/libcd/bios", CD_datasync);
 
-extern int* D_80032D9C;
-extern int* D_80032DA0;
-extern int* D_80032DA4;
-extern int* D_80032DA8;
-extern volatile int* D_80032DAC;
-
 int CD_getsector(void* buffer, size_t size) {
     *D_80032D68 = 0;
     *D_80032D74 = 0x80;
@@ -176,33 +277,4 @@ int CD_getsector(void* buffer, size_t size) {
     return 0;
 }
 
-extern int CD_TestParmNum;
-
 void CD_set_test_parmnum(int parmNum) { CD_TestParmNum = parmNum; }
-
-extern char D_80039260[];
-extern char D_80039268[];
-
-void callback(void) {
-    int interrupt;
-    unsigned char temp_s1;
-
-    temp_s1 = *D_80032D68 & 3;
-
-    while (true) {
-        interrupt = getintr();
-        if (interrupt == 0) {
-            break;
-        }
-
-        if (interrupt & 4) {
-            if (CD_cbready != NULL) {
-                CD_cbready(D_80032D80.ready, &D_80039268);
-            }
-        }
-        if (interrupt & 2 && (CD_cbsync != NULL)) {
-            CD_cbsync(D_80032D80.sync, &D_80039260);
-        }
-    }
-    *D_80032D68 = temp_s1;
-}

--- a/src/main/psxsdk/libcd/sys.c
+++ b/src/main/psxsdk/libcd/sys.c
@@ -81,11 +81,11 @@ static inline cd_cw(u8 com, u8* param, u8* result, s32 arg3) {
 
     for (i = 3; i != -1; i--) {
         CD_cbsync = NULL;
-        if (com != 1 && CD_status & 0x10) {
-            CD_cw(1, NULL, NULL, 0);
+        if (com != CdlNop && (CD_status & 0x10)) {
+            CD_cw(CdlNop, NULL, NULL, 0);
         }
         if ((param == NULL) || (D_80032A24[com] == 0) ||
-            (CD_cw(2, param, result, 0) == 0)) {
+            (CD_cw(CdlSetloc, param, result, 0) == 0)) {
             CD_cbsync = old;
             if (CD_cw(com, param, result, arg3) == 0) {
                 return 0;


### PR DESCRIPTION
All credit goes to @devperson7 : https://decomp.me/scratch/wQ7Dv
I just changed small things to make it fit this project.

Something neat is that `callback` was already decompiled and put at the end of the file, but making it static inline and placing it above `CD_cw` does not cause a mismatch ?? I figure the compiler is generating a non-inline version at the end of the file since it is passed as a function pointer in other functions. Maybe this is happening elsewhere in the project ?