### PR TITLE
Add FIX_UB macro

### DIFF
--- a/include/stage.h
+++ b/include/stage.h
@@ -208,12 +208,15 @@ void HitDetection(void);
 s32 Random();
 #ifdef VERSION_PC
 void CreateEntityFromEntity(u16 entityId, Entity* source, Entity* entity);
+#endif
 
+#ifdef FIX_UB
 // BUG! on non-MIPS processors, not adding this forward declaration results to
 // the caller receiving an undefined numbers that can be random and
 // mis-representative of the actual return value.
 u8 GetPlayerCollisionWith(Entity* self, u16 w, u16 h, u16 flags);
 #endif
+
 void DestroyEntity(Entity*);
 void DestroyEntitiesFromIndex(s16 index);
 void FallEntity(void);

--- a/include/stage.h
+++ b/include/stage.h
@@ -206,9 +206,6 @@ void UpdateStageEntities();
 void HitDetection(void);
 
 s32 Random();
-#ifdef VERSION_PC
-void CreateEntityFromEntity(u16 entityId, Entity* source, Entity* entity);
-#endif
 
 #ifdef FIX_UB
 // BUG! on non-MIPS processors, not adding this forward declaration results to

--- a/include/version.h
+++ b/include/version.h
@@ -36,6 +36,16 @@
 #define VERSION_TOKEN us
 #endif
 
+#ifdef VERSION_PC
+
+// Macro to fix Undefined Behaviors found across the original codebase.
+// These are community, unofficial fixes brought for making the code portable
+// on different platforms, and to fix bugs in the original game release that
+// are unrelated to gameplay or glitch exploitation.
+#define FIX_UB
+
+#endif
+
 #define __CPP_STR(x) #x
 #define CPP_STR(x) __CPP_STR(x)
 // note: the "token" produced by PATH_JOIN gets stringified into a

--- a/include/version.h
+++ b/include/version.h
@@ -44,7 +44,6 @@
 // are unrelated to gameplay mechanics or glitch exploitation. This includes:
 //   * Array access beyond its intended boundaries
 //   * Access to uninitialized or unrelated portion of memory
-//   * Use of uninitialized or unrelated
 //   * Missing return statements
 //   * Mismatching function signatures to their original intended type
 //   * Data overflow

--- a/include/version.h
+++ b/include/version.h
@@ -41,7 +41,18 @@
 // Macro to fix Undefined Behaviors found across the original codebase.
 // These are community, unofficial fixes brought for making the code portable
 // on different platforms, and to fix bugs in the original game release that
-// are unrelated to gameplay or glitch exploitation.
+// are unrelated to gameplay mechanics or glitch exploitation. This includes:
+//   * Array access beyond its intended boundaries
+//   * Access to uninitialized or unrelated portion of memory
+//   * Use of uninitialized or unrelated
+//   * Missing return statements
+//   * Mismatching function signatures to their original intended type
+//   * Data overflow
+//   * Unintended graphical glitches
+// What this macro must NOT be use for:
+//   * Gameplay behavior or mechanics, even when they result to an exploit
+//   * Enhancements and beautifiers
+//   * Extend behavior or fix a dormant mechanic
 #define FIX_UB
 
 #endif

