### PR TITLE
Add ./sotn.sh support for Saturn

### DIFF
--- a/.github/workflows/saturn-build.yml
+++ b/.github/workflows/saturn-build.yml
@@ -41,12 +41,8 @@ jobs:
           sudo dpkg -i fdpp-dev_1.6-1_amd64.deb
           sudo dpkg -i comcom32_0.1~alpha3-1_all.deb
           sudo dpkg -i dosemu2_2.0~pre9-1_amd64.deb
-      - name: Extract asm
-        run: VERSION=saturn make extract
-      - name: Build saturn binaries
-        run: VERSION=saturn make build
-      - name: Check saturn
-        run: VERSION=saturn make saturn
+      - name: Build saturn
+        run: ./sotn.sh build saturn
 
   function-finder-saturn:
     if: github.repository == 'Xeeynamo/sotn-decomp' && github.ref == 'refs/heads/master' && github.event_name == 'push'
@@ -64,8 +60,8 @@ jobs:
       - name: Install bchunk
         run: |
           sudo apt-get install bchunk binutils-sh-elf
-      - name: Extract asm
-        run: VERSION=saturn make extract
+      - name: Build saturn
+        run: ./sotn.sh build saturn
       - name: Clone asset repository
         uses: actions/checkout@v6
         with:

