### PR TITLE
Update Metrowrap

### DIFF
--- a/tools/builds/gen.py
+++ b/tools/builds/gen.py
@@ -830,11 +830,12 @@ with open(build_ninja, "w") as f:
         command=(
             "VERSION=$version"
             " tools/sotn_str/target/release/sotn_str process -p -f $in"
-            " | bin/mw -o $out --src-dir $src_dir"
+            " | iconv --from-code=UTF-8 --to-code=$encoding"
+            " | bin/mw -o $out"
             " --mwcc-path bin/mwccpsp.exe --use-wibo --wibo-path bin/wibo --as-path tools/pspas/target/release/pspas"
-            " --asm-dir asm/pspeu --target-encoding $encoding --macro-inc-path include/macro.inc"
+            " --asm-dir asm/pspeu --macro-inc-path include/macro.inc "
             " -gccdep -MD"  # for metrowerks, "system" headers seem to be anything included with angle brackets
-            f" -gccinc -Iinclude -Iinclude/pspsdk -D_internal_version_$version -DSOTN_STR {extra_cpp_defs} -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck"
+            f" -gccinc -I$src_dir  -Iinclude -Iinclude/pspsdk -D_internal_version_$version -DSOTN_STR {extra_cpp_defs} -c -lang c -sdatathreshold 0 -char unsigned -fl divbyzerocheck"
             " $opt_level -opt nointrinsics"
             " -"
         ),

--- a/tools/sotn-assets/deps/build_deps.go
+++ b/tools/sotn-assets/deps/build_deps.go
@@ -73,7 +73,7 @@ func ensurePSPDeps(eg *errgroup.Group) {
 		)
 	})
 	eg.Go(func() error {
-		const MetroWrapVersion = "0.1.2"
+		const MetroWrapVersion = "0.2.1"
 		_, err := os.Stat("bin/.mw-version-" + MetroWrapVersion)
 		if err == nil {
 			return nil
@@ -81,7 +81,7 @@ func ensurePSPDeps(eg *errgroup.Group) {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("check bin/.mw-version-*: %w", err)
 		}
-		if err := Cargo("install", "metrowrap", "--bins", "--root", ".", "--locked", "--version", MetroWrapVersion); err != nil {
+		if err := Cargo("install", "metrowrap", "--force", "--bins", "--root", ".", "--locked", "--version", MetroWrapVersion); err != nil {
 			return fmt.Errorf("install metrowrap: %w", err)
 		}
 		if err := os.WriteFile("bin/.mw-version-"+MetroWrapVersion, []byte{}, 0644); err != nil {


### PR DESCRIPTION
Updating to include @Xeeynamo's flag for emitting empty functions and data for progressing tracking.

Support for transcoding was removed, so `iconv` is used, just like the `gcc` build. The `--src-dir` option was deprecated, so that's been replaced with `-I`.