### PR TITLE
sel: import credits script

### DIFF
--- a/config/assets.us.yaml
+++ b/config/assets.us.yaml
@@ -160,6 +160,8 @@ files:
           - [0x22E4, skip]
           - [0xB304, cutscene, cutscene_endings]
           - [0xBC4A, skip]
+          - [0xBC54, credits, credits]
+          - [0xC404, skip]
           - [0xCD54, palette, us/D_8018CD54, 16]
           - [0xCDB4, palette, D_8018CDB4, 256]
           - [0xCFB4, palette, D_8018CFB4, 256]

--- a/config/splat.us.stsel.yaml
+++ b/config/splat.us.stsel.yaml
@@ -50,7 +50,7 @@ segments:
       - [0xA50C, .data, lba_stage]
       - [0xB2CC, .data, stream_info]
       - [0xB304, .data, cutscene_data]
-      - [0xBC54, data]
+      - [0xC404, data]
       - [0xCD54, .data, CD54]
       - [0xDBD4, .data, sprites]
       - [0xF9A8, .data, F9A8]

--- a/include/cutscene.h
+++ b/include/cutscene.h
@@ -29,6 +29,13 @@ typedef enum {
     CSOP_WAIT_FOR_FLAG_RESET,
 } CutsceneOpcode;
 
