### PR TITLE
pc: add NO3 overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,6 +643,69 @@ set(SOURCE_FILES_STAGE_RWRP
     src/st/rwrp/bss.c
 )
 
+set(SOURCE_FILES_STAGE_NO3
+    src/pc/stages/stage_no3.c
+    src/st/no3/header.c
+    src/st/no3/gen/e_laydef.c
+    src/st/no3/e_init.c
+    src/st/no3/gen/rooms.c
+    src/st/no3/gen/e_layout.c
+    src/st/no3/gen/sprites.c
+    src/st/no3/graphics_banks.c
+    src/st/no3/layers.c
+    src/st/no3/palette_def.c
+    src/st/no3/sprite_banks.c
+    src/st/no3/tilemaps.c
+    src/st/no3/stage_data.c
+    src/st/no3/background_block_init.c
+    src/st/no3/e_room_bg.c
+    src/st/no3/e_lock_camera.c
+    src/st/no3/e_breakable.c
+    src/st/no3/d_prize_drops.c
+    src/st/no3/cutscene.c
+    src/st/no3/cutscene_data.c
+    src/st/no3/st_update.c
+    src/st/no3/collision.c
+    src/st/no3/create_entity.c
+    src/st/no3/e_red_door_tiles.c
+    src/st/no3/e_red_door.c
+    src/st/no3/st_common.c
+    src/st/no3/e_collect.c
+    src/st/no3/e_misc.c
+    src/st/no3/e_stage_name.c
+    src/st/no3/e_particles.c
+    src/st/no3/e_room_fg.c
+    src/st/no3/popup.c
+    src/st/no3/prim_helpers.c
+    src/st/no3/d_water_data.c
+    src/st/no3/e_background_bushes_trees.c
+    src/st/no3/e_background_lightning.c
+    src/st/no3/e_bat.c
+    src/st/no3/e_bone_scimitar.c
+    src/st/no3/e_castle_door.c
+    src/st/no3/e_cavern_door.c
+    src/st/no3/e_death.c
+    src/st/no3/e_death_sky_swirl.c
+    src/st/no3/e_explosion_puff_opaque.c
+    src/st/no3/e_fire_warg.c
+    src/st/no3/e_heartroom.c
+    src/st/no3/e_jewel_sword_puzzle.c
+    src/st/no3/e_merman.c
+    src/st/no3/e_merman2.c
+    src/st/no3/entrance_weights.c
+    src/st/no3/e_outdoor_ents.c
+    src/st/no3/e_shutting_window.c
+    src/st/no3/e_sky_entities.c
+    src/st/no3/e_stairway.c
+    src/st/no3/e_tilemap_shuffler.c
+    src/st/no3/e_transparent_water.c
+    src/st/no3/e_trapdoor.c
+    src/st/no3/e_unkId16.c
+    src/st/no3/e_warg.c
+    src/st/no3/e_zombie.c
+    src/st/no3/water_effects.c
+)
+
 set(SOURCE_FILES_WEAPON
     src/weapon/w_000.c
     src/weapon/w_002.c
@@ -779,6 +842,7 @@ add_overlay(wrp ${SOURCE_FILES_STAGE_WRP})
 add_overlay(nz0 ${SOURCE_FILES_STAGE_NZ0})
 add_overlay(st0 ${SOURCE_FILES_STAGE_ST0})
 add_overlay(rwrp ${SOURCE_FILES_STAGE_RWRP})
+add_overlay(no3 ${SOURCE_FILES_STAGE_NO3})
 
 add_overlay(tt_000 ${SOURCE_FILES_TT_000})
 add_overlay(tt_001 ${SOURCE_FILES_TT_001})

--- a/src/pc/stages/stage_no3.c
+++ b/src/pc/stages/stage_no3.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <game.h>
+#include <string.h>
+#include "overlay.h"
+#include "../../st/no3/no3.h"
+#include "stage_loader.h"
+
+extern AbbreviatedOverlay OVL_EXPORT(Overlay);
+extern PfnEntityUpdate EntityUpdates[];
+extern LayoutEntity* entityLayoutHorizontal[];
+extern LayoutEntity* entityLayoutVertical[];
+extern GAME_IMPORT PfnEntityUpdate* PfnEntityUpdates;
+extern GAME_IMPORT LayoutEntity** g_pStObjLayoutHorizontal;
+extern GAME_IMPORT LayoutEntity** g_pStObjLayoutVertical;
+OVL_API void InitStage(Overlay* o) {
+    LoadReset();
+    memcpy(o, &OVL_EXPORT(Overlay), sizeof(AbbreviatedOverlay));
+    PfnEntityUpdates = EntityUpdates;
+    g_pStObjLayoutHorizontal = entityLayoutHorizontal;
+    g_pStObjLayoutVertical = entityLayoutVertical;
+}


### PR DESCRIPTION
Same story, depends on #3377 . The goal is to import as many overlays to PC as possible, so people can try out and report bugs + recordings

<img width="1285" height="1009" alt="image" src="https://github.com/user-attachments/assets/e6f24abb-190a-466d-a550-e141a86306e0" />
