### PR TITLE
Stricter `bool` type

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -59,7 +59,8 @@ typedef unsigned short ushort;
 typedef unsigned int uint;
 
 #ifndef __cplusplus
-typedef enum { false, true } bool;
+enum { false, true };
+typedef signed int bool;
 #endif
 
 #ifndef NULL


### PR DESCRIPTION
As @roeming rightly pointed out on Discord, the type `enum` is of free interpretation from the compiler if it should be a `signed int` or anything else. Furthermore the compiler can change a specific `enum` type into `unsigned` if a value higher than `INT_MAX` is found. There are also cases where a `s8`/`u8` could be confused as a `bool` (which is how C++ behaves), which should not apply to our code base. Finally we have Windows developers who could confuse `bool` with `BOOL`, which is a fixed 32-bit integer.

This PR solves the `bool` ambiguity by setting `signed int` in stone to what SOTN expects, while keeping the code base well documented. This will ultimately helps to make the code more portable.