### PR TITLE
pc: fix st0 crashes with new PRIM_DR_ENV macro

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -84,6 +84,13 @@
 #define HIHU(x) (((u16*)&(x))[1])
 #define LOW(x) (*(s32*)&(x))
 #define LOWU(x) (*(u32*)&(x))
+
+#ifdef VERSION_PC
+// on 64-bit builds, this needs to read 64-bit, not 32-bit with LOW
+#define PRIM_DR_ENV(prim) (*(DR_ENV**)&(prim)->r1)
+#else
+#define PRIM_DR_ENV(prim) ((DR_ENV*)LOW((prim)->r1))
+#endif
 #define F(x) (*(f32*)&(x))
 #define POS(x) (*(Pos*)&(x))
 #define UV(x) (*(uvPair*)&(x))

--- a/src/st/dai/e_bell.c
+++ b/src/st/dai/e_bell.c
@@ -257,7 +257,7 @@ void EntityBell(Entity* self) {
     posX = playerPtr->posX.i.hi - tempPosX;
     posY = tempPosY + 124 - playerPtr->posY.i.hi;
     if ((u16)(posY) < 80 && (abs(posX) < 24)) {
-        drEnv = (DR_ENV*)LOW(prim->r1);
+        drEnv = PRIM_DR_ENV(prim);
         drawEnv = g_CurrentBuffer->draw;
         drawEnv.isbg = 0;
         drawEnv.ofs[0] = 0;

--- a/src/st/e_ctulhu.h
+++ b/src/st/e_ctulhu.h
@@ -494,7 +494,7 @@ void EntityCtulhu(Entity* self) {
             prim = self->ext.prim;
             prim->type = PRIM_ENV;
 
-            dr_env = (DR_ENV*)LOW(prim->r1);
+            dr_env = PRIM_DR_ENV(prim);
             drawEnv = g_CurrentBuffer->draw;
             drawEnv.isbg = 0;
             drawEnv.dtd = 0;

--- a/src/st/no1/unk_40E98.c
+++ b/src/st/no1/unk_40E98.c
@@ -190,7 +190,7 @@ void func_us_801C10F4(Entity* self) {
     drawEnv.clip = clipRect;
     drawEnv.ofs[0] = 0x180;
     drawEnv.ofs[1] = 0x100;
-    SetDrawEnv(LOW(prim->r1), &drawEnv);
+    SetDrawEnv(PRIM_DR_ENV(prim), &drawEnv);
     prim->drawMode = DRAW_DEFAULT;
     prim->priority = 0xC5;
 

--- a/src/st/st0/2DAC8.c
+++ b/src/st/st0/2DAC8.c
@@ -1148,7 +1148,7 @@ void func_801AF774(Entity* self) {
         drawEnv.clip = rect;
         drawEnv.ofs[0] = 0;
         drawEnv.ofs[1] = 0x100;
-        drEnv = (DR_ENV*)LOW(prim->r1);
+        drEnv = PRIM_DR_ENV(prim);
         SetDrawEnv(drEnv, &drawEnv);
         prim->priority = 0x9F;
         prim->drawMode = DRAW_DEFAULT;
@@ -1161,7 +1161,7 @@ void func_801AF774(Entity* self) {
     case 2:
         func_801AF380();
         prim = self->ext.et_801AF774.prim4;
-        drEnv = (DR_ENV*)LOW(prim->r1);
+        drEnv = PRIM_DR_ENV(prim);
         drawEnv = g_CurrentBuffer->draw;
         drawEnv.isbg = 1;
         drawEnv.isbg = 0;

--- a/src/st/st0/3AB08.c
+++ b/src/st/st0/3AB08.c
@@ -752,7 +752,7 @@ void EntityCutscenePhotograph(Entity* self) {
         prim->drawMode = DRAW_HIDE;
         prim = prim->next;
         for (i = 0; i < 2; i++) {
-            dr_env = (DR_ENV*)LOW(prim->r1);
+            dr_env = PRIM_DR_ENV(prim);
             dr_env->tag = 0;
             prim->type = PRIM_GT4;
             prim = prim->next;
@@ -947,7 +947,7 @@ void EntityCutscenePhotograph(Entity* self) {
 
         prim = prim->next;
         prim->type = PRIM_ENV;
-        dr_env = (DR_ENV*)LOW(prim->r1);
+        dr_env = PRIM_DR_ENV(prim);
 
         drawEnv = g_CurrentBuffer->draw;
 

--- a/src/st/st0/3D8F0.c
+++ b/src/st/st0/3D8F0.c
@@ -133,7 +133,7 @@ void func_801BD8F0(Entity* self) {
 #ifndef VERSION_PSP
         prim = prim->next;
         for (i = 0; i < 2; i++) {
-            dr_env = LOW(prim->r1);
+            dr_env = PRIM_DR_ENV(prim);
             dr_env->tag = 0;
             prim->type = PRIM_GT4;
             prim = prim->next;


### PR DESCRIPTION
Straighforward fix for a hard problem to track. `LOW(prim->r1)` was reading 32-bit pointers on 64-bit targets, causing a crash. This still doesn't prevent pointer corruption if the same primitive gets `x2` and `y2` replaced, but so far it didn't happen. 

Let's keep an eye close to this pattern for the next coming PRs.