### PR TITLE
Fix off-by-one error in new entity layout labeler

### DIFF
--- a/tools/sotn-assets/assets/layout/layout.go
+++ b/tools/sotn-assets/assets/layout/layout.go
@@ -235,7 +235,7 @@ func buildEntityLayouts(fileName, outputDir, subDir string, ovlName string) erro
 			if lastEntry.X != -1 || lastEntry.Y != -1 {
 				return fmt.Errorf("layout entity bank %d needs to have a X:-1 and Y:-1 entry at the end", i)
 			}
-			roomNum := indexOf(el.Indices, i) - 1
+			roomNum := indexOf(el.Indices, i)
 			if roomNum < 0 {
 				sb.WriteString(fmt.Sprintf("// Offset %d, No Room Found\n", nWritten))
 			} else {


### PR DESCRIPTION
My recent PR has a silly mistake. I made a script that extracts the Rooms array from each of the game's overlays and draws all the rooms with labels:

<img width="2008" height="1103" alt="image" src="https://github.com/user-attachments/assets/114ee446-9f54-4fab-9af3-1e58ecc3f677" />

This reveals some discrepancies in the map at https://www.sotn.fun/wiki/Room_IDs and I have confirmed in-game that the room numbering in this new map is correct. The numbering on the wiki image is off by one in places. I was using that as gospel, which was the wrong move. I have now confirmed that this numbering is correct. Should have been more thorough to begin with.