### PR TITLE
pc: load servant as overlays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,21 +432,13 @@ set_source_files_properties(src/weapon/w_046.c PROPERTIES COMPILE_DEFINITIONS WE
 set_source_files_properties(src/weapon/w_051.c PROPERTIES COMPILE_DEFINITIONS WEAPON_ID=w_051)
 set_source_files_properties(src/weapon/w_052.c PROPERTIES COMPILE_DEFINITIONS WEAPON_ID=w_052)
 
-# organization is:
-# two executables, sdl2 and null, plus a shared library "core"
-# any executable links core (which is pc shared code + sotn psx code)
-# the null backend is present to try and help with developing a backend-agnostic interface
-# and for a basic "does it segfault" check in CI
-
-# core library
-
 set(SOURCE_FILES_CORE
     ${SOURCE_FILES_DRA}
     ${SOURCE_FILES_RIC}
     ${SOURCE_FILES_WEAPON}
-    ${SOURCE_FILES_TT_000}
-    ${SOURCE_FILES_TT_001}
-    ${SOURCE_FILES_TT_002}
+#    ${SOURCE_FILES_TT_000}
+#    ${SOURCE_FILES_TT_001}
+#    ${SOURCE_FILES_TT_002}
 )
 if (USE_PLAYER_MARIA)
     add_compile_definitions(USE_PLAYER_MARIA)
@@ -455,15 +447,20 @@ if (USE_PLAYER_MARIA)
             src/pc/pl_maria.c)
 endif()
 
-add_library(core ${SOURCE_FILES_CORE})
+add_subdirectory(tools/psyz/psyz)
 
-target_include_directories(core PUBLIC
+add_executable(${PROJECT_NAME}
+    ${SOURCE_FILES_PC}
+    ${SOURCE_FILES_3RD}
+    ${SOURCE_FILES_CORE})
+
+target_include_directories(${PROJECT_NAME} PUBLIC
     include
     src/dra
     src/pc/3rd
 )
 
-target_compile_definitions(core PUBLIC
+target_compile_definitions(${PROJECT_NAME} PUBLIC
     _USE_MATH_DEFINES # needed for msvc
     VERSION_PC
     PERMUTER
@@ -472,17 +469,11 @@ target_compile_definitions(core PUBLIC
     _internal_version_us
 )
 
-add_executable(${PROJECT_NAME}
-    ${SOURCE_FILES_PC}
-    ${SOURCE_FILES_MOCK_SDK}
-    ${SOURCE_FILES_3RD})
-add_subdirectory(tools/psyz/psyz)
-target_link_libraries(core PUBLIC psyz)
 target_include_directories(psyz PUBLIC tools/psyz/psyz/include)
 target_compile_definitions(psyz PRIVATE __psyz)
 psyz_strip_file_prefix(${PROJECT_NAME})
 if (WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE core)
+    target_link_libraries(${PROJECT_NAME} PRIVATE psyz)
     set_target_properties(${PROJECT_NAME} PROPERTIES ENABLE_EXPORTS ON)
     if (MSVC)
         # Windows PE has no -rdynamic equivalent, and a DLL must resolve all
@@ -494,7 +485,7 @@ if (WIN32)
             COMMAND ${CMAKE_COMMAND}
                     -DDUMPBIN=${_msvc_bindir}/dumpbin.exe
                     -DOUT=${_sotn_def}
-                    "-DINPUTS=$<TARGET_FILE:core>$<SEMICOLON>$<TARGET_FILE:psyz>$<SEMICOLON>$<JOIN:$<TARGET_OBJECTS:${PROJECT_NAME}>,$<SEMICOLON>>"
+                    "-DINPUTS=$<TARGET_FILE:psyz>$<SEMICOLON>$<JOIN:$<TARGET_OBJECTS:${PROJECT_NAME}>,$<SEMICOLON>>"
                     -P ${CMAKE_SOURCE_DIR}/cmake/gen_export_def.cmake
             VERBATIM
             COMMENT "Generating export .def for overlay symbol resolution")
@@ -502,10 +493,10 @@ if (WIN32)
                      PROPERTY LINK_FLAGS " /DEF:${_sotn_def}")
     endif()
 elseif (APPLE)
-    target_link_libraries(${PROJECT_NAME} PRIVATE core m)
+    target_link_libraries(${PROJECT_NAME} PRIVATE psyz m)
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,-export_dynamic)
 else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE core m ${CMAKE_DL_LIBS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE psyz m ${CMAKE_DL_LIBS})
     target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SOURCE_FILES_TT_000
     src/servant/tt_000/bat.c
     src/servant/tt_000/servant_clutdata.c
     src/servant/tt_000/servant_spriteparts.c