--- a/Makefile.saturn.mk
+++ b/Makefile.saturn.mk
@@ -7,7 +7,6 @@ $(VERSION_PREFIX)_EXTRACT_TARGETS	:= $($(VERSION_PREFIX)_GAME) $(addprefix st,$(
 $(VERSION_PREFIX)_BUILD_TARGETS	:= $($(VERSION_PREFIX)_GAME) $($(VERSION_PREFIX)_STAGES) $($(VERSION_PREFIX)_BOSSES) $($(VERSION_PREFIX)_SERVANTS)
 
 SATURN_SPLITTER_DIR			:= $(TOOLS_DIR)/saturn-splitter
-SATURN_SPLITTER_APP 		:= $(SATURN_SPLITTER_DIR)/rust-dis/target/release/rust-dis
 SATURN_ASSETS_DIR := $(ASSETS_DIR)/saturn
 SATURN_LIB_TARGETS	:= lib/gfs lib/spr lib/dma lib/scl lib/csh lib/per lib/cdc lib/mth lib/bup lib/sys
 
@@ -22,30 +21,14 @@ SATURN_BUILD_PRGS		:= $(addprefix $(BUILD_DIR)/,$(addsuffix .PRG,$(SATURN_BUILD_
 SATURN_LIB_OBJECTS		:= $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(SATURN_LIB_TARGETS)))
 SATURN_PCM_FILES 		:= $(wildcard disks/saturn/SD/*.PCM)
 SATURN_WAV_FILES 		:= $(patsubst disks/saturn/SD/%.PCM,$(SATURN_ASSETS_DIR)/SD/%.wav,$(SATURN_PCM_FILES))
-DEPENDENCIES			+= $(SATURN_SPLITTER_APP)
 
 # Saturn specific targets
 .PHONY: saturn
 saturn: build_saturn check_saturn
 
-.PHONY: check # TODO: remove once `make saturn` in validate-and-report is merged to master
-.PHONY: check_saturn
-check_saturn:
-	sha1sum --check config/check.saturn.sha
-
 .PHONY: build_saturn
 build_saturn: $(SATURN_TOOLCHAIN)
 	python3 ./tools/builds/saturn.py && ninja
-
-.PHONY: extract_saturn
-extract_saturn: $(SATURN_SPLITTER_APP)
-	$(SATURN_SPLITTER_APP) config/saturn/game.prg.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/t_bat.prg.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/zero.bin.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/stage_02.prg.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/warp.prg.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/alucard.prg.yaml
-	$(SATURN_SPLITTER_APP) config/saturn/richter.prg.yaml
 
 .PHONY: extract_disk_saturn
 extract_disk_saturn:
@@ -61,67 +44,12 @@ diff_saturn:
 	sh-elf-objdump -z -m sh2 -b binary -D ./disks/saturn/$(FILENAME) > ./build/saturn/$(FILENAME)-theirs.txt && \
 	diff ./build/saturn/$(FILENAME)-ours.txt ./build/saturn/$(FILENAME)-theirs.txt > ./build/saturn/$(FILENAME)-diff.txt || true
 
-$(BUILD_DIR)/0.BIN: $(BUILD_DIR)/zero.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/GAME.PRG: $(BUILD_DIR)/game.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/ALUCARD.PRG: $(BUILD_DIR)/alucard.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/RICHTER.PRG: $(BUILD_DIR)/richter.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/STAGE_02.PRG: $(BUILD_DIR)/stage_02.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/WARP.PRG: $(BUILD_DIR)/warp.elf
-	sh-elf-objcopy $< -O binary $@
-$(BUILD_DIR)/T_BAT.PRG: $(BUILD_DIR)/t_bat.elf
-	sh-elf-objcopy $< -O binary $@
-
-$(BUILD_DIR)/zero.elf: $(BUILD_DIR)/zero.o $(SATURN_LIB_OBJECTS) config/saturn/zero_syms.txt config/saturn/game_syms.txt config/saturn/zero_user_syms.txt
-	cd $(BUILD_DIR) && \
-		sh-elf-ld -verbose --no-check-sections -nostdlib \
-		-o zero.elf \
-		-Map zero.map \
-		-T ../../config/saturn/zero.ld \
-		-T ../../config/saturn/zero_syms.txt \
-		-T ../../config/saturn/game_syms.txt \
-		-T ../../config/saturn/zero_user_syms.txt \
-		zero.o $(addsuffix .o,$(SATURN_LIB_TARGETS))
-
-$(BUILD_DIR)/%.elf: $(BUILD_DIR)/%.o config/saturn/zero_syms.txt config/saturn/game_syms.txt config/saturn/%_user_syms.txt
-	cd $(BUILD_DIR) && \
-		sh-elf-ld -verbose --no-check-sections -nostdlib \
-		-o $*.elf \
-		-Map $*.map \
-		-T ../../config/saturn/$*.ld \
-		-T ../../config/saturn/zero_syms.txt \
-		-T ../../config/saturn/game_syms.txt \
-		-T ../../config/saturn/$*_user_syms.txt \
-		$*.o
-
 $(BUILD_DIR)/lib/%.o: $(SRC_DIR)/saturn/lib/%.c $(CC1_SATURN)
 	mkdir -p $(dir $@)
 	cd $(BUILD_DIR) && $(DOSEMU_APP) "GCC.EXE -c -I./ -O0 -m2 -fsigned-char lib/$*.c -o lib/$*.o"
 $(BUILD_DIR)/%.o: $(SRC_DIR)/saturn/%.c $(CC1_SATURN)
 	mkdir -p $(dir $@)
 	cd $(BUILD_DIR) && $(DOSEMU_APP) "GCC.EXE -c -I./ -O2 -m2 -fsigned-char $*.c -o $*.o"
-
-$(CC1_SATURN): $(SATURN_TOOLCHAIN)
-	mkdir -p $(dir $@)
-	cp -r $(SATURN_TOOLCHAIN)/* $(BUILD_DIR)
-	cp  ./src/saturn/macro.inc $(BUILD_DIR)
-	cp -r ./src/saturn/*.c $(BUILD_DIR)
-	cp -r ./src/saturn/*.h $(BUILD_DIR)
-	cp -r ./src/saturn/lib $(BUILD_DIR)/lib
-	cp -r ./include/saturn $(BUILD_DIR)/saturn
-	mkdir -p $(BUILD_DIR)/asm/saturn/
-	cp -r ./asm/saturn/game $(BUILD_DIR)/asm/saturn/game
-	cp -r ./asm/saturn/t_bat $(BUILD_DIR)/asm/saturn/t_bat
-	cp -r ./asm/saturn/zero $(BUILD_DIR)/asm/saturn/zero
-	cp -r ./asm/saturn/stage_02 $(BUILD_DIR)/asm/saturn/stage_02
-	cp -r ./asm/saturn/warp $(BUILD_DIR)/asm/saturn/warp
-	cp -r ./asm/saturn/alucard $(BUILD_DIR)/asm/saturn/alucard
-	cp -r ./asm/saturn/richter $(BUILD_DIR)/asm/saturn/richter
-	touch $(CC1_SATURN)
 
 $(SATURN_SPLITTER_APP):
 	git submodule init $(SATURN_SPLITTER_DIR)

--- a/Makefile.saturn.mk
+++ b/Makefile.saturn.mk
@@ -26,9 +26,17 @@ SATURN_WAV_FILES 		:= $(patsubst disks/saturn/SD/%.PCM,$(SATURN_ASSETS_DIR)/SD/%
 .PHONY: saturn
 saturn: build_saturn check_saturn
 
+.PHONY: check_saturn
+check_saturn:
+	sha1sum --check config/check.saturn.sha
+
 .PHONY: build_saturn
 build_saturn: $(SATURN_TOOLCHAIN)
 	python3 ./tools/builds/saturn.py && ninja
+
+.PHONY: extract_saturn
+extract_saturn:
+	@./sotn.sh extract-saturn
 
 .PHONY: extract_disk_saturn
 extract_disk_saturn:

--- a/Makefile.saturn.mk
+++ b/Makefile.saturn.mk
@@ -1,10 +1,5 @@
 # Saturn is special and does not yet conform
 VERSION_PREFIX 	:= SATURN
-SATURN_GAME		:= GAME ALUCARD RICHTER
-SATURN_STAGES	:= STAGE_02 WARP
-SATURN_STAGES	+= 
-SATURN_BOSSES 	:= 
-SATURN_SERVANTS	:= T_BAT
 
 # Extract targets is for when stages and bosses need to be prefixed with st and bo respectively
 $(VERSION_PREFIX)_EXTRACT_TARGETS	:= $($(VERSION_PREFIX)_GAME) $(addprefix st,$($(VERSION_PREFIX)_STAGES)) $(addprefix bo,$($(VERSION_PREFIX)_BOSSES)) $($(VERSION_PREFIX)_SERVANTS)
@@ -44,13 +39,13 @@ build_saturn: $(SATURN_TOOLCHAIN)
 
 .PHONY: extract_saturn
 extract_saturn: $(SATURN_SPLITTER_APP)
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/game.prg.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/t_bat.prg.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/zero.bin.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/stage_02.prg.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/warp.prg.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/alucard.prg.yaml
-	$(SATURN_SPLITTER_APP) $(CONFIG_DIR)/saturn/richter.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/game.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/t_bat.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/zero.bin.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/stage_02.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/warp.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/alucard.prg.yaml
+	$(SATURN_SPLITTER_APP) config/saturn/richter.prg.yaml
 
 .PHONY: extract_disk_saturn
 extract_disk_saturn:

--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -10,17 +10,35 @@ import (
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/deps"
 )
 
+// allVersions are built by `./sotn.sh build` with no arguments.
 var allVersions = []string{"us", "hd", "pspeu"}
+
+// buildableVersions are all versions accepted by the build command.
+var buildableVersions = []string{"us", "hd", "pspeu", "saturn"}
 
 func buildVersions(versions []string) error {
 	if err := deps.EnsureBuildDeps(versions); err != nil {
-		return fmt.Errorf("ensuring build deps: %w", err)
+		return fmt.Errorf("ensuring build dependencies: %w", err)
 	}
-	versionStr := strings.Join(versions, ",")
-	if err := genNinjaIfNeeded(versionStr, versions); err != nil {
-		return err
+	var regular []string
+	for _, v := range versions {
+		if v == "saturn" {
+			if err := buildSaturn(); err != nil {
+				return fmt.Errorf("build saturn: %w", err)
+			}
+		} else {
+			regular = append(regular, v)
+		}
 	}
-	return deps.Ninja()
+	if len(regular) > 0 {
+		if err := genNinjaIfNeeded(strings.Join(regular, ","), regular); err != nil {
+			return err
+		}
+		if err := deps.Ninja(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func ninjaStampValue(versionStr string) string {
@@ -92,8 +110,8 @@ func parseBuildArgs(args []string) ([]string, error) {
 		if arg == "all" {
 			return allVersions, nil
 		}
-		if !slices.Contains(allVersions, arg) {
-			return nil, fmt.Errorf("unknown version %q; valid values: %v", arg, allVersions)
+		if !slices.Contains(buildableVersions, arg) {
+			return nil, fmt.Errorf("unknown version %q; valid values: %v", arg, buildableVersions)
 		}
 		versions = append(versions, arg)
 	}

--- a/tools/sotn-assets/build_saturn.go
+++ b/tools/sotn-assets/build_saturn.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/deps"
+)
+
+var saturnSplitterYAMLs = []string{
+	"config/saturn/game.prg.yaml",
+	"config/saturn/t_bat.prg.yaml",
+	"config/saturn/zero.bin.yaml",
+	"config/saturn/stage_02.prg.yaml",
+	"config/saturn/warp.prg.yaml",
+	"config/saturn/alucard.prg.yaml",
+	"config/saturn/richter.prg.yaml",
+}
+
+func buildSaturn() error {
+	if err := extractSaturn(); err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+	if err := genSaturnNinjaIfNeeded(); err != nil {
+		return err
+	}
+	if err := deps.Ninja(); err != nil {
+		return fmt.Errorf("ninja: %w", err)
+	}
+	return deps.CheckSHA("config/check.saturn.sha")
+}
+
+var saturnExtractSentinels = []string{
+	"asm/saturn/game",
+	"config/saturn/game_syms.txt",
+	"config/saturn/zero_syms.txt",
+}
+
+func extractSaturn() error {
+	for _, sentinel := range saturnExtractSentinels {
+		if _, err := os.Stat(sentinel); err != nil {
+			return runSaturnSplitter()
+		}
+	}
+	return nil
+}
+
+func runSaturnSplitter() error {
+	const splitter = "tools/saturn-splitter/rust-dis/target/release/rust-dis"
+	for _, yaml := range saturnSplitterYAMLs {
+		if err := deps.RunApp(splitter, yaml); err != nil {
+			return fmt.Errorf("split %s: %w", filepath.Base(yaml), err)
+		}
+	}
+	return nil
+}
+
+func genSaturnNinjaIfNeeded() error {
+	const ninjaFile = "build.ninja"
+	const stampFile = "build.ninja.version"
+	const stamp = "saturn"
+
+	needsRegen := false
+	if stampData, err := os.ReadFile(stampFile); err != nil || string(stampData) != stamp {
+		needsRegen = true
+	}
+	if !needsRegen {
+		ninjaInfo, err := os.Stat(ninjaFile)
+		if err != nil {
+			needsRegen = true
+		} else if info, err := os.Stat("tools/builds/saturn.py"); err == nil && info.ModTime().After(ninjaInfo.ModTime()) {
+			needsRegen = true
+		}
+	}
+
+	if needsRegen {
+		if err := deps.GenSaturnNinja(); err != nil {
+			return err
+		}
+		return os.WriteFile(stampFile, []byte(stamp), 0o644)
+	}
+	return nil
+}

--- a/tools/sotn-assets/clean.go
+++ b/tools/sotn-assets/clean.go
@@ -12,7 +12,7 @@ import (
 func clean(version string, verbose bool) error {
 	var versions []sotn.Version
 	if version == "" || version == "all" {
-		for _, v := range sotn.VersionsAll {
+		for _, v := range sotn.VersionsEverything {
 			versions = append(versions, v)
 		}
 	} else {
@@ -31,6 +31,9 @@ func clean(version string, verbose bool) error {
 			})
 		}
 	}
+	eg.Go(func() error {
+		return deps.GitClean("config/saturn", verbose)
+	})
 	eg.Go(func() error {
 		return deps.GitClean("assets/", verbose)
 	})

--- a/tools/sotn-assets/deps/build_deps.go
+++ b/tools/sotn-assets/deps/build_deps.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/sotn"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/util"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -25,6 +26,8 @@ func EnsureBuildDeps(versions []string) error {
 			ensurePSXDeps(&eg)
 		case sotn.PlatformPSP:
 			ensurePSPDeps(&eg)
+		case sotn.PlatformSaturn:
+			ensureSaturnDeps(&eg)
 		default:
 			return fmt.Errorf("unsupported platform version: %s", version)
 		}
@@ -127,4 +130,32 @@ func ensurePythonDeps() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func ensureSaturnDeps(eg *errgroup.Group) {
+	eg.Go(func() error {
+		if err := downloadAndExtractStructuredTarGzFromGithub(
+			"Xeeynamo/sotn-decomp", cc1Psx26Release,
+			"cygnus-2.7-96Q3-bin", "bin",
+		); err != nil {
+			return err
+		}
+		const dst = "tools/builds/GCCSH"
+		if _, err := os.Stat(dst + "/CC1.EXE"); err == nil {
+			return nil
+		}
+		return util.CopyDirRecursive("bin/cygnus-2.7-96Q3-bin", dst)
+	})
+	eg.Go(func() error {
+		if err := GitSubmoduleInitAndUpdate("tools/saturn-splitter", true); err != nil {
+			return err
+		}
+		if err := CargoBuild("tools/saturn-splitter/rust-dis/Cargo.toml", ""); err != nil {
+			return err
+		}
+		if err := CargoBuild("tools/saturn-splitter/adpcm-extract/Cargo.toml", ""); err != nil {
+			return err
+		}
+		return nil
+	})
 }

--- a/tools/sotn-assets/deps/exec.go
+++ b/tools/sotn-assets/deps/exec.go
@@ -119,6 +119,42 @@ func ObjdiffGUI(args ...string) error {
 	return cmd.Start()
 }
 
+func RunApp(app string, args ...string) error {
+	return (&exec.Cmd{
+		Path:   app,
+		Args:   append([]string{app}, args...),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}).Run()
+}
+
+func GenSaturnNinja() error {
+	binPath, err := venvPython()
+	if err != nil {
+		return err
+	}
+	return (&exec.Cmd{
+		Path:   binPath,
+		Args:   []string{binPath, "tools/builds/saturn.py"},
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}).Run()
+}
+
+func CheckSHA(checkFile string) error {
+	binPath, err := venvPython()
+	if err != nil {
+		return err
+	}
+	return (&exec.Cmd{
+		Path:   binPath,
+		Args:   []string{binPath, "tools/builds/check.py", checkFile},
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}).Run()
+}
+
 func GenNinja(args ...string) error {
 	binPath, err := venvPython()
 	if err != nil {

--- a/tools/sotn-assets/deps/setup.go
+++ b/tools/sotn-assets/deps/setup.go
@@ -80,6 +80,68 @@ func extractTarGz(tarGzPath, targetName, destination string) error {
 	return fmt.Errorf("file %s not found in archive", targetName)
 }
 
+func downloadAndExtractStructuredTarGzFromGithub(repo, tag, name, destDir string) error {
+	tagPath := filepath.Join(destDir, name+".tag")
+	if tagData, err := os.ReadFile(tagPath); err == nil && string(tagData) == tag {
+		return nil
+	}
+	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s.tar.gz", repo, tag, name)
+	tarGzPath := filepath.Join(destDir, name+".tar.gz")
+	if err := download(url, tarGzPath); err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer os.Remove(tarGzPath)
+	if err := extractTarGzWithStructure(tarGzPath, destDir); err != nil {
+		return fmt.Errorf("failed to extract %s: %w", tarGzPath, err)
+	}
+	return os.WriteFile(tagPath, []byte(tag), 0o644)
+}
+
+func extractTarGzWithStructure(tarGzPath, destDir string) error {
+	f, err := os.Open(tarGzPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(destDir, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dest, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+				return err
+			}
+			out, err := os.Create(dest)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+			os.Chmod(dest, os.FileMode(header.Mode))
+		}
+	}
+	return nil
+}
+
 func downloadAndExtractAllTarGzFromGithub(repo, tag, name, destDir string) error {
 	return downloadGithubReleaseTarGz(
 		repo, tag, name,

--- a/tools/sotn-assets/main.go
+++ b/tools/sotn-assets/main.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/spf13/cobra"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/deps"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/format"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/mods"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/sotn"
@@ -65,6 +66,17 @@ func main() {
 	}
 	cleanCmd.Flags().BoolP("verbose", "v", false, "Echo git clean stdout and stderr")
 	rootCmd.AddCommand(cleanCmd)
+	rootCmd.AddCommand(&cobra.Command{
+		Use:          "extract-saturn",
+		Short:        "Extract Saturn asm stubs from disc files using saturn-splitter",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := deps.EnsureBuildDeps([]string{"saturn"}); err != nil {
+				return err
+			}
+			return runSaturnSplitter()
+		},
+	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:          "extract-assets <asset.yaml>",
 		Short:        "Extract asset files from the disk files",

--- a/tools/sotn-assets/sotn/version.go
+++ b/tools/sotn-assets/sotn/version.go
@@ -16,13 +16,19 @@ const (
 	PlatformPSP    = Platform("psp")
 	PlatformPSX    = Platform("psx")
 
-	VersionUS    = Version("us")
-	VersionHD    = Version("hd")
-	VersionPSPEU = Version("pspeu")
+	VersionUS     = Version("us")
+	VersionHD     = Version("hd")
+	VersionPSPEU  = Version("pspeu")
+	VersionSaturn = Version("saturn")
 )
 
 var (
+	// VersionsAll defaults when doing `build [all]`
 	VersionsAll = []Version{VersionUS, VersionHD, VersionPSPEU}
+
+	// VersionsEverything adds Saturn to the mix for more specific stuff we do
+	// not want to propagate to the usual build chain
+	VersionsEverything = append(VersionsAll, VersionSaturn)
 )
 
 func GetVersion() Version {

--- a/tools/sotn-assets/util/utils.go
+++ b/tools/sotn-assets/util/utils.go
@@ -86,6 +86,31 @@ func MaxBy[T any](slice []T, getter func(T) int) (max int) {
 	return max
 }
 
+func CopyDirRecursive(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+}
+
 func Btoi(b bool) int {
 	if b {
 		return 1


### PR DESCRIPTION
Continuation of #3172, adding Saturn support and performing a major Makefile clean-up. 

6b670b0 is needed as the GH workflow is the one from `master` and not the one from this PR. After this gets merged, 6b670b0 can be reverted.