### PR TITLE
st0: fix Update() OOB on unpatched HitDetection

### DIFF
--- a/src/st/st0_hit_detection.h
+++ b/src/st/st0_hit_detection.h
@@ -290,6 +290,13 @@ void OVL_EXPORT(HitDetection)(void) {
             BottomCornerText(g_api.enemyDefs[entityHit->enemyId].name, false);
             entityHit->flags |= FLAG_NOT_AN_ENEMY;
         }
+#ifdef VERSION_PC
+        // BUG! On ST0 only, the sentinel value miscVar2 is never reset. If the
+        // entityHit has hitPoints==0 (e.g. EntityDraculaFireball), the value
+        // miscVar2=0xFF will leak resulting to a UNK_Invincibility0[] OOB.
+        // This is fixed in the normal HitDetection with a simple miscVar2=0.
+        miscVar2 = 0;
+#endif
         if (entityHit->hitPoints) {
             if (iterEnt->attack) {
                 if ((iterEnt->hitboxState & 0x80) == 0) {


### PR DESCRIPTION
TL;DR the `HitDetection` from ST0 has a bug that the one used in other stages does not. I simply backported the fix.