### PR TITLE
Fix PSPEU progress report percentage stuck at 100%

### DIFF
--- a/tools/builds/gen.py
+++ b/tools/builds/gen.py
@@ -825,17 +825,18 @@ with open(build_ninja, "w") as f:
         command="mipsel-linux-gnu-objcopy -O binary $in $out && truncate -c -s 12288 $out",
         description="psx strip $in",
     )
+    extra_mw_flags = "--skip-asm" if sotn_progress_report else ""
     nw.rule(
         "psp-cc",
         command=(
             "VERSION=$version"
             " tools/sotn_str/target/release/sotn_str process -p -f $in"
             " | iconv --from-code=UTF-8 --to-code=$encoding"
-            " | bin/mw -o $out"
+            f" | bin/mw -o $out {extra_mw_flags}"
             " --mwcc-path bin/mwccpsp.exe --use-wibo --wibo-path bin/wibo --as-path tools/pspas/target/release/pspas"
             " --asm-dir asm/pspeu --macro-inc-path include/macro.inc "
             " -gccdep -MD"  # for metrowerks, "system" headers seem to be anything included with angle brackets
-            f" -gccinc -I$src_dir  -Iinclude -Iinclude/pspsdk -D_internal_version_$version -DSOTN_STR {extra_cpp_defs} -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck"
+            f" -gccinc -I$src_dir -Iinclude -Iinclude/pspsdk -D_internal_version_$version -DSOTN_STR {extra_cpp_defs} -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck"
             " $opt_level -opt nointrinsics"
             " -"
         ),

--- a/tools/sotn-assets/deps/setup.go
+++ b/tools/sotn-assets/deps/setup.go
@@ -138,9 +138,12 @@ func downloadFromGithubIfNotExists(repo, tag, name, destination string) error {
 	_ = os.Remove(destination)
 	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, name)
 	if err := downloadIfNotExists(url, destination); err != nil {
-		return fmt.Errorf("failed to download at %s", url)
+		return fmt.Errorf("failed to download %s: %w", url, err)
 	}
-	return os.WriteFile(tagPath, []byte(tag), 0o644)
+	if err := os.WriteFile(tagPath, []byte(tag), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", tagPath, err)
+	}
+	return nil
 }
 
 func downloadIfNotExists(url string, filename string) error {

--- a/tools/sotn-assets/psx/offsets.go
+++ b/tools/sotn-assets/psx/offsets.go
@@ -42,7 +42,7 @@ func (off Addr) Boundaries() Offsets {
 }
 
 func (off Addr) Format(f fmt.State, c rune) {
-	f.Write([]byte(fmt.Sprintf("0x%08X", uint32(off))))
+	_, _ = f.Write([]byte(fmt.Sprintf("0x%08X", uint32(off))))
 }
 
 func (off Addr) Real(begin Addr) int {
@@ -78,13 +78,13 @@ func (off Addr) InRange(begin Addr, end Addr) bool {
 func (off Addr) MoveFile(r io.ReadSeeker, begin Addr) error {
 	end := off.Boundaries().GameEnd
 	if !off.InRange(begin, end) {
-		err := fmt.Errorf("offset %s is outside the boundaries [%s, %s]", off, begin, end)
-		panic(err)
-		return err
+		return fmt.Errorf("offset %s is outside the boundaries [%s, %s]", off, begin, end)
 	}
 
 	fileOffset := int64(off - begin)
-	r.Seek(fileOffset, 0)
+	if _, err := r.Seek(fileOffset, 0); err != nil {
+		return fmt.Errorf("seeking to offset %s: %w", off, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The tool Metrowrap always compile the content from `INCLUDE_ASM`, and the reporting toolset cannot distinguish if the PSP source file is fully decompiled or still work in progress. This PR largely depends from https://github.com/ttkb-oss/metrowrap/pull/5