### PR TITLE
Unimported data reported as 0% progress

### DIFF
--- a/tools/sotn-assets/objdiffbin.go
+++ b/tools/sotn-assets/objdiffbin.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,5 +78,65 @@ func handleObjdiffReport(version string) error {
 	}
 
 	reportPath := filepath.Join("build", version, "report.json")
-	return deps.ObjdiffCLI("report", "generate", "-o", reportPath)
+	if err := deps.ObjdiffCLI("report", "generate", "-o", reportPath); err != nil {
+		return err
+	}
+	return addNonmatchingData(reportPath)
+}
+
+func addNonmatchingData(reportPath string) error {
+	// rewrites reportPath content to manually inject data+rodata+bss percentage report
+	// every file containing data that comes from asm/ instead of src/, it marked as non-matching
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		return err
+	}
+	var report map[string]any
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return fmt.Errorf("parse %s: %v", reportPath, err)
+	}
+	units, _ := report["units"].([]any)
+	for _, u := range units {
+		unit, _ := u.(map[string]any)
+		if unit == nil {
+			continue
+		}
+		meta, _ := unit["metadata"].(map[string]any)
+		if meta == nil {
+			continue
+		}
+		srcPath, _ := meta["source_path"].(string)
+		if !strings.HasPrefix(srcPath, "asm/") {
+			continue
+		}
+		measures, _ := unit["measures"].(map[string]any)
+		if measures == nil {
+			measures = map[string]any{}
+			unit["measures"] = measures
+		}
+		// Force the unit to display as 0% on decomp.dev. matched_data is
+		// already 0 (proto3 default-suppressed); we set it explicitly so it
+		// survives any re-serialization downstream.
+		for _, k := range []string{
+			"fuzzy_match_percent",
+			"matched_code_percent",
+			"matched_data_percent",
+			"matched_functions_percent",
+			"complete_code_percent",
+			"complete_data_percent",
+		} {
+			measures[k] = 0.0
+		}
+		measures["matched_code"] = "0"
+		measures["matched_data"] = "0"
+		measures["matched_functions"] = 0
+		measures["complete_code"] = "0"
+		measures["complete_data"] = "0"
+		measures["complete_units"] = 0
+	}
+	out, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(reportPath, out, 0644)
 }


### PR DESCRIPTION
Another fix to the progress reporter for https://decomp.dev/Xeeynamo/sotn-decomp . I noticed data is always considered matching for all overlays. This PR should fix that.