+typedef enum {
+    CSOP_END_CREDITS,
+    CSOP_SUBTEXT,
+    CSOP_ENTRY,
+    CSOP_SECTION,
+} CreditOpcode;
+
 enum ActorNameIndices {
     NAME_IDX_RICHTER,
     NAME_IDX_DRACULA,
@@ -81,6 +88,11 @@ enum ActorNameIndices {
 #define CS_LINE_MAX 4
 #endif
 #define ASCII_SPACE 32
+
+#define END_CREDITS() CSOP_END_CREDITS
+#define CREDITS_SUBTEXT(x) CSOP_SUBTEXT, x
+#define CREDITS_ENTRY(x) CSOP_ENTRY, x
+#define CREDITS_SECTION(x) CSOP_SECTION, x
 
 typedef struct {
     /* 0x00 */ u8* scriptCur;         // ptr to dialogue next character

--- a/src/st/sel/cutscene.c
+++ b/src/st/sel/cutscene.c
@@ -613,7 +613,7 @@ s32 func_801B79D4(Entity* entity) {
 
     switch (entity->step) {
     case 0:
-        if (func_801B76F0(D_8018BC54)) {
+        if (func_801B76F0(OVL_EXPORT(credits))) {
             entity->flags |= FLAG_HAS_PRIMS;
             entity->primIndex = (s32)g_Dialogue.prim[1];
             entity->step++;
@@ -663,11 +663,11 @@ s32 func_801B79D4(Entity* entity) {
         bitDepth = 0;
 
         switch (nextChar) {
-        case 0:
+        case CSOP_END_CREDITS:
             entity->step = 7;
             g_Dialogue.unk12 = 0x400;
             return 0;
-        case 1:
+        case CSOP_SUBTEXT:
             g_Dialogue.startY = g_Dialogue.nextCharX + *g_Dialogue.scriptCur++;
             g_Dialogue.nextLineX++;
             if (g_Dialogue.nextLineX > 0xF) {
@@ -675,7 +675,7 @@ s32 func_801B79D4(Entity* entity) {
             }
             g_Dialogue.nextCharY = 0;
             return 0;
-        case 2:
+        case CSOP_ENTRY:
             g_Dialogue.startY = g_Dialogue.nextCharX + *g_Dialogue.scriptCur++;
             g_Dialogue.nextLineX++;
             if (g_Dialogue.nextLineX > 0xF) {
@@ -701,7 +701,7 @@ s32 func_801B79D4(Entity* entity) {
             g_Dialogue.portraitAnimTimer += 6;
             g_Dialogue.nextCharY = 0;
             return 0;
-        case 3:
+        case CSOP_SECTION:
             g_Dialogue.startY = g_Dialogue.nextCharX + *g_Dialogue.scriptCur++;
             g_Dialogue.nextLineX++;
             if (g_Dialogue.nextLineX > 0xF) {

--- a/src/st/sel/cutscene_data.c
+++ b/src/st/sel/cutscene_data.c
@@ -12,3 +12,7 @@ static s32 D_8018BC4C = 0;
 s8 D_8018BC50 = 0;
 static s8 D_8018BC51 = 0;
 static s16 D_8018BC52 = 0;
+
+u8 OVL_EXPORT(credits)[] = {
+#include "gen/credits.h"
+};

--- a/src/st/sel/sel.h
+++ b/src/st/sel/sel.h
@@ -184,7 +184,7 @@ extern StreamInfo* g_Streams[4];
 extern SpriteParts* g_SpriteBanks[];
 
 extern u8 OVL_EXPORT(cutscene_endings)[];
-extern u8 D_8018BC54[];
+extern u8 OVL_EXPORT(credits)[];
 extern s32 g_StreamWidth;
 extern int g_StreamHeight;
 

--- a/tools/sotn-assets/asset_config.go
+++ b/tools/sotn-assets/asset_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/binary"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/blueprintsdef"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/cmpgfx"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/credits"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/cutscene"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/gfxbanks"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/headergfx"
@@ -59,6 +60,7 @@ var handlers = func() map[string]assets.Handler {
 		binary.Handler,
 		blueprintsdef.Handler,
 		cmpgfx.Handler,
+		credits.Handler,
 		cutscene.Handler,
 		gfxbanks.Handler,
 		headergfx.Handler,

--- a/tools/sotn-assets/assets/credits/handler.go
+++ b/tools/sotn-assets/assets/credits/handler.go
@@ -1,0 +1,226 @@
+package credits
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/sotn"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/util"
+)
+
+type handler struct{}
+
+var Handler = &handler{}
+
+func (h *handler) Name() string { return "credits" }
+
+func (h *handler) Extract(e assets.ExtractArgs) error {
+	if e.Start == e.End {
+		return fmt.Errorf("a credits script cannot be 0 bytes")
+	}
+	r := bytes.NewReader(e.Data)
+	script, err := parseScript(r, e.RamBase, e.RamBase.Sum(e.Start), e.End-e.Start)
+	if err != nil {
+		return err
+	}
+	yaml := "script:\n"
+	for _, command := range script {
+		if len(command) == 0 {
+			continue
+		}
+		switch command[0] {
+		case "TEXT":
+			yaml += fmt.Sprintf("  - [TEXT, \"%s\"]\n", command[1])
+		case "BYTE":
+			yaml += fmt.Sprintf("  - [BYTE, %s]\n", command[1])
+		default:
+			yaml += fmt.Sprintf("  - [%s]\n", strings.Join(command, ", "))
+		}
+	}
+	return util.WriteFile(assetPath(e.AssetDir, e.Name), []byte(yaml))
+}
+
+type scriptRow []string
+
+// skip conversion of hex values into decimals
+func (r *scriptRow) UnmarshalYAML(node ast.Node) error {
+	seq, ok := node.(*ast.SequenceNode)
+	if !ok {
+		return fmt.Errorf("expected sequence, got %T", node)
+	}
+	for _, n := range seq.Values {
+		*r = append(*r, n.GetToken().Value)
+	}
+	return nil
+}
+
+type scriptSrc struct {
+	Script []scriptRow `yaml:"script"`
+}
+
+func (h *handler) Build(e assets.BuildArgs) error {
+	platform := sotn.GetPlatform()
+	inFileName := assetPath(e.AssetDir, e.Name)
+	data, err := os.ReadFile(inFileName)
+	if err != nil {
+		return fmt.Errorf("failed to read credits file: %w", err)
+	}
+	var script scriptSrc
+	if err := yaml.Unmarshal(data, &script); err != nil {
+		return fmt.Errorf("failed to parse credits file: %w", err)
+	}
+	pool := getCommandPool()
+	sb := strings.Builder{}
+	sb.WriteString("// clang-format off\n")
+	for i, args := range script.Script {
+		if len(args) == 0 {
+			return fmt.Errorf("")
+		}
+		op := args[0]
+		if op == "TEXT" {
+			text := args[1]
+			for _, r := range text {
+				if r == '\'' {
+					sb.WriteString("'\\'',")
+				} else {
+					byteValue := byte(r)
+
+					// If the byte is in the PSP's upper language character position,
+					// output the hex literal
+					if platform == sotn.PlatformPSP && byteValue >= 0xA0 && byteValue <= 0xDF {
+						// TODO: This can probably output something like _SE() which
+						// can be handled by sotn_str
+						sb.WriteString(fmt.Sprintf("'\\x%02X',", byteValue))
+					} else {
+						// Otherwise, just output the character as-is
+						sb.WriteString(fmt.Sprintf("'%c',", r))
+					}
+				}
+			}
+			sb.WriteString("\n")
+			continue
+		}
+		if op == "BYTE" {
+			if len(args) != 2 {
+				return fmt.Errorf("BYTE must have exactly one argument")
+			}
+			sb.WriteString(args[1])
+			sb.WriteString(",\n")
+			continue
+		}
+		cmd, found := pool[op]
+		if !found {
+			return fmt.Errorf("script %q does not have a command", args[0])
+		}
+		sb.WriteString(args[0])
+		sb.WriteString("(")
+		if cmd.params != len(args)-1 {
+			return fmt.Errorf("command %q at line %d expects %d arguments but got %d",
+				op, i+1, cmd.params, len(args)-1)
+		}
+		sb.WriteString(strings.Join(args[1:], ","))
+		sb.WriteString("),\n")
+	}
+	return util.WriteFile(sourcePath(e.SrcDir, e.Name), []byte(sb.String()))
+}
+
+func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
+	return assets.InfoResult{}, nil
+}
+
+func assetPath(dir, name string) string {
+	if name == "" {
+		name = "credits_script"
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.yaml", name))
+}
+
+func sourcePath(dir, name string) string {
+	if name == "" {
+		name = "credits_script"
+	}
+	return filepath.Join(dir, fmt.Sprintf("gen/%s.h", name))
+}
+
+type cmdDef struct {
+	name   string
+	params int
+}
+
+var commandDefinitions = []cmdDef{
+	{name: "END_CREDITS", params: 0},
+	{name: "CREDITS_SUBTEXT", params: 1},
+	{name: "CREDITS_ENTRY", params: 1},
+	{name: "CREDITS_SECTION", params: 1},
+}
+
+func getCommandPool() map[string]cmdDef {
+	cmdPool := map[string]cmdDef{}
+	for _, command := range commandDefinitions {
+		cmdPool[command.name] = command
+	}
+	return cmdPool
+}
+
+func parseScript(r io.ReadSeeker, baseAddr, addr psx.Addr, length int) ([][]string, error) {
+	if err := addr.MoveFile(r, baseAddr); err != nil {
+		return nil, fmt.Errorf("unable to read credits script: %w", err)
+	}
+	platform := sotn.GetPlatform()
+
+	script := make([][]string, 0)
+	text := ""
+	flushText := func() {
+		if len(text) > 0 {
+			script = append(script, []string{"TEXT", text})
+			text = ""
+		}
+	}
+	read1 := func(r io.ReadSeeker) byte {
+		b := make([]byte, 1)
+		_, _ = r.Read(b)
+		length -= 1
+		return b[0]
+	}
+	for length > 0 {
+		op := int(read1(r))
+		if op < len(commandDefinitions) {
+			flushText()
+			command := []string{commandDefinitions[op].name}
+			for i := 0; i < commandDefinitions[op].params; i++ {
+				command = append(command, strconv.FormatInt(int64(read1(r)), 10))
+			}
+			script = append(script, command)
+		} else if op < 0x20 {
+			text += fmt.Sprintf("\\x%02X", byte(op))
+		} else if op < 0x7F {
+			if op == 0x22 {
+				text += "\\\""
+			} else {
+				text += string([]byte{byte(op)})
+			}
+		} else if op >= 0x80 && op <= 0x9F {
+			strByte := "0x" + strconv.FormatInt(int64(op), 16)
+			script = append(script, []string{"BYTE", strByte})
+			strByte = "0x" + strconv.FormatInt(int64(read1(r)), 16)
+			script = append(script, []string{"BYTE", strByte})
+		} else if platform == sotn.PlatformPSP && op >= 0xA0 && op <= 0xDF {
+			// PSP has multi-language support with characters that exceed the ASCII range
+			text += fmt.Sprintf("\\x%02X", byte(op))
+		} else {
+			strByte := "0x" + strconv.FormatInt(int64(op), 16)
+			script = append(script, []string{"BYTE", strByte})
+		}
+	}
+	flushText()
+	return script, nil
+}


### PR DESCRIPTION
The game credits uses a customized and trimmed down entity from `EntityCutscene`. As such, I created a custom handler that parses the credits as follows:

`assets/st/sel/credits.yaml`:
```yaml
script:
  - [CREDITS_SUBTEXT, 22]
  - [TEXT, "CASTLEVANIA"]
  - [CREDITS_SUBTEXT, 7]
  - [TEXT, "SYMPHONY OF THE NIGHT"]
  - [CREDITS_SECTION, 0]
  - [CREDITS_SECTION, 0]
  - [CREDITS_SECTION, 30]
  - [TEXT, "-Cast-"]
  - [CREDITS_SECTION, 0]
  - [CREDITS_SUBTEXT, 16]
  - [TEXT, "ROBERT BELGRADE"]
```

`src/st/sel/gen/credits.h`:
```c
CREDITS_SUBTEXT(22),
'C','A','S','T','L','E','V','A','N','I','A',
CREDITS_SUBTEXT(7),
'S','Y','M','P','H','O','N','Y',' ','O','F',' ','T','H','E',' ','N','I','G','H','T',
CREDITS_SECTION(0),
CREDITS_SECTION(0),
CREDITS_SECTION(30),
'-','C','a','s','t','-',
CREDITS_SECTION(0),
CREDITS_SUBTEXT(16),
'R','O','B','E','R','T',' ','B','E','L','G','R','A','D','E',
```
