### PR TITLE
Add saturn sound player tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 [submodule "tools/psyz"]
 	path = tools/psyz
 	url = https://github.com/Xeeynamo/psyz
+[submodule "tools/saturn/sound-player"]
+	path = tools/saturn/sound-player
+	url = https://github.com/sozud/saturn-sound-player.git


### PR DESCRIPTION
This adds a sound player for sotn saturn, it can play the base sound bank, player character and stage sounds. The `sfx set` setting allows filtering by what is actually used in the stage so you don't have to flip through tons of incorrect IDs.

<img width="960" height="540" alt="sotn-player" src="https://github.com/user-attachments/assets/cb2960d5-a56d-48ba-8ff1-6193cc1a5c40" />

Usage like:
```
cd tools/saturn/sound-player
git submodule update --init --recursive    
cmake -S . -B build     
cmake --build build -j8       
./build/saturn-sfx play --game-bin ../../../disks/saturn/0.BIN 
```