### PR TITLE
Fix asset tool to allow specifying filepath for layers

### DIFF
--- a/tools/sotn-assets/assets/layer/handler.go
+++ b/tools/sotn-assets/assets/layer/handler.go
@@ -80,7 +80,11 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 }
 
 func (h *handler) Build(e assets.BuildArgs) error {
-	return buildLayers(e.AssetDir, filepath.Join(e.AssetDir, "layers.json"), e.SrcDir, e.OvlName)
+	outString, err := buildLayers(e.AssetDir, filepath.Join(e.AssetDir, "layers.json"), e.SrcDir, e.OvlName)
+	if err != nil {
+		return err
+	}
+	return util.WriteFile(sourcePath(e.SrcDir, e.Name), []byte(outString))
 }
 
 func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
@@ -135,4 +139,7 @@ func tiledefClutsFileName(ovl string, n int) string {
 
 func tiledefCollisionsFileName(ovl string, n int) string {
 	return fmt.Sprintf("%s_tiledef_%d_cols.bin", ovl, n)
+}
+func sourcePath(dir, name string) string {
+	return filepath.Join(dir, fmt.Sprintf("gen/%s.h", name))
 }

--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -135,7 +135,7 @@ func readLayers(r io.ReadSeeker, off, baseAddr psx.Addr) ([]roomLayers, datarang
 	return roomsLayers, datarange.New(slices.Min(layerOffsets), off.Sum(count*8)), nil
 }
 
-func buildLayers(inputDir, fileName, outputDir, ovlName string) error {
+func buildLayers(inputDir, fileName, outputDir, ovlName string) (string, error) {
 	getHash := func(l layerUnpacked) string {
 		return fmt.Sprintf("%s-%s-%d-%d-%d-%d", l.Data, l.Tiledef, l.Left, l.Top, l.Right, l.Bottom)
 	}
@@ -155,12 +155,12 @@ func buildLayers(inputDir, fileName, outputDir, ovlName string) error {
 
 	data, err := os.ReadFile(fileName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var roomsLayers []map[string]*layerUnpacked
 	if err := json.Unmarshal(data, &roomsLayers); err != nil {
-		return err
+		return "", err
 	}
 
 	tilemaps := map[string]struct{}{}
@@ -193,7 +193,7 @@ func buildLayers(inputDir, fileName, outputDir, ovlName string) error {
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return err
+		return "", err
 	}
 
 	var layers []map[string]interface{} // first layer is always empty
@@ -270,7 +270,7 @@ func buildLayers(inputDir, fileName, outputDir, ovlName string) error {
 		}
 	}
 	sb.WriteString("};\n")
-	return util.WriteFile(filepath.Join(outputDir, "gen/layers.h"), []byte(sb.String()))
+	return sb.String(), nil
 }
 
 func makeSymbolFromFileName(fileName string) string {


### PR DESCRIPTION
Changes the calling convention for the Layers handler, so that now the buildLayers function will return the `layers.h` file text, which can then be written by the `Build` function.

This allows specifying the output filename in the `assets.yaml` file, which means it is no longer hardcoded to `gen/layers.h`. This will allow doing GEN_VERSION(layers.h) which is required for https://github.com/Xeeynamo/sotn-decomp/pull/3311. I rebased that branch to use this fix, and confirmed that it works.