### PR TITLE
Decompile `t_bat` FindValidTarget

### DIFF
--- a/config/saturn/t_bat_user_syms.txt
+++ b/config/saturn/t_bat_user_syms.txt
@@ -1,1 +1,6 @@
 _s_IsServantDestroyed = 0x060D1DFC;
+_s_LastTargetedEntityIndex = 0x060D1E00;
+_g_BatAbilityStats = 0x060D1D34;
+_s_BatStats = 0x060D2830;
+_g_Entities = 0x060997F8;
+___ashiftrt_r4_7 = 0x06030E56;

--- a/src/saturn/sattypes.h
+++ b/src/saturn/sattypes.h
@@ -185,7 +185,7 @@ typedef struct Entity {
     /* 0x34 */ u32 flags;
     /* 0x38 */ u16 enemyId;
     /* 0x3A */ u16 hitboxState; // hitbox state
-    /* 0x3C */ char pad_3C[2];
+    /* 0x3C */ s16 hitPoints;
     /* 0x3E */ s16 attack;
     /* 0x40 */ s16 attackElement;
     /* 0x42 */ s16 pad_42;

--- a/src/saturn/sattypes.h
+++ b/src/saturn/sattypes.h
@@ -25,6 +25,7 @@ typedef unsigned long long u64;
 #define STAGE_INVERTEDCASTLE_FLAG 0x20
 #define STAGE_ST0 0x1F
 #define TOTAL_ENTITY_COUNT 256
+#define STAGE_ENTITY_START 64
 #define FACTORY(id, param) ((id) + (param << 16))
 
 #define SFX_HEART_PICKUP 0x67A

--- a/src/saturn/sattypes.h
+++ b/src/saturn/sattypes.h
@@ -118,6 +118,38 @@ typedef enum {
     Player_MariaSpellFourHolyBeasts,
 } PlayerSteps;
 
+// Flags for entity->flags
+typedef enum {
+    FLAG_UNK_10 = 0x10,
+    FLAG_UNK_20 = 0x20,
+    FLAG_UNK_40 = 0x40,
+    FLAG_UNK_80 = 0x80,
+    FLAG_DEAD = 0x100, // entity must execute its death routine
+    FLAG_UNK_200 = 0x200,
+    FLAG_UNK_400 = 0x400,
+    FLAG_UNK_800 = 0x800,
+    FLAG_UNK_1000 = 0x1000,
+    FLAG_UNK_2000 = 0x2000,
+    FLAG_UNK_4000 = 0x4000,
+    FLAG_UNK_8000 = 0x8000,
+    FLAG_UNK_10000 = 0x10000,
+    FLAG_UNK_20000 = 0x20000,         // func_8011A9D8 will destroy if not set
+    FLAG_POS_PLAYER_LOCKED = 0x40000, // entity follows player position
+    FLAG_UNK_80000 = 0x80000,
+    FLAG_UNK_100000 = 0x100000,
+    FLAG_UNK_00200000 = 0x00200000,
+    FLAG_SUPPRESS_STUN = 0x400000, // disable invincibility frames
+    FLAG_HAS_PRIMS = 0x800000,     // call FreePrimitives on DestroyEntity
+    FLAG_NOT_AN_ENEMY = 0x01000000,
+    FLAG_UNK_02000000 = 0x02000000,
+    FLAG_KEEP_ALIVE_OFFCAMERA = 0x04000000, // don't destroy entity off-screen
+    FLAG_POS_CAMERA_LOCKED = 0x08000000,    // entity follows camera position
+    FLAG_UNK_10000000 = 0x10000000,         // CHI func_801A169C: "Is Airborne"?
+    FLAG_UNK_20000000 = 0x20000000,
+    FLAG_DESTROY_IF_BARELY_OUT_OF_CAMERA = 0x40000000,
+    FLAG_DESTROY_IF_OUT_OF_CAMERA = 0x80000000,
+} EntityFlag;
+
 typedef struct {
     u8 disableFlag;
     u8 resetFlag;

--- a/src/saturn/t_bat.c
+++ b/src/saturn/t_bat.c
@@ -4,7 +4,25 @@
 
 INCLUDE_ASM("asm/saturn/t_bat/data", d60CF000, d_060CF000);
 INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF060, func_060CF060);
-INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF294, func_060CF294);
+
+s32 CheckEntityValid(Entity *entity) {
+    if (entity->hitboxState == 0)
+        return 0;
+    if (entity->posX.i.hi < -16)
+        return 0;
+    if (entity->posX.i.hi > 0x150)
+        return 0;
+    if (entity->posY.i.hi > 0xF0)
+        return 0;
+    if (entity->posY.i.hi < 0)
+        return 0;
+    if (entity->hitPoints >= 0x7000) 
+        return 0;
+    if (entity->hitPoints <= 0)
+        return 0;
+    return 1;
+}
+
 INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF2E8, func_060CF2E8);
 INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF410, func_060CF410);
 INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF5F4, func_060CF5F4);

