### PR TITLE
no3: fix EntityBoneScimitarParts OOB

### DIFF
--- a/src/st/e_bone_scimitar.h
+++ b/src/st/e_bone_scimitar.h
@@ -300,7 +300,14 @@ void EntityBoneScimitar(Entity* self) {
 void EntityBoneScimitarParts(Entity* self) {
     if (self->step) {
         if (--self->ext.skeleton.explosionTimer) {
+#if defined(VERSION_PC)
+            // BUG! BONE_SCIMITAR_SPECIAL assigns a self->params value bigger
+            // than anim_bone_rot, causing a OOB access. On PS1 US this reads
+            // at 80183da8, where NO3 rooms are stored.
+            self->rotate += anim_bone_rot[self->params & 0xFF];
+#else
             self->rotate += anim_bone_rot[self->params];
+#endif
             FallEntity();
             MoveEntity();
             return;


### PR DESCRIPTION
Another example where this change is neither related to `VERSION_PC` and it would require too many surgical changes to match the exact PS1 behaviour (which would be different between US, JP, EU and other builds anyway).

We need to agree on a naming scheme of some sort for these. CC @bismurphy 