### PR TITLE
flatten USE_ENEMY_3 macro

### DIFF
--- a/src/st/cen/e_init.c
+++ b/src/st/cen/e_init.c
@@ -61,10 +61,8 @@ PfnEntityUpdate OVL_EXPORT(EntityUpdates)[] = {
 };
 
 EInit OVL_EXPORT(EInitBreakable) = {ANIMSET_OVL(1), 0, 0x00, 0x000, 0};
-#ifndef VERSION_PSP
-#define USE_ENEMY_3
-#endif
 #include "../e_init_common.h"
+EInit g_EInitEnemy3 = {ANIMSET_OVL(1), 0, 0x00, 0x000, 3};
 EInit g_EInitElevator = {ANIMSET_OVL(11), 1, 0x48, 0x223, 5};
 
 #ifdef VERSION_PSP

--- a/src/st/e_init_common.h
+++ b/src/st/e_init_common.h
@@ -9,8 +9,5 @@ EInit g_EInitUnkId13 = {ANIMSET_DRA(0), 0, 0x00, 0x000, 2};
 EInit g_EInitLockCamera = {ANIMSET_DRA(0), 0, 0x00, 0x000, 1};
 EInit g_EInitCommon = {ANIMSET_DRA(0), 0, 0x00, 0x000, 3};
 EInit g_EInitDamageNum = {ANIMSET_DRA(0), 0, 0x00, 0x000, 3};
-#ifdef USE_ENEMY_3
-EInit g_EInitEnemy3 = {ANIMSET_OVL(1), 0, 0x00, 0x000, 3};
-#endif
 
 #endif

--- a/src/st/wrp/e_init.c
+++ b/src/st/wrp/e_init.c
@@ -52,7 +52,7 @@ PfnEntityUpdate OVL_EXPORT(EntityUpdates)[] = {
 };
 
 EInit OVL_EXPORT(EInitBreakable) = {ANIMSET_OVL(1), 0, 0x00, 0x000, 0};
-#define USE_ENEMY_3
 #include "../e_init_common.h"
+EInit g_EInitEnemy3 = {ANIMSET_OVL(1), 0, 0x00, 0x000, 3};
 EInit g_EInitReverseSmallRocks = {ANIMSET_OVL(11), 1, 0x48, 0x21A, 97};
 EInit g_EInitSmallRocks = {ANIMSET_OVL(1), 0, 0x00, 0x000, 5};


### PR DESCRIPTION
`USE_ENEMY_3` was only used in two overlays. It was pointless to have it shared in a common file.