### PR TITLE
More `CutsceneRun` Sharing

### DIFF
--- a/src/boss/bo6/cutscene.c
+++ b/src/boss/bo6/cutscene.c
@@ -20,7 +20,8 @@ extern const char* actor_names[];
 
 #include "../../st/set_cutscene_end.h"
 
-INCLUDE_ASM("boss/bo6/nonmatchings/cutscene", CutsceneRun);
+#define CUTSCENE_TILEMAP_SCROLL
+#include "../../st/cutscene_run.h"
 
 #include "../../st/cutscene_skip.h"
 

--- a/src/st/cen/cutscene.c
+++ b/src/st/cen/cutscene.c
@@ -78,6 +78,7 @@ INCLUDE_ASM("st/cen/nonmatchings/cutscene", DrawCutsceneActorName);
 
 #include "../set_cutscene_end.h"
 
+#define CUTSCENE_TILEMAP_SCROLL
 #include "../cutscene_run.h"
 
 #ifndef VERSION_HD

--- a/src/st/cutscene_run.h
+++ b/src/st/cutscene_run.h
@@ -1,4 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Options:
+//
+//     #define CUTSCENE_TILEMAP_SCROLL:
+//
+//         adds additional decrements based on `g_Tilemap`'s scroll position
+
 extern Dialogue g_Dialogue;
 extern u32 g_CutsceneFlags;
 extern PfnEntityUpdate OVL_EXPORT(EntityUpdates)[];
