### PR TITLE
Changed  permuter default prelude file to be include/main.inc

### DIFF
--- a/tools/sotn_permuter/permuter_settings.pspeu.toml
+++ b/tools/sotn_permuter/permuter_settings.pspeu.toml
@@ -2,7 +2,7 @@ compiler_type = "gcc"
 compiler_command_old = "bin/wibo bin/mwccpsp.exe -gccinc -Iinclude -D_internal_version_pspeu -Op -c -lang c -sdatathreshold 0 -char unsigned"
 compiler_command = "python3 tools/mwccgap/mwccgap.py $INPUT $OUTPUT --mwcc-path bin/mwccpsp.exe --use-wibo --wibo-path bin/wibo --as-path bin/allegrex-as --asm-dir-prefix asm/pspeu --macro-inc-path include/macro.inc -gccinc -Iinclude -D_internal_version_pspeu -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck -Op -opt nointrinsics"
 assembler_command = "bin/allegrex-as -EL -I include/ -G0 -march=allegrex -mabi=eabi"
-asm_prelude_file = "tools/sotn_permuter/prelude.inc"
+asm_prelude_file = "include/main.inc"
 
 [decompme.compilers]
 "mipsel-linux-gnu-cpp" = "psyq4.0"

--- a/tools/sotn_permuter/permuter_settings.us.toml
+++ b/tools/sotn_permuter/permuter_settings.us.toml
@@ -1,7 +1,7 @@
 compiler_type = "gcc"
 compiler_command = "mipsel-linux-gnu-cpp -Iinclude -Iinclude/psxsdk -undef -Wall -fno-builtin -Dmips -D__GNUC__=2 -D__OPTIMIZE__ -D__mips__ -D__mips -Dpsx -D__psx__ -D__psx -D_PSYQ -D__EXTENSIONS__ -D_MIPSEL -D_LANGUAGE_C -DLANGUAGE_C -DNO_LOGS -DHACKS -DUSE_INCLUDE_ASM -D_internal_version_us -DSOTN_STR -lang-c | ./tools/sotn_str/target/release/sotn_str process | iconv --from-code=UTF-8 --to-code=Shift-JIS | ./bin/cc1-psx-26 -G0 -w -O2 -funsigned-char -fpeephole -ffunction-cse -fpcc-struct-return -fcommon -fverbose-asm -msoft-float -g -quiet -mcpu=3000 -fgnu-linker -mgas -gcoff | python3 tools/maspsx/maspsx.py --expand-div --aspsx-version=2.34 | mipsel-linux-gnu-as -Iinclude -march=r3000 -mtune=r3000 -no-pad-sections -O1 -G0"
 assembler_command = "mipsel-linux-gnu-as -Iinclude -march=r3000 -mtune=r3000 -no-pad-sections -O1 -G0"
-asm_prelude_file = "tools/sotn_permuter/prelude.inc"
+asm_prelude_file = "include/main.inc"
 
 [decompme.compilers]
 "mipsel-linux-gnu-cpp" = "psyq4.0"


### PR DESCRIPTION
I did some limited testing and it appears to function as it did previously for both us and pspeu, but can now handle gte asm macros.
The previous prelude.inc file has been retained in case there are any issues.