+    src/pc/servants/servant_000.c
 )
 
 set(SOURCE_FILES_TT_001
@@ -171,12 +172,14 @@ set(SOURCE_FILES_TT_001
     src/servant/tt_001/ghost.c
     src/servant/tt_001/servant_clutdata.c
     src/servant/tt_001/servant_spriteparts.c
+    src/pc/servants/servant_001.c
 )
 
 set(SOURCE_FILES_TT_002
     src/servant/tt_002/init.c
     src/servant/tt_002/faerie.c
     src/servant/tt_002/faerie_spriteparts.c
+    src/pc/servants/servant_002.c
 )
 
 set(SOURCE_FILES_STAGE_SEL
@@ -436,9 +439,6 @@ set(SOURCE_FILES_CORE
     ${SOURCE_FILES_DRA}
     ${SOURCE_FILES_RIC}
     ${SOURCE_FILES_WEAPON}
-#    ${SOURCE_FILES_TT_000}
-#    ${SOURCE_FILES_TT_001}
-#    ${SOURCE_FILES_TT_002}
 )
 if (USE_PLAYER_MARIA)
     add_compile_definitions(USE_PLAYER_MARIA)
@@ -538,3 +538,7 @@ add_overlay(sel ${SOURCE_FILES_STAGE_SEL})
 add_overlay(wrp ${SOURCE_FILES_STAGE_WRP})
 add_overlay(nz0 ${SOURCE_FILES_STAGE_NZ0})
 add_overlay(st0 ${SOURCE_FILES_STAGE_ST0})
+
+add_overlay(tt_000 ${SOURCE_FILES_TT_000})
+add_overlay(tt_001 ${SOURCE_FILES_TT_001})
+add_overlay(tt_002 ${SOURCE_FILES_TT_002})

--- a/src/pc/servant_pc.c
+++ b/src/pc/servant_pc.c
@@ -3,15 +3,16 @@
 #include "servant.h"
 #include <string.h>
 
-extern ServantDesc bat_ServantDesc;
-extern ServantDesc ghost_ServantDesc;
-extern ServantDesc faerie_ServantDesc;
-extern ServantDesc g_ServantDesc;
+// extern ServantDesc bat_ServantDesc;
+// extern ServantDesc ghost_ServantDesc;
+// extern ServantDesc faerie_ServantDesc;
+// extern ServantDesc g_ServantDesc;
 
 // To add a new servant, replace proper null with it's servant desc
-ServantDesc* servantDescs[] = {
-    NULL, &bat_ServantDesc, &ghost_ServantDesc, &faerie_ServantDesc, NULL, NULL,
-    NULL};
+// ServantDesc* servantDescs[] = {
+//     NULL, &bat_ServantDesc, &ghost_ServantDesc, &faerie_ServantDesc, NULL,
+//     NULL, NULL};
+ServantDesc* servantDescs[] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 void HandleServantPrg() { g_ServantDesc = *servantDescs[g_Servant]; }
 

--- a/src/pc/servant_pc.c
+++ b/src/pc/servant_pc.c
@@ -1,22 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "pc.h"
 #include "servant.h"
+#include "stages/overlay.h"
 #include <string.h>
 
-// extern ServantDesc bat_ServantDesc;
-// extern ServantDesc ghost_ServantDesc;
-// extern ServantDesc faerie_ServantDesc;
-// extern ServantDesc g_ServantDesc;
+static const char* ovlNames[] = {
+    NULL, "tt_000", "tt_001", "tt_002", "tt_003", "tt_004", "tt_005", "tt_006"};
 
-// To add a new servant, replace proper null with it's servant desc
-// ServantDesc* servantDescs[] = {
-//     NULL, &bat_ServantDesc, &ghost_ServantDesc, &faerie_ServantDesc, NULL,
-//     NULL, NULL};
-ServantDesc* servantDescs[] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-
-void HandleServantPrg() { g_ServantDesc = *servantDescs[g_Servant]; }
+void HandleServantPrg() {
+    if (g_Servant == 0) {
+        return;
+    }
+    if (g_Servant >= LEN(ovlNames)) {
+        ERRORF("servant %d not valid", g_Servant);
+        return;
+    }
+    const char* name = ovlNames[g_Servant];
+    if (!name) {
+        ERRORF("servant %d has no overlay", g_Servant);
+        return;
+    }
+    if (!LoadServantOverlay(name, &g_ServantDesc)) {
+        ERRORF("servant '%s' was not loaded", name);
+    }
+}
 
 void HandleServantChr() {
+    if (g_Servant == 0) {
+        return;
+    }
     char smolbuf[48];
     snprintf(smolbuf, sizeof(smolbuf), "disks/us/SERVANT/FT_00%d.BIN",
              g_Servant - 1);

--- a/src/pc/servants/servant_000.c
+++ b/src/pc/servants/servant_000.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "../../servant/tt_000/bat.h"
+#include "../stages/overlay.h"
+#include <string.h>
+
+extern ServantDesc bat_ServantDesc;
+OVL_API void InitServant(ServantDesc* o) {
+    memcpy(o, &bat_ServantDesc, sizeof(ServantDesc));
+}

--- a/src/pc/servants/servant_001.c
+++ b/src/pc/servants/servant_001.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "../../servant/tt_001/ghost.h"
+#include "../../pc/stages/overlay.h"
+#include <string.h>
+
+extern ServantDesc ghost_ServantDesc;
+OVL_API void InitServant(ServantDesc* o) {
+    memcpy(o, &ghost_ServantDesc, sizeof(ServantDesc));
+}

--- a/src/pc/servants/servant_002.c
+++ b/src/pc/servants/servant_002.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "../../servant/tt_002/faerie.h"
+#include "../../pc/stages/overlay.h"
+#include <string.h>
+
+extern ServantDesc faerie_ServantDesc;
+OVL_API void InitServant(ServantDesc* o) {
+    memcpy(o, &faerie_ServantDesc, sizeof(ServantDesc));
+}

--- a/src/pc/stages/overlay.c
+++ b/src/pc/stages/overlay.c
@@ -97,8 +97,8 @@ static const char* GetExeDir(void) {
     return dir;
 }
 
-static OvlHandle CurrentStageOverlay = NULL;
-bool LoadStageOverlay(const char* name, Overlay* o) {
+static void* OpenOverlayEntrypoint(
+    const char* name, const char* entrypointName, OvlHandle* outHandle) {
     char path[512];
     const char* exeDir = GetExeDir();
     if (exeDir) {
@@ -112,23 +112,50 @@ bool LoadStageOverlay(const char* name, Overlay* o) {
     OvlHandle handle = OvlOpen(path);
     if (!handle) {
         ERRORF("failed to load '%s': %s", path, OvlError());
-        return false;
+        return NULL;
     }
 
-    PfnInitStage entrypoint = (PfnInitStage)OvlSym(handle, OVL_ENTRYPOINT_NAME);
+    void* entrypoint = OvlSym(handle, entrypointName);
     if (!entrypoint) {
         ERRORF("failed as '%s' has no '%s' entrypoint: %s", path,
-               OVL_ENTRYPOINT_NAME, OvlError());
+               entrypointName, OvlError());
         OvlClose(handle);
-        return false;
+        return NULL;
     }
 
+    INFOF("loaded '%s'", path);
+    *outHandle = handle;
+    return entrypoint;
+}
+
+static OvlHandle CurrentStageOverlay = NULL;
+bool LoadStageOverlay(const char* name, Overlay* o) {
+    OvlHandle handle;
+    PfnInitStage entrypoint = (PfnInitStage)OpenOverlayEntrypoint(
+        name, OVL_STAGE_ENTRYPOINT_NAME, &handle);
+    if (!entrypoint) {
+        return false;
+    }
     if (CurrentStageOverlay) {
         OvlClose(CurrentStageOverlay);
     }
     CurrentStageOverlay = handle;
+    entrypoint(o);
+    return true;
+}
 
-    INFOF("loaded '%s'", path);
+static OvlHandle CurrentServantOverlay = NULL;
+bool LoadServantOverlay(const char* name, ServantDesc* o) {
+    OvlHandle handle;
+    PfnInitServant entrypoint = (PfnInitServant)OpenOverlayEntrypoint(
+        name, OVL_SERVANT_ENTRYPOINT_NAME, &handle);
+    if (!entrypoint) {
+        return false;
+    }
+    if (CurrentServantOverlay) {
+        OvlClose(CurrentServantOverlay);
+    }
+    CurrentServantOverlay = handle;
     entrypoint(o);
     return true;
 }

--- a/src/pc/stages/overlay.h
+++ b/src/pc/stages/overlay.h
@@ -3,6 +3,7 @@
 #define PC_OVERLAY_H
 
 #include <game.h>
+#include <servant.h>
 
 #if defined(_WIN32)
 #define OVL_API __declspec(dllexport)
@@ -10,13 +11,18 @@
 #define OVL_API
 #endif
 
-// public function necessary to register a stage overlay
-#define OVL_ENTRYPOINT_NAME "InitStage"
+// public function necessary to register an overlay
+#define OVL_STAGE_ENTRYPOINT_NAME "InitStage"
+#define OVL_SERVANT_ENTRYPOINT_NAME "InitServant"
 
-// public signature of OVL_ENTRYPOINT_NAME
+// public signature for the overlay entrypoint
 typedef void (*PfnInitStage)(Overlay* o);
+typedef void (*PfnInitServant)(ServantDesc* o);
 
-// DLL/shared library name to load, writes endpoints to *o
+// DLL/shared library name to load, writes public to struct
 bool LoadStageOverlay(const char* name, Overlay* o);
+
+// DLL/shared library name to load, writes public to struct
+bool LoadServantOverlay(const char* name, ServantDesc* o);
 
 #endif

--- a/src/pc/stubs.c
+++ b/src/pc/stubs.c
@@ -149,7 +149,3 @@ u16* func_80106A28(u32 arg0, u16 kind) {
     NOT_IMPLEMENTED;
     return g_FontCharData;
 }
-
-void SeAutoPan(short arg0, short arg1, short arg2, short arg3) {
-    NOT_IMPLEMENTED;
-}


### PR DESCRIPTION
A few changes
* `tt_00x` are now compiled and loaded dynamically, exactly as we now do with overlays
* Remove the intermediary `core` library, plus compile psyz in the executable directly; this will enable future LTO optimization
* Add full-screen mode by pressing F4