--- a/src/saturn/t_bat.c
+++ b/src/saturn/t_bat.c
@@ -18,19 +18,19 @@ typedef struct {
 
 INCLUDE_ASM("asm/saturn/t_bat/data", d60CF000, d_060CF000);
 
-extern u32 s_LastTargetedEntityIndex; // 0x060D1E00
+extern u32 s_LastTargetedEntityIndex;        // 0x060D1E00
 extern BatAbilityValues g_BatAbilityStats[]; // 0x060D1D34
-extern FamiliarStats s_BatStats; // 0x060D2830
+extern FamiliarStats s_BatStats;             // 0x060D2830
 
-Entity* FindValidTarget(Entity *self) {
-    #define ABS(x, y) (((x) - (y)) < 0 ? (y) - (x) : (x) - (y))
+Entity* FindValidTarget(Entity* self) {
+#define ABS(x, y) (((x) - (y)) < 0 ? (y) - (x) : (x) - (y))
     s16 s_TargetMatch[0x80];
 
     const s32 EntitySearchCount = 128;
     s32 foundIndex;
     s32 i;
     u32 found;
-    Entity *entity;
+    Entity* entity;
 
     found = 0;
     entity = &g_Entities[STAGE_ENTITY_START];
@@ -42,7 +42,7 @@ Entity* FindValidTarget(Entity *self) {
         if (entity->hitboxState == 0) {
             continue;
         }
-        if (entity->flags & 0x200000) {
+        if (entity->flags & FLAG_UNK_00200000) {
             continue;
         }
         if (entity->posX.i.hi < -16) {
@@ -57,7 +57,8 @@ Entity* FindValidTarget(Entity *self) {
         if (entity->posY.i.hi < 0) {
             continue;
         }
-        if (entity->hitboxState & 8 && !g_BatAbilityStats[s_BatStats.level / 10].makeBadAttacks) {
+        if (entity->hitboxState & 8 &&
+            !g_BatAbilityStats[s_BatStats.level / 10].makeBadAttacks) {
             continue;
         }
         if (ABS(self->posX.i.hi, entity->posX.i.hi) < 64 &&
@@ -73,13 +74,14 @@ Entity* FindValidTarget(Entity *self) {
         if (entity->hitPoints >= 0x7000) {
             continue;
         }
-        if (entity->flags & 0x80000) {
-            if (entity->hitPoints >= g_BatAbilityStats[s_BatStats.level / 10].minimumEnemyHp) {
+        if (entity->flags & FLAG_UNK_80000) {
+            if (entity->hitPoints >=
+                g_BatAbilityStats[s_BatStats.level / 10].minimumEnemyHp) {
                 found++;
                 s_TargetMatch[i] = 1;
             }
         } else {
-            entity->flags |= 0x80000;
+            entity->flags |= FLAG_UNK_80000;
             return entity;
         }
     }
@@ -88,7 +90,8 @@ Entity* FindValidTarget(Entity *self) {
         for (i = 0; i < EntitySearchCount; i++) {
             if (s_TargetMatch[foundIndex]) {
                 entity = &g_Entities[STAGE_ENTITY_START + foundIndex];
-                s_LastTargetedEntityIndex = (foundIndex + 1) % EntitySearchCount;
+                s_LastTargetedEntityIndex =
+                    (foundIndex + 1) % EntitySearchCount;
                 return entity;
             }
             foundIndex = (foundIndex + 1) % EntitySearchCount;

--- a/src/saturn/t_bat.c
+++ b/src/saturn/t_bat.c
@@ -5,7 +5,7 @@
 INCLUDE_ASM("asm/saturn/t_bat/data", d60CF000, d_060CF000);
 INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF060, func_060CF060);
 
-s32 CheckEntityValid(Entity *entity) {
+s32 CheckEntityValid(Entity* entity) {
     if (entity->hitboxState == 0)
         return 0;
     if (entity->posX.i.hi < -16)
@@ -16,7 +16,7 @@ s32 CheckEntityValid(Entity *entity) {
         return 0;
     if (entity->posY.i.hi < 0)
         return 0;
-    if (entity->hitPoints >= 0x7000) 
+    if (entity->hitPoints >= 0x7000)
         return 0;
     if (entity->hitPoints <= 0)
         return 0;

--- a/src/saturn/t_bat.c
+++ b/src/saturn/t_bat.c
@@ -2,8 +2,100 @@
 #include "inc_asm.h"
 #include "sattypes.h"
 
+typedef struct {
+    s32 delayFrames;
+    s32 angleStep;
+    s32 additionalBatCount;
+    s32 minimumEnemyHp;
+    s32 makeBadAttacks;
+} BatAbilityValues;
+
+typedef struct {
+    s32 level;
+    s32 exp;
+    s32 unk8; // Possibly the number of times loaded
+} FamiliarStats;
+
 INCLUDE_ASM("asm/saturn/t_bat/data", d60CF000, d_060CF000);
-INCLUDE_ASM("asm/saturn/t_bat/f_nonmat", f60CF060, func_060CF060);
+
+extern u32 s_LastTargetedEntityIndex; // 0x060D1E00
+extern BatAbilityValues g_BatAbilityStats[]; // 0x060D1D34
+extern FamiliarStats s_BatStats; // 0x060D2830
+
+Entity* FindValidTarget(Entity *self) {
+    #define ABS(x, y) (((x) - (y)) < 0 ? (y) - (x) : (x) - (y))
+    s16 s_TargetMatch[0x80];
+
+    const s32 EntitySearchCount = 128;
+    s32 foundIndex;
+    s32 i;
+    u32 found;
+    Entity *entity;
+
+    found = 0;
+    entity = &g_Entities[STAGE_ENTITY_START];
+    for (i = 0; i < EntitySearchCount; i++, entity++) {
+        s_TargetMatch[i] = 0;
+        if (!entity->entityId) {
+            continue;
+        }
+        if (entity->hitboxState == 0) {
+            continue;
+        }
+        if (entity->flags & 0x200000) {
+            continue;
+        }
+        if (entity->posX.i.hi < -16) {
+            continue;
+        }
+        if (entity->posX.i.hi > 336) {
+            continue;
+        }
+        if (entity->posY.i.hi > 240) {
+            continue;
+        }
+        if (entity->posY.i.hi < 0) {
+            continue;
+        }
+        if (entity->hitboxState & 8 && !g_BatAbilityStats[s_BatStats.level / 10].makeBadAttacks) {
+            continue;
+        }
+        if (ABS(self->posX.i.hi, entity->posX.i.hi) < 64 &&
+            ABS(self->posY.i.hi, entity->posY.i.hi) < 64) {
+            continue;
+        }
+        if (!self->facingLeft && self->posX.i.hi < entity->posX.i.hi) {
+            continue;
+        }
+        if (self->facingLeft && self->posX.i.hi > entity->posX.i.hi) {
+            continue;
+        }
+        if (entity->hitPoints >= 0x7000) {
+            continue;
+        }
+        if (entity->flags & 0x80000) {
+            if (entity->hitPoints >= g_BatAbilityStats[s_BatStats.level / 10].minimumEnemyHp) {
+                found++;
+                s_TargetMatch[i] = 1;
+            }
+        } else {
+            entity->flags |= 0x80000;
+            return entity;
+        }
+    }
+    if (found > 0) {
+        foundIndex = s_LastTargetedEntityIndex % EntitySearchCount;
+        for (i = 0; i < EntitySearchCount; i++) {
+            if (s_TargetMatch[foundIndex]) {
+                entity = &g_Entities[STAGE_ENTITY_START + foundIndex];
+                s_LastTargetedEntityIndex = (foundIndex + 1) % EntitySearchCount;
+                return entity;
+            }
+            foundIndex = (foundIndex + 1) % EntitySearchCount;
+        }
+    }
+    return NULL;
+}
 
 s32 CheckEntityValid(Entity* entity) {
     if (entity->hitboxState == 0)

--- a/src/servant/tt_000/bat.c
+++ b/src/servant/tt_000/bat.c
@@ -81,12 +81,11 @@ u16 g_BatClut[] = {
 static Entity* FindValidTarget(Entity* self) {
     static s32 s_TargetMatch[0x80];
 
-    const int EntitySearchCount = 128;
+    const s32 EntitySearchCount = 128;
     s32 foundIndex;
     s32 i;
     u32 found;
     Entity* entity;
-    s32 distance;
 
     found = 0;
     entity = &g_Entities[STAGE_ENTITY_START];


### PR DESCRIPTION
Depends on https://github.com/Xeeynamo/sotn-decomp/pull/3236
Saturn: https://decomp.me/scratch/UFBfy

You'll notice in the scratch that the compiler generates a call to `__ashiftrt_r4_7` when we use the modulo operator. Something to keep in mind if you see weird function calls in the Ghidra decompilation