### PR TITLE
make saturn-splitter less verbose

### DIFF
--- a/tools/builds/dosemu_wrapper.sh
+++ b/tools/builds/dosemu_wrapper.sh
@@ -16,9 +16,18 @@ out=$(echo "$2" | tr '/' '\\')
 # emulator failures only to its log, so use a per-process log and surface it
 # when the compiler fails instead of leaving CI with an unexplained exit 33.
 log_file="${TMPDIR:-/tmp}/sotn-dosemu-$$.log"
+# This wrapper is invoked as `sh dosemu_wrapper.sh`, ignoring the shebang, so
+# stick to POSIX sh (no PIPESTATUS, no process substitution).
+out_log="${TMPDIR:-/tmp}/sotn-dosemu-out-$$.log"
 dosemu -quiet -dumb -o "$log_file" -f ./dosemurc -K . \
-    -E "TOOLS\BUILDS\BUILD.BAT $in $out $3"
+    -E "TOOLS\BUILDS\BUILD.BAT $in $out $3" >"$out_log" 2>&1
 status=$?
+# The bundled Cygnus GCC 2.7 doesn't understand the linemarker format used by
+# the host's modern cpp to auto-include stdc-predef.h, so it emits this
+# harmless two-line warning on every single compile. Filter it out.
+# dosemu's output uses DOS line endings, so strip \r before matching $.
+tr -d '\r' <"$out_log" | sed '/^In file included from <command-line>:0:$/{N;/stdc-predef\.h:0: warning: unrecognized text at end of #line$/d}'
+rm -f "$out_log"
 
 if [ "$status" -ne 0 ] || [ ! -s "$2" ]; then
     if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
This gates most of the saturn-splitter output behind a `-v` option to clean up the build output