--- a/src/boss/dop_anim.h
+++ b/src/boss/dop_anim.h
@@ -290,7 +290,7 @@ void PlayAnimation(s8* frameProps, AnimationFrame** frames) {
         ((u16*)g_CurrentEntity->anim)[g_CurrentEntity->pose * 2]))))
 
 u32 OVL_EXPORT(UpdateAnim)(s8* hitboxes, AnimationFrame** anims) {
-#if defined(VERSION_PC)
+#if defined(FIX_UB)
     s32 ret = 0;
 #else
     s32 ret;

--- a/src/dra/84B88.c
+++ b/src/dra/84B88.c
@@ -2257,7 +2257,7 @@ void EntityAguneaHitEnemy(Entity* self) {
 }
 
 // tetra spirit out of bounds problem, add a value at beginning and end
-#ifdef VERSION_PC
+#ifdef FIX_UB
 u8 D_800B0848[] = {0x00, 0x80, 0x80, 0x80, 0x90, 0x80, 0xA0, 0x80, 0xB0,
                    0xA0, 0x80, 0xA0, 0x90, 0xA0, 0xA0, 0xA0, 0xB0, 0xC0};
 #else
@@ -2458,7 +2458,7 @@ void func_80129864(Entity* self) {
             prim->drawMode |= DRAW_HIDE;
             break;
         case 1:
-#ifdef VERSION_PC
+#ifdef FIX_UB
             // self->animCurFrame starts at 0. Seems like an out of bounds
             // bug in original?
             temp_u = D_800B0848[(self->animCurFrame) * 2];

--- a/src/dra/alu_anim.c
+++ b/src/dra/alu_anim.c
@@ -270,7 +270,7 @@ void PlayAnimation(s8* frameProps, AnimationFrame** frames) {
         ((u16*)g_CurrentEntity->anim)[g_CurrentEntity->pose * 2]))))
 
 u32 UpdateAnim(s8* frameProps, AnimationFrame** anims) {
-#if defined(VERSION_PC)
+#ifdef FIX_UB
     s32 ret = 0;
 #else
     s32 ret;

--- a/src/ric/pl_main.c
+++ b/src/ric/pl_main.c
@@ -420,7 +420,7 @@ void RicMain(void) {
 #endif
 #endif
 
-#if defined(VERSION_PC) || defined(VERSION_PSP)
+#if defined(FIX_UB) || defined(VERSION_PSP)
     damageEffects = 0;
 #endif
     for (i = 0; i < LEN(g_Player.timers); i++) {
@@ -641,7 +641,7 @@ void RicMain(void) {
         break;
     }
     g_Player.unk08 = g_Player.status;
-#if defined(VERSION_PC) || defined(VERSION_PSP)
+#if defined(FIX_UB) || defined(VERSION_PSP)
     // uninitialized on PSX, it was a coincidence it worked
     newStatus = 0;
 #endif

--- a/src/ric/pl_whip.c
+++ b/src/ric/pl_whip.c
@@ -325,9 +325,9 @@ void RicEntityWhip(Entity* self) {
                            (PLAYER.poseTimer == 13 || PLAYER.poseTimer == 14)) {
                     self->palette = PAL_FLAG(PAL_UNK_13C);
                 } else {
-// poseTimer can be -1 apparently.
-// todo this should read the previous element out of bounds?
-#ifdef VERSION_PC
+#ifdef FIX_UB
+                    // poseTimer can be -1 apparently.
+                    // todo this should read the previous element out of bounds?
                     if (PLAYER.poseTimer >= 0) {
                         self->palette =
                             D_80155C70[PLAYER.poseTimer % LEN(D_80155C70)];
@@ -386,9 +386,9 @@ void RicEntityWhip(Entity* self) {
                            PLAYER.poseTimer == 13 || PLAYER.poseTimer == 14) {
                     self->palette = PAL_FLAG(PAL_UNK_13C);
                 } else {
-// poseTimer can be -1 apparently.
-// todo this should read the previous element out of bounds?
-#ifdef VERSION_PC
+#ifdef FIX_UB
+                    // poseTimer can be -1 apparently.
+                    // todo this should read the previous element out of bounds?
                     if (PLAYER.poseTimer >= 0) {
                         self->palette = D_80155C70[PLAYER.poseTimer % 3];
                     }

--- a/src/servant/tt_000/bat.c
+++ b/src/servant/tt_000/bat.c
@@ -428,7 +428,7 @@ void OVL_EXPORT(ServantInit)(InitializeMode mode) {
     SpriteParts** spriteBanks;
     Entity* e;
 
-#ifdef VERSION_PC
+#ifdef FIX_UB
     const int len = LEN(g_ServantClut);
 #else
     const int len = 256;

--- a/src/servant/tt_001/ghost.c
+++ b/src/servant/tt_001/ghost.c
@@ -230,7 +230,7 @@ void OVL_EXPORT(ServantInit)(InitializeMode mode) {
     s32 i;
     SpriteParts** spriteBanks;
     Entity* e;
-#ifdef VERSION_PC
+#ifdef FIX_UB
     const int lenServantClut = LEN(g_ServantClut);
     const int leng_GhostClut = LEN(g_GhostClut);
 #else

--- a/src/servant/tt_002/faerie.c
+++ b/src/servant/tt_002/faerie.c
@@ -451,7 +451,7 @@ void OVL_EXPORT(ServantInit)(InitializeMode mode) {
     SpriteParts** spriteBanks;
     Entity* entity;
 
-#ifdef VERSION_PC
+#ifdef FIX_UB
     const int len = LEN(g_FaerieClut);
 #else
     const int len = 256;

--- a/src/servant/tt_003/demon.c
+++ b/src/servant/tt_003/demon.c
@@ -541,7 +541,7 @@ void OVL_EXPORT(ServantInit)(InitializeMode mode) {
     SpriteParts** spriteBanks;
     Entity* entity;
 
-#ifdef VERSION_PC
+#ifdef FIX_UB
     const int lenServant = LEN(g_ServantClut);
     const int lenDemon = LEN(g_DemonClut);
 #else

--- a/src/st/e_bone_scimitar.h
+++ b/src/st/e_bone_scimitar.h
@@ -300,7 +300,7 @@ void EntityBoneScimitar(Entity* self) {
 void EntityBoneScimitarParts(Entity* self) {
     if (self->step) {
         if (--self->ext.skeleton.explosionTimer) {
-#if defined(VERSION_PC)
+#if defined(FIX_UB)
             // BUG! BONE_SCIMITAR_SPECIAL assigns a self->params value bigger
             // than anim_bone_rot, causing a OOB access. On PS1 US this reads
             // at 80183da8, where NO3 rooms are stored.

--- a/src/st/entity_axe_knight.h
+++ b/src/st/entity_axe_knight.h
@@ -27,7 +27,7 @@ static s16 dead_particle_pos[][2] = {
     {11, -7},
     {4, 6},
     {-3, 0},
-#if defined(VERSION_PC)
+#if defined(FIX_UB)
     // BUG! OOB on death animation
     {0, 0},
 #endif

--- a/src/st/nz0/bss.c
+++ b/src/st/nz0/bss.c
@@ -7,7 +7,7 @@ u32 g_SkipCutscene;
 Dialogue g_Dialogue;
 u32 D_801CB6CC[26];
 u32 g_CutsceneFlags;
-#ifdef VERSION_PC
+#ifdef FIX_UB
 s16 D_801CB738[4]; // protect OOB for EntityMovableBox and BoxPuzzleSpikes
 #else
 s16 D_801CB738[2];

--- a/src/st/nz0/e_puzzle.c
+++ b/src/st/nz0/e_puzzle.c
@@ -2,7 +2,7 @@
 #include "nz0.h"
 #include "sfx.h"
 
-#ifdef VERSION_PC
+#ifdef FIX_UB
 // BUG! fix a OOB where x can be -1
 #define PUZZLE_MODIFIER(x) D_801CB738[x]
 #else

--- a/src/st/sel/2C048.c
+++ b/src/st/sel/2C048.c
@@ -478,7 +478,7 @@ bool MainMenuFadeIn(void) {
     prim->drawMode = DRAW_HIDE;
     prim = prim->next;
     prim->drawMode = DRAW_HIDE;
-#ifdef VERSION_PC
+#ifdef FIX_UB
     // BUG! return value 1 is never returned
     return true;
 #endif

--- a/src/st/st0/3C5C0.c
+++ b/src/st/st0/3C5C0.c
@@ -49,9 +49,6 @@ extern SVECTOR D_pspeu_09279DC0; // bss
 #define offsetof(st, m) (size_t)((size_t) & (((st*)0)->m)) // __builtin_offsetof
 
 void func_801BC5C0(Entity* self) {
-#ifdef VERSION_PC
-    u8 sp[sizeof(ST0_SCRATCHPAD)];
-#endif
     s16 var_s7;
     s16 var_s6;
     u8* var_s5;

--- a/src/st/st0_hit_detection.h
+++ b/src/st/st0_hit_detection.h
@@ -287,7 +287,7 @@ void OVL_EXPORT(HitDetection)(void) {
             BottomCornerText(g_api.enemyDefs[entityHit->enemyId].name, false);
             entityHit->flags |= FLAG_NOT_AN_ENEMY;
         }
-#ifdef VERSION_PC
+#ifdef FIX_UB
         // BUG! On ST0 only, the sentinel value miscVar2 is never reset. If the
         // entityHit has hitPoints==0 (e.g. EntityDraculaFireball), the value
         // miscVar2=0xFF will leak resulting to a UNK_Invincibility0[] OOB.

--- a/src/weapon/shared.h
+++ b/src/weapon/shared.h
@@ -21,7 +21,7 @@ static void LoadWeaponPalette(s32 clutIndex) {
     }
 
     for (i = 0; i < LEN(*D_8006EDCC)
-#ifdef VERSION_PC
+#ifdef FIX_UB
                 && i < LEN(g_WeaponCluts[clutIndex])
 #endif
              ;


### PR DESCRIPTION
Quite an important macro that is intended to separate PC exclusive code paths to undefined behaviour fixes.

I would like to have a review from both @bismurphy on this one, in addition to at least another extra review to ensure we are all on-board on what `FIX_UB` is intended for.