### PR TITLE
Fix mis-alignment between signed and unsigned char

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-return-type")
 endif()
 
+if(MSVC)
+    add_compile_options(/J)  # Treat char as unsigned
+else()
+    add_compile_options(-funsigned-char)
+endif()
+
 find_package(SDL2 REQUIRED)
 
 set(SOURCE_FILES_PC


### PR DESCRIPTION
`char` is `unsigned` in our decomp. This forces all compilers to do the same.