### PR TITLE
Fix Matchings & Reporting Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ CLANG			:= $(BIN_DIR)/clang-format
 GOPATH          := $(HOME)/go
 GO              := $(GOPATH)/bin/go
 SOTNLINT		:= cargo run --release --manifest-path $(TOOLS_DIR)/lints/sotn-lint/Cargo.toml $(SRC_DIR)/
-DUPS			:= cd $(TOOLS_DIR)/dups; cargo run --release -- --threshold .90 --output-file ../gh-duplicates/duplicates.txt
+DUPS_THRESHOLD  ?= .90
+DUPS			:= cd $(TOOLS_DIR)/dups; cargo run --release -- --threshold $(DUPS_THRESHOLD) --output-file ../../$(REPORTS_DIR)/duplicates.txt
 MIPSMATCH_APP   := $(BIN_DIR)/mipsmatch
 SOTNSTR_APP     := $(TOOLS_DIR)/sotn_str/target/release/sotn_str
 ASMDIFFER_APP	:= $(TOOLS_DIR)/asm-differ/diff.py
@@ -449,6 +450,7 @@ build/$(VERSION)/src/%.o: src/%
 reports: duplicates-report function-finder
 prepare-reports: build $(REPORTS_DIR)
 	$(MAKE) force_symbols -j
+	$(PYTHON) tools/function_finder/fix_matchings.py
 
 function-finder: ##@ generates lists of files, their decomp status, and call graphs
 function-finder: prepare-reports
@@ -462,10 +464,7 @@ $(REPORTS_DIR):
 duplicates-report: ##@ generate a report of duplicate functions
 duplicates-report: $(REPORTS_DIR)/duplicates.txt
 $(REPORTS_DIR)/duplicates.txt: prepare-reports
-	cd tools/dups ; \
-		cargo run --release -- \
-			--threshold .90 \
-			--output-file ../../$(REPORTS_DIR)/duplicates.txt
+	$(DUPS)
 
 
 ##@

--- a/tools/analyze_calls.py
+++ b/tools/analyze_calls.py
@@ -114,7 +114,12 @@ def handle_jal_call(full_file, call_index):
             "8016B3E4" in callreg_setline
         ):  # weird case in one function with compiler optimizing two calls into one
             return "PlaySfx"
-        if "0xB8($a2)" in callreg_setline or "-0x20($s0)" in callreg_setline:
+        # cases where jalr is using the value set earlier in a register
+        if (
+            "0xB8($a2)" in callreg_setline
+            or "-0x20($s0)" in callreg_setline
+            or "0x0($v0)" in callreg_setline
+        ):
             return "UnknownEntityFunction"
         if "8017B5A8" in callreg_setline:
             return "g_api_CreateEntFactoryFromEntity"

--- a/tools/function_finder/function_finder_psx.py
+++ b/tools/function_finder/function_finder_psx.py
@@ -176,12 +176,12 @@ if __name__ == "__main__":
 
     base_url = "https://raw.githubusercontent.com/Xeeynamo/sotn-decomp/gh-duplicates"
 
-    if os.path.isfile("gh-duplicates/duplicates.txt"):
-        with open("gh-duplicates/duplicates.txt", "r") as f:
+    if os.path.isfile("build/us/reports/duplicates.txt"):
+        with open("build/us/reports/duplicates.txt", "r") as f:
             dups_text = f.read()
     else:
         print(
-            "'warning: gh-duplicates/duplicates.txt' file not found, skipping duplicate check",
+            "'warning: build/us/reports/duplicates.txt' file not found, skipping duplicate check",
             file=sys.stderr,
         )
         dups_text = None


### PR DESCRIPTION
Runs `fix_matchings.py` prior to generating reports like was previously done.

Maps `0x0($v0)` to `"UnknownEntityFunction"` in `analyze_calls.py`. This appears to be new in `bo6`.

`function_finder.py` now looks for the duplicates report in `build/us/reports`.