### PR TITLE
Remove Result_t from libcd header

### DIFF
--- a/include/psxsdk/libcd.h
+++ b/include/psxsdk/libcd.h
@@ -121,9 +121,7 @@ typedef struct {
     char name[16]; /* file name (body) */
 } CdlFILE;
 
-typedef char Result_t[8];
-
-typedef void (*CdlCB)(u_char, Result_t*);
+typedef void (*CdlCB)(u_char, u_char*);
 
 int CdInit(void);
 char CdStatus(void);
@@ -134,14 +132,14 @@ void CdFlush(void);
 int CdSetDebug(int level);
 char* CdComstr(u_char com);
 char* CdIntstr(u_char intr);
-int CdSync(int mode, Result_t* result);
-int CdReady(int mode, Result_t* result);
+int CdSync(int mode, u_char* result);
+int CdReady(int mode, u_char* result);
 CdlCB CdSyncCallback(CdlCB func);
 CdlCB CdReadyCallback(CdlCB func);
 
 // Issues direct primitive commands to the CD-ROM subsystem
-int CdControl(u_char com, u_char* param, Result_t* result);
-int CdControlB(u_char com, u_char* param, Result_t* result);
+int CdControl(u_char com, u_char* param, u_char* result);
+int CdControlB(u_char com, u_char* param, u_char* result);
 int CdControlF(u_char com, u_char* param);
 
 /*
@@ -157,7 +155,7 @@ CdlLOC* CdIntToPos(int i, CdlLOC* p);
 int CdPosToInt(CdlLOC* p);
 CdlFILE* CdSearchFile(CdlFILE* fp, char* name);
 int CdRead(int sectors, u_long* buf, int mode);
-int CdReadSync(int mode, Result_t* result);
+int CdReadSync(int mode, u_char* result);
 CdlCB CdReadCallback(CdlCB func);
 int CdRead2(long mode);
 

--- a/src/dra/sound.c
+++ b/src/dra/sound.c
@@ -109,7 +109,7 @@ void func_80131FCC(void) {
 }
 
 u8 DoCdCommand(u_char com, u_char* param, u_char* result) {
-    g_CdCommandStatus = CdSync(CdlNop, (Result_t*)g_CdCommandResult);
+    g_CdCommandStatus = CdSync(CdlNop, g_CdCommandResult);
 
     if (com == CdlGetlocL) {
         if (g_CdCommandStatus != CdlComplete) {
@@ -128,7 +128,7 @@ u8 DoCdCommand(u_char com, u_char* param, u_char* result) {
     }
 
     if (g_CdCommandStatus == CdlComplete) {
-        if (CdControl(com, param, (Result_t*)result)) {
+        if (CdControl(com, param, result)) {
             D_8013B680 = 0;
             return D_8013B680;
         }

--- a/src/dra_psp/63C08.c
+++ b/src/dra_psp/63C08.c
@@ -733,7 +733,7 @@ void func_80131FCC(void) {
 }
 
 u8 DoCdCommand(u_char com, u_char* param, u_char* result) {
-    g_CdCommandStatus = CdSync(CdlNop, (Result_t*)g_CdCommandResult);
+    g_CdCommandStatus = CdSync(CdlNop, g_CdCommandResult);
 
     if (com == CdlGetlocL) {
         if (g_CdCommandStatus != CdlComplete) {
@@ -752,7 +752,7 @@ u8 DoCdCommand(u_char com, u_char* param, u_char* result) {
     }
 
     if (g_CdCommandStatus == CdlComplete) {
-        if (CdControl(com, param, (Result_t*)result)) {
+        if (CdControl(com, param, result)) {
             D_8013B680 = 0;
             return D_8013B680;
         }

--- a/src/main/psxsdk/libcd/bios.c
+++ b/src/main/psxsdk/libcd/bios.c
@@ -3,6 +3,9 @@
 #include "../libspu/libspu_internal.h"
 #include <common.h>
 
+// internal type representing the CD buffer size
+typedef char Result_t[8];
+
 typedef struct {
     unsigned char sync;  // sync state
     unsigned char ready; // ready state
@@ -226,7 +229,7 @@ static inline void callback(void) {
     *libcd_CDRegister0 = temp_s1;
 }
 
-int CD_sync(int mode, Result_t* result) {
+int CD_sync(int mode, u_char* result) {
     int i;
     int sync;
 
@@ -254,7 +257,7 @@ int CD_sync(int mode, Result_t* result) {
     }
 }
 
-int CD_ready(int mode, Result_t* result) {
+int CD_ready(int mode, u_char* result) {
     int i;
     int c;
     int ready;
@@ -285,7 +288,7 @@ int CD_ready(int mode, Result_t* result) {
     }
 }
 
-int CD_cw(u8 com, u8* param, Result_t* result, s32 arg3) {
+int CD_cw(u8 com, u8* param, u_char* result, s32 arg3) {
     int i;
 
     if (D_80032AB0 > 1) {

--- a/src/main/psxsdk/libcd/c_011.c
+++ b/src/main/psxsdk/libcd/c_011.c
@@ -33,7 +33,7 @@ extern s32 D_80098894;
 void StCdInterrupt(void) {
     volatile s16 subroutine_arg8[4];
     CdlLOC loc;
-    Result_t result;
+    u_char result[8];
     u32* var_a1;
     s32 var_t0;
     u32* var_a0;
@@ -52,7 +52,7 @@ void StCdInterrupt(void) {
         D_80032EB0 = 1;
         return;
     }
-    if (CdReady(1, &result) == CdlDiskError) {
+    if (CdReady(1, result) == CdlDiskError) {
         return;
     }
     subroutine_arg8[1] = result[0];

--- a/src/main/psxsdk/libcd/cdread.c
+++ b/src/main/psxsdk/libcd/cdread.c
@@ -19,7 +19,7 @@ typedef struct {
 static CdlCB CD_ReadCallbackFunc = NULL;
 static volatile cdreadStruct D_80032DBC = {0};
 
-void cb_read(u_char arg0, Result_t* result) {
+void cb_read(u_char arg0, u_char* result) {
     int pos[3];
 
     if (arg0 == 1) {
@@ -122,7 +122,7 @@ int CdRead(int sectors, u_long* buf, int mode) {
     return cd_read_retry(false) > 0;
 }
 
-int CdReadSync(int mode, Result_t* result) {
+int CdReadSync(int mode, u_char* result) {
     int var_s0;
 
     while (true) {

--- a/src/main/psxsdk/libcd/cdread2.c
+++ b/src/main/psxsdk/libcd/cdread2.c
@@ -5,7 +5,7 @@
 void data_ready_callback();
 extern s32 D_8003C768;
 
-static inline void StCdInterrupt2(u_char intr, Result_t* result) {
+static inline void StCdInterrupt2(u_char intr, u_char* result) {
     StCdInterrupt();
 }
 

--- a/src/main/psxsdk/libcd/event.c
+++ b/src/main/psxsdk/libcd/event.c
@@ -3,15 +3,15 @@
 #include <kernel.h>
 #include "libcd_internal.h"
 
-static inline void def_cbsync(u_char intr, Result_t* result) {
+static inline void def_cbsync(u_char intr, u_char* result) {
     DeliverEvent(HwCdRom, EvSpCOMP);
 }
 
-static inline void def_cbready(u_char intr, Result_t* result) {
+static inline void def_cbready(u_char intr, u_char* result) {
     DeliverEvent(HwCdRom, EvSpDR);
 }
 
-static inline void def_cbread(u_char intr, Result_t* result) {
+static inline void def_cbread(u_char intr, u_char* result) {
     DeliverEvent(HwCdRom, EvSpDR);
 }
 

--- a/src/main/psxsdk/libcd/libcd_internal.h
+++ b/src/main/psxsdk/libcd/libcd_internal.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 #include <psxsdk/libcd.h>
 
-int CD_sync(int mode, Result_t* result);
-int CD_ready(int mode, Result_t* result);
+int CD_sync(int mode, u_char* result);
+int CD_ready(int mode, u_char* result);
 int CD_flush(void);
 void CD_initintr(void);
 int CD_init(void);

--- a/src/main/psxsdk/libcd/sys.c
+++ b/src/main/psxsdk/libcd/sys.c
@@ -67,9 +67,9 @@ char* CdIntstr(u8 intr) {
     return D_80032B48[intr];
 }
 
-int CdSync(int mode, Result_t* result) { return CD_sync(mode, result); }
+int CdSync(int mode, u_char* result) { return CD_sync(mode, result); }
 
-int CdReady(int mode, Result_t* result) { return CD_ready(mode, result); }
+int CdReady(int mode, u_char* result) { return CD_ready(mode, result); }
 
 CdlCB CdSyncCallback(CdlCB func) {
     CdlCB old = CD_cbsync;
@@ -83,7 +83,7 @@ CdlCB CdReadyCallback(CdlCB func) {
     return old;
 }
 
-static inline cd_cw(u8 com, u8* param, Result_t* result, s32 arg3) {
+static inline cd_cw(u8 com, u8* param, u_char* result, s32 arg3) {
     CdlCB old = CD_cbsync;
     int count = 4;
 
@@ -105,13 +105,13 @@ static inline cd_cw(u8 com, u8* param, Result_t* result, s32 arg3) {
     return -1;
 }
 
-int CdControl(u8 com, u8* param, Result_t* result) {
+int CdControl(u8 com, u8* param, u_char* result) {
     return cd_cw(com, param, result, 0) == 0;
 }
 
 int CdControlF(u8 com, u8* param) { return cd_cw(com, param, NULL, 1) == 0; }
 
-int CdControlB(u8 com, u8* param, Result_t* result) {
+int CdControlB(u8 com, u8* param, u_char* result) {
     if (cd_cw(com, param, result, 0)) {
         return 0;
     }

--- a/src/pc/psxsdk/libcd.c
+++ b/src/pc/psxsdk/libcd.c
@@ -53,7 +53,7 @@ int CdPosToInt(CdlLOC* p) {
            DECODE_BCD(p->sector) - 150;
 }
 
-int CdControl(u_char com, u_char* param, Result_t* result) {
+int CdControl(u_char com, u_char* param, u_char* result) {
     DEBUGF("com %d %s", com, CdSyncModeToStr(com));
     CdlLOC* pos;
 
@@ -78,7 +78,7 @@ int CdControl(u_char com, u_char* param, Result_t* result) {
     return 1;
 }
 
-int CdSync(int mode, Result_t* result) {
+int CdSync(int mode, u_char* result) {
     DEBUGF("mode %0d %s", mode, CdSyncModeToStr(mode));
     return CdlComplete;
 }


### PR DESCRIPTION
Removes the custom type `Result_t` to avoid compilation issues when swapping the PSX SDK headers with those from the original SDK with modern compilers. This code reverts to the matching signature `u_char*`.

The type `Result_t` is still present in `src/main/psxsdk/libcd/bios.c`, but it is only used for its own internal use.

CC @gamezter 