### PR TITLE
Add comments for some music and movie file functions

### DIFF
--- a/include/cutscene.h
+++ b/include/cutscene.h
@@ -11,9 +11,9 @@ typedef enum {
     CSOP_NEXT_DIALOG,
     CSOP_SET_POS,
     CSOP_CLOSE_DIALOG,
-    CSOP_PLAY_SOUND,
-    CSOP_WAIT_FOR_SOUND,
-    CSOP_SCRIPT_UNKNOWN_11,
+    CSOP_PLAY_SOUND,        // play sound, usually (always?) for music.    (does nothing if cutscene is being skipped)
+    CSOP_WAIT_FOR_SOUND,    // wait for CD audio playback to begin         (does nothing if cutscene is being skipped)
+    CSOP_SCRIPT_UNKNOWN_11, // wait for CD audio playback to stop          (does nothing if cutscene is being skipped)
     CSOP_SET_END,
     CSOP_SCRIPT_UNKNOWN_13,
     CSOP_SCRIPT_UNKNOWN_14,
@@ -22,7 +22,7 @@ typedef enum {
     CSOP_SET_FLAG,
     CSOP_SCRIPT_UNKNOWN_18,
     CSOP_LOAD_PORTRAIT,
-    CSOP_SCRIPT_UNKNOWN_20,
+    CSOP_SCRIPT_UNKNOWN_20, // same as CSOP_PLAY_SOUND, but always runs (always runs even if cutscene is being skipped)
     CSOP_SCRIPT_UNKNOWN_21,
     CSOP_SCRIPT_UNKNOWN_22,
     CSOP_SCRIPT_UNKNOWN_23,

--- a/src/dra/dra_bss.h
+++ b/src/dra/dra_bss.h
@@ -61,7 +61,7 @@ extern u16 g_CurSfxDistance20_21;
 extern u8 D_80139014;
 extern u8 g_SfxScriptModeCopy[4];
 extern u32 g_DebugCurPal;
-extern s16 D_8013901C;
+extern s16 D_8013901C; // very likely: "has CD music track actually started playing?"
 extern u8 g_MuteCd;
 extern s8 g_SfxScriptDistanceCopy[4];
 extern s16 g_CurrentXaSoundId;

--- a/src/dra/sound.c
+++ b/src/dra/sound.c
@@ -81,6 +81,10 @@ u16 func_80131F38(void) {
     return g_SeqPlayingId | 0x200;
 }
 
+// this is something vaguely like: "is a CD music track currently playing?"
+// seems like: cutscenes and dialogue tend to use this after starting a music track to wait until 
+// playback has actually started (or, to wait to know a playing track that was requested 
+// to stop has actually ended)
 bool func_80131F68(void) {
     bool ret;
     if (D_8013B61C) {
@@ -1129,7 +1133,7 @@ void PlaySfx(s16 sfxId) {
         case 0x92:
         case 0x93:
         case 0x94:
-            D_8013B61C = 1;
+            D_8013B61C = 1; // flag vaguely like: "has music track started playing?"
             break;
         }
         g_SoundCommandRingBuffer[g_SoundCommandRingBufferWritePos] = sfxId;

--- a/src/st/cen/cutscene.c
+++ b/src/st/cen/cutscene.c
@@ -283,24 +283,30 @@ void OVL_EXPORT(EntityCutscene)(Entity* self) {
                     nextChar = *g_Dialogue.scriptCur++;
                     nextChar <<= 4;
                     nextChar |= *g_Dialogue.scriptCur++;
-                    g_api.PlaySfx(nextChar);
+                    g_api.PlaySfx(nextChar); // usually: music track ID
                     continue;
                 case CSOP_WAIT_FOR_SOUND:
                     if (g_SkipCutscene) {
                         continue;
                     }
+                    // "has music track started playing?"
                     if (g_api.func_80131F68() != false) {
+                        // yes: playing, go to next step
                         continue;
                     }
+                    // no: music not playing yet, so repeat this step
                     *g_Dialogue.scriptCur--;
                     return;
                 case CSOP_SCRIPT_UNKNOWN_11:
                     if (g_SkipCutscene) {
                         continue;
                     }
+                    // "has music track stopped playing?"
                     if (g_api.func_80131F68() != true) {
+                        // yes: nothing is playing, go to next step
                         continue;
                     }
+                    // no: still waiting for playback to stop, repeat this step
                     *g_Dialogue.scriptCur--;
                     return;
                 case CSOP_SET_END:

--- a/src/st/sel/stream_info.c
+++ b/src/st/sel/stream_info.c
@@ -1,30 +1,51 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "sel.h"
 
+// each "stream" here represents one of the 4 movie files (.STR files) 
+// at a specific location on the SOTN disk.
+// offsets shown here are from the .idx file exported from running "jpsxdec" on the raw .bin or ISO.
+
+// movie file: LOGO15XA.STR (Konami Logo)
+// #:13|ID:LOGO15XA.STR|Sectors:23113-24544|Type:File|Size:2932736|Path:LOGO15XA.STR|Has mode 2 form 2:Yes|Has CD audio:No
+// -> #:14|ID:LOGO15XA.STR[0]|Sectors:23113-24543|Type:Video|Dimensions:320x240|Frame Count:143|Sector Frames:23113-24534|Sectors/Frame:1001/100|1st frame end sector:9|Disc Speed:2|Header Frames:1-143
+// -> #:15|ID:LOGO15XA.STR[0.0]|Sectors:23120-24240|Type:XA|File:1|Channel:1|Stereo?:Yes|Samples/Sec:37800|Bits/Sample:4|Sector stride:8|Disc speed:2x
 StreamInfo g_StreamInfo0 = {
-    .cdOffset = 0x5a49,
+    .cdOffset = 0x5a49, // = 23113
     .frameCount = 0x8f,
     .isRGB24 = 1,
 };
 
+// movie file: OPN_WS.STR (opening cinematic)
+// #:10|ID:OPN_WS.STR|Sectors:13873-23112|Type:File|Size:18923520|Path:OPN_WS.STR|Has mode 2 form 2:Yes|Has CD audio:No
+// -> #:11|ID:OPN_WS.STR[0]|Sectors:13873-23102|Type:Video|Dimensions:320x240|Frame Count:922|Sector Frames:13873-23093|Sectors/Frame:1001/100|1st frame end sector:9|Disc Speed:2|Header Frames:1-922
+// -> #:12|ID:OPN_WS.STR[0.0]|Sectors:13880-23112|Type:XA|File:1|Channel:1|Stereo?:Yes|Samples/Sec:37800|Bits/Sample:4|Sector stride:8|Disc speed:2x
 StreamInfo g_StreamInfo1 = {
-    .cdOffset = 0x3631,
+    .cdOffset = 0x3631, // 13873
     .frameCount = 0x39a,
     .isRGB24 = 1,
 };
 
+// movie file: TYK_WS.STR (inverted castle reveal cinematic)
+// #:7|ID:TYK_WS.STR|Sectors:8317-13872|Type:File|Size:11378688|Path:TYK_WS.STR|Has mode 2 form 2:Yes|Has CD audio:No
+// -> #:8|ID:TYK_WS.STR[0]|Sectors:8317-13872|Type:Video|Dimensions:320x240|Frame Count:555|Sector Frames:8317-13863|Sectors/Frame:1001/100|1st frame end sector:9|Disc Speed:2|Header Frames:1-555
+// -> #:9|ID:TYK_WS.STR[0.0]|Sectors:8324-13788|Type:XA|File:1|Channel:1|Stereo?:Yes|Samples/Sec:37800|Bits/Sample:4|Sector stride:8|Disc speed:2x
 StreamInfo g_StreamInfo2 = {
-    .cdOffset = 0x207d,
+    .cdOffset = 0x207d, // 8317
     .frameCount = 0x221,
     .isRGB24 = 1,
 };
 
+// movie file: END_WS.STR (ending cinematic)
+// #:4|ID:END_WS.STR|Sectors:879-8316|Type:File|Size:15233024|Path:END_WS.STR|Has mode 2 form 2:Yes|Has CD audio:No
+// -> #:5|ID:END_WS.STR[0]|Sectors:879-8316|Type:Video|Dimensions:320x240|Frame Count:743|Sector Frames:879-8307|Sectors/Frame:1001/100|1st frame end sector:9|Disc Speed:2|Header Frames:1-743
+// -> #:6|ID:END_WS.STR[0.0]|Sectors:886-7910|Type:XA|File:1|Channel:1|Stereo?:Yes|Samples/Sec:37800|Bits/Sample:4|Sector stride:8|Disc speed:2x
 StreamInfo g_StreamInfo3 = {
-    .cdOffset = 0x36f,
+    .cdOffset = 0x36f, // 879
     .frameCount = 0x2e4,
     .isRGB24 = 1,
 };
 
+// reference all 4 movie files:
 StreamInfo* g_Streams[] = {
     &g_StreamInfo0,
     &g_StreamInfo1,

--- a/src/st/st0/prologue_scroll.c
+++ b/src/st/st0/prologue_scroll.c
@@ -287,10 +287,13 @@ void PrologueScroll(void) {
         }
         break;
     case 5: // 0x801B0940
+        // wait for music playback to start
         if (
 #if defined(VERSION_PSP)
+            // PSP: assume music began playing
             1
 #else
+            // check "is a CD music track currently playing"?
             g_api.func_80131F68()
 #endif
         ) {


### PR DESCRIPTION
No actual code changes, just filling in some comments around:
1. Add descriptions for some of the movie file offsets in game_handlers.c and breadcrumbs for how to analyze with tools like jpsxdec
2. Add comments in various cutscene audio handlers related to "has CD music started playing"


Future work:
A. The cutscene code is duplicated all over the place, I just added the comments in one section only for now. I might take a stab at de-duplicating it later.
B. We could probably safely rename a few things but... I'm not quite sure that's the only meaning of this is related to music (it PROBABLY is). Those renames would be:
- rename func_80131F68() to something like IsMusicPlaybackStarted()
- rename D_8013901C to something like g_IsMusicPlaying    (maybe. probably. just not totally sure)

TODO:
- [ ] fix failed lint checks