### PR TITLE
Build All Versions Together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ endif
 
 .PHONY: all
 all: ##@ (Default) build and check
-all: build check
+all: build_all check
 
 .PHONY: extract_assets
 extract_assets:
@@ -157,9 +157,8 @@ build_pspeu: $(SOTNSTR_APP) $(SOTNASSETS) $(ALLEGREX) $(MWCCPSP) $(MWCCGAP_APP) 
 	ninja
 .PHONY: build_all
 build_all:
-	$(MAKE) VERSION=us
-	$(MAKE) VERSION=pspeu
-	$(MAKE) VERSION=hd
+	$(PYTHON) tools/builds/gen.py
+	ninja
 
 .PHONY: clean clean_asm
 clean_asm:
@@ -167,9 +166,9 @@ clean_asm:
 clean: ##@ clean extracted files, assets, and build artifacts
 clean: clean_asm
 	git clean -fdx assets/
-	git clean -fdx build/$(VERSION)/
+	git clean -fdx build/
 	git clean -fdx src/**/gen/
-	git clean -fdx config/*$(VERSION)*
+	git clean -fdx config/
 	git clean -fdx function_calls/
 	git clean -fdx sotn_calltree.txt
 

--- a/tools/sotn-assets/assets/cmpgfx/handler.go
+++ b/tools/sotn-assets/assets/cmpgfx/handler.go
@@ -65,7 +65,7 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 	if err := util.WriteFile(assetPathAsRAW(e.AssetDir, e.Name), cmp); err != nil {
 		return fmt.Errorf("error writing file: %v", err)
 	}
-	fout, err := os.Create(assetPathAsPNG(e.AssetDir, e.Name))
+	fout, err := util.CreateAtomicWriter(assetPathAsPNG(e.AssetDir, e.Name))
 	if err != nil {
 		return fmt.Errorf("error creating file: %v", err)
 	}

--- a/tools/sotn-assets/assets/headergfx/handler.go
+++ b/tools/sotn-assets/assets/headergfx/handler.go
@@ -49,7 +49,7 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 	if err := os.MkdirAll(e.AssetDir, 0755); err != nil {
 		return fmt.Errorf("error creating directory: %v", err)
 	}
-	fout, err := os.Create(assetPath(e.AssetDir, e.Name))
+	fout, err := util.CreateAtomicWriter(assetPath(e.AssetDir, e.Name))
 	if err != nil {
 		return fmt.Errorf("error creating file: %v", err)
 	}

--- a/tools/sotn-assets/assets/palette/palette.go
+++ b/tools/sotn-assets/assets/palette/palette.go
@@ -81,7 +81,7 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 	for i, paletteFileName := range paletteNames {
 		i, paletteFileName := i, paletteFileName
 		eg.Go(func() error {
-			f, err := os.Create(filepath.Join(e.AssetDir, paletteFileName))
+			f, err := util.CreateAtomicWriter(filepath.Join(e.AssetDir, paletteFileName))
 			if err != nil {
 				return err
 			}

--- a/tools/sotn-assets/assets/rawgfx/handler.go
+++ b/tools/sotn-assets/assets/rawgfx/handler.go
@@ -61,7 +61,7 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 	if err := os.MkdirAll(filepath.Dir(assetPath(e.AssetDir, e.Name)), 0755); err != nil {
 		return fmt.Errorf("error creating directory: %v", err)
 	}
-	fout, err := os.Create(assetPath(e.AssetDir, e.Name))
+	fout, err := util.CreateAtomicWriter(assetPath(e.AssetDir, e.Name))
 	if err != nil {
 		return fmt.Errorf("error creating file: %v", err)
 	}

--- a/tools/sotn-assets/assets/spritesheet/handler.go
+++ b/tools/sotn-assets/assets/spritesheet/handler.go
@@ -118,10 +118,11 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 			if err != nil {
 				return fmt.Errorf("error generating image: %v", err)
 			}
-			f, err := os.Create(filepath.Join(e.AssetDir, entry.Name))
+			f, err := util.CreateAtomicWriter(filepath.Join(e.AssetDir, entry.Name))
 			if err != nil {
 				return err
 			}
+            defer f.Close()
 			if err := util.PngEncode(f, bitmap, w, h, palette); err != nil {
 				return fmt.Errorf("failed to encode %s: %w", entry.Name, err)
 			}
@@ -219,7 +220,7 @@ func (h *handler) Build(e assets.BuildArgs) error {
 	if err := os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
-	f, err := os.Create(dstFile)
+	f, err := util.CreateAtomicWriter(dstFile)
 	if err != nil {
 		return err
 	}

--- a/tools/sotn-assets/assets/tiledef/handler.go
+++ b/tools/sotn-assets/assets/tiledef/handler.go
@@ -159,7 +159,7 @@ func Build(inFile, symbol, outDir string) error {
 	if err := os.MkdirAll(filepath.Dir(outFileName), 0755); err != nil {
 		return err
 	}
-	f, err := os.Create(outFileName)
+	f, err := util.CreateAtomicWriter(outFileName)
 	if err != nil {
 		return err
 	}

--- a/tools/sotn-assets/util/utils.go
+++ b/tools/sotn-assets/util/utils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
 	"golang.org/x/exp/constraints"
 	"image/color"
+    "io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -141,7 +142,19 @@ func WriteFile(name string, content []byte) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v\n", dir, err)
 	}
-	return os.WriteFile(name, content, 0644)
+    return WriteFileAtomic(name, content)
+}
+
+func WriteFileAtomic(name string, content []byte) error {
+    w, err := CreateAtomicWriter(name)
+    if err != nil {
+        return fmt.Errorf("could not create writer for %q: %v\n", name, err)
+    }
+    defer w.Close()
+    if _, err := w.Write(content); err != nil {
+        return fmt.Errorf("could not write  %q: %v\n", name, err)
+    }
+    return nil
 }
 
 // WriteJsonFile converts the passed object as a JSON and internally calls WriteFile
@@ -257,4 +270,53 @@ func Make4bppFromBitmap(data []byte) []byte {
 		out[i>>1] = (data[i] & 0xF) | ((data[i+1] & 0xF) << 4)
 	}
 	return out
+}
+
+type StringWriteCloser interface {
+    io.WriteCloser
+    io.StringWriter
+
+    Name() string
+}
+
+type AtomicWriter struct {
+    name string
+    f *os.File
+}
+
+func CreateAtomicWriter(name string) (StringWriteCloser, error) {
+    base := filepath.Base(name)
+    dir := filepath.Dir(name)
+    f, err := os.CreateTemp(dir, base)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create temp file for %q: %v\n", name, err)
+    }
+
+    a := AtomicWriter { name: name, f: f }
+
+    return a, nil
+}
+
+func (a AtomicWriter) Close() error {
+    a.f.Close()
+    if err := os.Rename(a.f.Name(), a.name); err != nil {
+        // in the common case, a.f will already be renamed
+        // in case it isn't remove the temp file
+        os.Remove(a.f.Name())
+        return fmt.Errorf("failed to move temp file to destination %q: %v\n", a.name, err)
+    }
+
+    return nil
+}
+
+func (a AtomicWriter) Write(p []byte) (int, error) {
+    return a.f.Write(p)
+}
+
+func (a AtomicWriter) WriteString(s string) (int, error) {
+    return a.f.WriteString(s)
+}
+
+func (a AtomicWriter) Name() string {
+    return a.f.Name()
 }


### PR DESCRIPTION
Changes the default target of `make` and `tools/builds/gen.py` to build all decomped versions of the game together in one bulid graph.

There are two parts to this change: making assets writes atomic to allowing assets to be shared across versions, and updating the build graph to not duplicate shared targets.

Different versions of the game are currently configured to write to the same asset paths. I think this is a good thing™ since it makes differing assets obvious. The work to separate these assets was done in cdda8fcd87e20ee88edbecea069cbd1108f07883 but running multiple versions of `sotn-assets` in parallel resulted in race conditions that prevented multiple versions of the game from building together (whether in the same graph or not). This change updates `sotn-assets` to write files atomically which avoid partial reads while allowing multiple instances of `sotn-assets` to run concurrently. An alternative to this approach would be to put `sotn-assets` rules in the same ninja pool, but that would force them to be serialized, which seems unnecessary, but possibly simpler.

The second area is merging all three build graphs into a single monolithic graph. This is primarily meant eliminating duplicate asset steps for shared assets.

`make` will now build `us`, `hd`, and `pspeu`. Using the `VERSION` env var still works and will only build that version. `make clean` cleans all versions.

picci builds are out of scope for this change.