### PR TITLE
Ensure bin/sotn-assets is always up-to-date

### DIFF
--- a/tools/sotn-assets/deps/build_deps.go
+++ b/tools/sotn-assets/deps/build_deps.go
@@ -96,14 +96,21 @@ func ensurePSPDeps(eg *errgroup.Group) {
 	})
 }
 
+// gen.py invokes sotn-assets by path as "bin/sotn-assets", so the running
+// executable must stay in sync with itself.
 func ensureSotnAssets() error {
-	// must "build" itself due to how gen.py works
-	if _, err := os.Stat("bin/sotn-assets"); err == nil {
-		return nil
-	}
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve own executable: %w", err)
+	}
+	selfInfo, err := os.Stat(self)
+	if err != nil {
+		return fmt.Errorf("stat own executable: %w", err)
+	}
+	if destInfo, err := os.Stat("bin/sotn-assets"); err == nil {
+		if selfInfo.ModTime().Equal(destInfo.ModTime()) {
+			return nil
+		}
 	}
 	if err := os.MkdirAll("bin", 0755); err != nil {
 		return err


### PR DESCRIPTION
Removes the need of `rm bin/sotn-assets` when the tool needs to be updated. `mtime` must be equal between src and dst, which ensures the binary copies itself even when reverting a code change. Example on why doing `src.mtime < dst.mtime` wouldn't work:

1. `bin/sotn-assets` is up-to-date with mtime `N`
2. I introduce a broken change, like a `panic("foobar")` in `assets_config.go`.
3. Invoking `./sotn.sh build` observes the mtime is now `N+1`, different from `N` of `bin/sotn-assets`, and the executable is replaced.
4. Now I revert the change. `./sotn.sh build` will have mtime `N` because the build was cached. `N != N+1`, so it will copy itself and replace  `bin/sotn-assets` with the older version

The reason this weird logic even exists is because `sotn-assets` is now a build orchestrator that calls Ninja. But Ninja calls `sotn-assets` to extract or build the game assets if needed. It's an architectural mistake I made that I am unsure how to fix it. But so far it does the job well.