### PR TITLE
pc: fix gameover screen

### DIFF
--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -450,6 +450,38 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
             sim.path = "BIN/F_PROLO1.BIN";
             sim.kind = SIM_12;
             break;
+        // gof.bin, gob.bin, c_gof.bin, c_gob.bin are packed back-to-back
+        // inside a single combined BIN/F_GO.BIN on disk
+        case 8: // game over bitmap foreground
+            if (FileReadToBuf(
+                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x00000, 0x8000) < 0) {
+                return -1;
+            }
+            LoadImage(&g_Vram.D_800ACDD0, D_80280000);
+            return 0;
+        case 9: // game over bitmap background
+            if (FileReadToBuf("disks/us/BIN/F_GO.BIN", D_80280000, 0x08000,
+                              0x10000) < 0) {
+                return -1;
+            }
+            LoadImage(&g_Vram.D_800ACDD8, D_80280000);
+            return 0;
+        case 10: // game over palette foreground
+            if (FileReadToBuf(
+                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x18000, 0x2000) < 0) {
+                return -1;
+            }
+            LoadImage(&g_Vram.D_800ACDB8, D_80280000);
+            StoreImage(&g_Vram.D_800ACDB8, g_Clut[2]);
+            return 0;
+        case 11: // game over palette background
+            if (FileReadToBuf(
+                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x1A000, 0x2000) < 0) {
+                return -1;
+            }
+            LoadImage(&g_Vram.D_800ACDA8, D_80280000);
+            StoreImage(&g_Vram.D_800ACDA8, g_Clut[0]);
+            return 0;
         case 12:
             sim.path = "ST/SEL/F_SEL.BIN";
             sim.kind = SIM_STAGE_CHR;


### PR DESCRIPTION
Interestingly, originally the gameover screen were 4 different files. These are still observable today in the PSP version.

<img width="1286" height="979" alt="image" src="https://github.com/user-attachments/assets/7484ede1-1a68-4948-a61b-1a2c0c68a60c" />