@@ -33,7 +40,7 @@ static void CutsceneRun(void) {
             entity->posX.i.hi |= *g_Dialogue.scriptEnd++;
             entity->posY.i.hi = *g_Dialogue.scriptEnd++ * 0x10;
             entity->posY.i.hi |= *g_Dialogue.scriptEnd++;
-#if defined(STAGE_IS_CEN) || defined(STAGE_IS_TOP)
+#ifdef CUTSCENE_TILEMAP_SCROLL
             entity->posX.i.hi -= g_Tilemap.scrollX.i.hi;
             entity->posY.i.hi -= g_Tilemap.scrollY.i.hi;
 #endif
@@ -45,7 +52,12 @@ static void CutsceneRun(void) {
             break;
         case 2:
             if (!((g_CutsceneFlags >> *g_Dialogue.scriptEnd) & 1)) {
+#ifdef STAGE_IS_DRE
+                g_Dialogue.scriptEnd -= 3;
+                g_Dialogue.timer--;
+#else
                 g_Dialogue.scriptEnd--;
+#endif
                 return;
             }
             g_CutsceneFlags &= ~(1 << *g_Dialogue.scriptEnd++);

--- a/src/st/dai/e_cutscene.c
+++ b/src/st/dai/e_cutscene.c
@@ -37,57 +37,8 @@ static void SetCutsceneEnd(u8* ptr) {
     g_Dialogue.unk3C = 1;
 }
 
-static void CutsceneRun(void) {
-    Entity* entity;
-    u16 startTimer;
-
-    g_Dialogue.timer++;
-    // protect from overflows
-    if (g_Dialogue.timer >= 0xFFFF) {
-        g_Dialogue.unk3C = 0;
-        return;
-    }
-    while (true) {
-        // Start the dialogue script only if the start timer has passed
-        startTimer = *g_Dialogue.scriptEnd++ << 8;
-        startTimer |= *g_Dialogue.scriptEnd++;
-        if (g_Dialogue.timer < startTimer) {
-            // Re-evaluate the condition at the next frame
-            g_Dialogue.scriptEnd -= 2;
-            return;
-        }
-        switch (*g_Dialogue.scriptEnd++) {
-        case 0:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            entity->entityId = *g_Dialogue.scriptEnd++;
-            entity->pfnUpdate = OVL_EXPORT(EntityUpdates)[entity->entityId - 1];
-            entity->posX.i.hi = *g_Dialogue.scriptEnd++ * 16;
-            entity->posX.i.hi |= *g_Dialogue.scriptEnd++;
-            entity->posY.i.hi = *g_Dialogue.scriptEnd++ * 16;
-            entity->posY.i.hi |= *g_Dialogue.scriptEnd++;
-            entity->posX.i.hi -= g_Tilemap.scrollX.i.hi;
-            entity->posY.i.hi -= g_Tilemap.scrollY.i.hi;
-            break;
-        case 1:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            break;
-        case 2:
-            if (!((g_CutsceneFlags >> *g_Dialogue.scriptEnd) & 1)) {
-                g_Dialogue.scriptEnd--;
-                return;
-            }
-            g_CutsceneFlags &= ~(1 << *g_Dialogue.scriptEnd++);
-            break;
-        case 3:
-            g_CutsceneFlags |= 1 << *g_Dialogue.scriptEnd++;
-            break;
-        }
-    }
-}
+#define CUTSCENE_TILEMAP_SCROLL
+#include "../cutscene_run.h"
 
 // Animates the portrait size of the actor by enlarging or shrinking it
 static void ScaleCutsceneAvatar(const u8 ySteps) {

--- a/src/st/dai/e_cutscene_psp.c
+++ b/src/st/dai/e_cutscene_psp.c
@@ -125,57 +125,8 @@ void SetCutsceneEnd(u8* ptr) {
     g_Dialogue.unk3C = 1;
 }
 
-static void CutsceneRun(void) {
-    Entity* entity;
-    u16 startTimer;
-
-    g_Dialogue.timer++;
-    // protect from overflows
-    if (g_Dialogue.timer >= 0xFFFF) {
-        g_Dialogue.unk3C = 0;
-        return;
-    }
-    while (true) {
-        // Start the dialogue script only if the start timer has passed
-        startTimer = *g_Dialogue.scriptEnd++ << 8;
-        startTimer |= *g_Dialogue.scriptEnd++;
-        if (g_Dialogue.timer < startTimer) {
-            // Re-evaluate the condition at the next frame
-            g_Dialogue.scriptEnd -= 2;
-            return;
-        }
-        switch (*g_Dialogue.scriptEnd++) {
-        case 0:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            entity->entityId = *g_Dialogue.scriptEnd++;
-            entity->pfnUpdate = OVL_EXPORT(EntityUpdates)[entity->entityId - 1];
-            entity->posX.i.hi = *g_Dialogue.scriptEnd++ * 16;
-            entity->posX.i.hi |= *g_Dialogue.scriptEnd++;
-            entity->posY.i.hi = *g_Dialogue.scriptEnd++ * 16;
-            entity->posY.i.hi |= *g_Dialogue.scriptEnd++;
-            entity->posX.i.hi -= g_Tilemap.scrollX.i.hi;
-            entity->posY.i.hi -= g_Tilemap.scrollY.i.hi;
-            break;
-        case 1:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            break;
-        case 2:
-            if (!((g_CutsceneFlags >> *g_Dialogue.scriptEnd) & 1)) {
-                g_Dialogue.scriptEnd--;
-                return;
-            }
-            g_CutsceneFlags &= ~(1 << *g_Dialogue.scriptEnd++);
-            break;
-        case 3:
-            g_CutsceneFlags |= 1 << *g_Dialogue.scriptEnd++;
-            break;
-        }
-    }
-}
+#define CUTSCENE_TILEMAP_SCROLL
+#include "../cutscene_run.h"
 
 // Animates the portrait size of the actor by enlarging or shrinking it
 static void ScaleCutsceneAvatar(const u8 ySteps) {

--- a/src/st/dre/cutscene.c
+++ b/src/st/dre/cutscene.c
@@ -20,56 +20,7 @@ static const char* actor_names[] = {_S("Alucard"), _S("Lisa"), _S("Succubus")};
 
 #include "../set_cutscene_end.h"
 
-static void CutsceneRun(void) {
-    Entity* entity;
-    u16 startTimer;
-
-    g_Dialogue.timer++;
-    // protect from overflows
-    if (g_Dialogue.timer >= 0xFFFF) {
-        g_Dialogue.unk3C = 0;
-        return;
-    }
-    while (true) {
-        // Start the dialogue script only if the start timer has passed
-        startTimer = *g_Dialogue.scriptEnd++ << 8;
-        startTimer |= *g_Dialogue.scriptEnd++;
-        if (g_Dialogue.timer < startTimer) {
-            // Re-evaluate the condition at the next frame
-            g_Dialogue.scriptEnd -= 2;
-            return;
-        }
-        switch (*g_Dialogue.scriptEnd++) {
-        case 0:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            entity->entityId = *g_Dialogue.scriptEnd++;
-            entity->pfnUpdate = PfnEntityUpdates[entity->entityId - 1];
-            entity->posX.i.hi = *g_Dialogue.scriptEnd++ * 0x10;
-            entity->posX.i.hi |= *g_Dialogue.scriptEnd++;
-            entity->posY.i.hi = *g_Dialogue.scriptEnd++ * 0x10;
-            entity->posY.i.hi |= *g_Dialogue.scriptEnd++;
-            break;
-        case 1:
-            entity = &g_Entities[*g_Dialogue.scriptEnd++ & 0xFF] +
-                     STAGE_ENTITY_START;
-            DestroyEntity(entity);
-            break;
-        case 2:
-            if (!((g_CutsceneFlags >> *g_Dialogue.scriptEnd) & 1)) {
-                g_Dialogue.scriptEnd -= 3;
-                g_Dialogue.timer--;
-                return;
-            }
-            g_CutsceneFlags &= ~(1 << *g_Dialogue.scriptEnd++);
-            break;
-        case 3:
-            g_CutsceneFlags |= 1 << *g_Dialogue.scriptEnd++;
-            break;
-        }
-    }
-}
+#include "../cutscene_run.h"
 
 #include "../cutscene_skip.h"
 

--- a/src/st/top/cutscene.c
+++ b/src/st/top/cutscene.c
@@ -11,6 +11,7 @@ extern Dialogue g_Dialogue;
 #include "../cutscene_unk4.h"
 #include "../cutscene_actor_name.h"
 #include "../set_cutscene_end.h"
+#define CUTSCENE_TILEMAP_SCROLL
 #include "../cutscene_run.h"
 #include "../cutscene_skip.h"
 #include "../cutscene_scale_avatar.h"


### PR DESCRIPTION
`CutsceneRun` has a common difference in many stages where the entity is moved in relation to the tile map's scroll position. Instead of continuing to add stages to this difference, I've added a new macro that stages can opt into to get the same behavior which decouples the cutscene code a bit. This allows `dai` and `bo6` to use the shared `CutsceneRun`.

On the other hand, I introduced a new check for `DRE` specifically (since that's the only stage that behaves this way) for how the `scriptEnd` and `timer` are decremented. This allows `dre` to use the shared `CutsceneRun`.