### PR TITLE
saturn: add progress report

### DIFF
--- a/.github/workflows/saturn-build.yml
+++ b/.github/workflows/saturn-build.yml
@@ -45,6 +45,15 @@ jobs:
           sudo dpkg -i dosemu2_2.0~pre9-1_amd64.deb
       - name: Build saturn
         run: ./sotn.sh build saturn
+      - name: Generate progress report
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: ./sotn.sh progress saturn
+      - name: Upload progress report
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: saturn_report
+          path: build/saturn/report.json
 
   function-finder-saturn:
     if: github.repository == 'Xeeynamo/sotn-decomp' && github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ asm/
 build/
 release/
 expected/
+rpt/
 disks/
 nonmatchings/
 .vscode/settings.json

--- a/tools/builds/saturn.py
+++ b/tools/builds/saturn.py
@@ -5,6 +5,14 @@ import ninja_syntax
 import os
 import shutil
 
+sotn_progress_report = "SOTN_PROGRESS_REPORT" in os.environ
+build_base_path = "build/saturn"
+extra_cpp_defs = ""
+if sotn_progress_report:
+    # Keep path short due to DOS emulation
+    build_base_path = "rpt/saturn"
+    extra_cpp_defs = " -DSKIP_ASM=1"
+
 # write out current pwd to open it as a disk
 with open('./tools/builds/.dosemurc', 'w') as f:
     f.write(f'$_hdimage = \'+0 {os.getcwd()} +1\'\n')
@@ -137,7 +145,7 @@ def add_srcs(srcs, output_dir, args):
         pre_name = os.path.join(obj_dir, f"{filename_without_extension}.pre")
         asm_name = os.path.join(obj_dir, f"{filename_without_extension}.s")
 
-        flags = '-lang-c -I./src/saturn -I./src/saturn/lib -undef -D__GNUC__=2 -D__GNUC_MINOR__=7 -D__sh__ -D__sh__ -D__sh2__'
+        flags = '-lang-c -I./src/saturn -I./src/saturn/lib -undef -D__GNUC__=2 -D__GNUC_MINOR__=7 -D__sh__ -D__sh__ -D__sh2__' + extra_cpp_defs
 
         ninja.build(
             pre_name,
@@ -483,9 +491,9 @@ asm_srcs = [
 ]
 
 # O0 srcs
-add_srcs(lib_srcs, "build/saturn", "O0")
+add_srcs(lib_srcs, build_base_path, "O0")
 
-add_srcs(snd_srcs, "build/saturn", "O3")
+add_srcs(snd_srcs, build_base_path, "O3")
 
 def elf_srcs(srcs, output_dir):
     for src in srcs:
@@ -499,8 +507,12 @@ def elf_srcs(srcs, output_dir):
             'coff2elf', 
             inputs=[input_name])
 
-elf_srcs(snd_srcs, "build/saturn")
-elf_srcs(lib_srcs, "build/saturn")
+elf_srcs(snd_srcs, build_base_path)
+elf_srcs(lib_srcs, build_base_path)
+
+if sotn_progress_report: # skip link step
+    ninja.close()
+    raise SystemExit(0)
 
 def add_asm_srcs(srcs, output_dir):
     for src in srcs:

--- a/tools/sotn-assets/build_saturn.go
+++ b/tools/sotn-assets/build_saturn.go
@@ -20,6 +20,13 @@ var saturnSplitterYAMLs = []string{
 }
 
 func buildSaturn() error {
+	if err := buildSaturnObjects(); err != nil {
+		return err
+	}
+	return checkVersions(os.Stderr, []string{"saturn"})
+}
+
+func buildSaturnObjects() error {
 	if err := extractSaturn(); err != nil {
 		return fmt.Errorf("extract: %w", err)
 	}
@@ -29,7 +36,7 @@ func buildSaturn() error {
 	if err := deps.Ninja(); err != nil {
 		return fmt.Errorf("ninja: %w", err)
 	}
-	return checkVersions(os.Stderr, []string{"saturn"})
+	return nil
 }
 
 var saturnExtractSentinels = []string{
@@ -65,9 +72,11 @@ func runSaturnSplitter() error {
 	return nil
 }
 
+const saturnNinjaStampFile = "build.ninja.version"
+
 func genSaturnNinjaIfNeeded() error {
 	const ninjaFile = "build.ninja"
-	const stampFile = "build.ninja.version"
+	const stampFile = saturnNinjaStampFile
 	const stamp = "saturn"
 
 	needsRegen := false

--- a/tools/sotn-assets/main.go
+++ b/tools/sotn-assets/main.go
@@ -231,6 +231,11 @@ func main() {
 		Short:        "Generate a progress report for https://decomp.dev/Xeeynamo/sotn-decomp",
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
+			// saturn bypasses getVersionFromArgs, which only knows PSX versions.
+			if len(args) > 0 && args[0] == saturnKind {
+				cmd.SetContext(context.WithValue(cmd.Context(), "version", saturnKind))
+				return nil
+			}
 			version, _, err := getVersionFromArgs(args)
 			if err != nil {
 				return err
@@ -240,6 +245,9 @@ func main() {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			version := cmd.Context().Value("version").(string)
+			if version == saturnKind {
+				return handleSaturnReport()
+			}
 			return handleObjdiffReport(version)
 		},
 	})

--- a/tools/sotn-assets/objdiffsaturn.go
+++ b/tools/sotn-assets/objdiffsaturn.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/deps"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/objdiff"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/splat"
+)
+
+type saturnOverlay struct {
+	id             string
+	name           string
+	splitterConfig string
+}
+
+var saturnOverlays = []saturnOverlay{
+	{"zero", "ZERO: Boot / libraries", "config/saturn/zero.bin.yaml"},
+	{"game", "GAME: Main engine", "config/saturn/game.prg.yaml"},
+	{"stage_02", "STAGE_02: Alchemy Laboratory", "config/saturn/stage_02.prg.yaml"},
+	{"warp", "WARP: Warp room", "config/saturn/warp.prg.yaml"},
+	{"alucard", "Alucard", "config/saturn/alucard.prg.yaml"},
+	{"richter", "Richter", "config/saturn/richter.prg.yaml"},
+	{"maria", "Maria", "config/saturn/maria.prg.yaml"},
+	{"t_bat", "T_BAT: Bat familiar", "config/saturn/t_bat.prg.yaml"},
+}
+
+const saturnKind = "saturn"
+const saturnBuildDir = "build/saturn"
+
+// saturnBaseDir is kept short because dosemu resolves it as a DOS path.
+const saturnBaseDir = "rpt/saturn"
+
+func saturnSourceFiles(configPath string) ([]string, error) {
+	cfg, err := splat.ReadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read splat config %q: %w", configPath, err)
+	}
+	seen := map[string]struct{}{}
+	var files []string
+	cfg.ForEachCodeSubsegment(func(_ splat.Segment, subsegments []any) {
+		for _, raw := range subsegments {
+			ss, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			file, ok := ss["file"].(string)
+			if !ok || file == "" {
+				continue
+			}
+			if _, dup := seen[file]; dup {
+				continue
+			}
+			seen[file] = struct{}{}
+			files = append(files, file)
+		}
+	})
+	sort.Strings(files)
+	return files, nil
+}
+
+func genSaturnObjdiffConfig() error {
+	var units []objdiff.Unit
+	categories := []objdiff.ProgressCategory{{ID: saturnKind, Name: "Saturn"}}
+	for _, ovl := range saturnOverlays {
+		categoryID := fmt.Sprintf("%s.%s", saturnKind, ovl.id)
+		categories = append(categories, objdiff.ProgressCategory{
+			ID:   categoryID,
+			Name: ovl.name,
+		})
+		files, err := saturnSourceFiles(ovl.splitterConfig)
+		if err != nil {
+			return err
+		}
+		for _, name := range files {
+			obj := name + ".o"
+			units = append(units, objdiff.Unit{
+				Name:       fmt.Sprintf("%s/%s", categoryID, name),
+				BasePath:   filepath.Join(saturnBaseDir, obj),
+				TargetPath: filepath.Join(saturnBuildDir, obj),
+				Metadata: objdiff.Metadata{
+					SourcePath:         filepath.Join("src/saturn", name+".c"),
+					ProgressCategories: []string{saturnKind, categoryID},
+				},
+			})
+		}
+	}
+	cfg := objdiff.Config{
+		CustomMake:       "ninja",
+		BuildBase:        false,
+		BuildTarget:      false,
+		Units:            units,
+		ProgressCategory: categories,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile("objdiff.json", data, 0644)
+}
+
+func handleSaturnReport() error {
+	defer func() { _ = regenSaturnNinjaWithoutProgressReport() }()
+
+	if err := buildSaturnTargetWithAsm(); err != nil {
+		return err
+	}
+	if err := buildSaturnBaseWithoutAsm(); err != nil {
+		return err
+	}
+	if err := genSaturnObjdiffConfig(); err != nil {
+		return err
+	}
+	reportPath := filepath.Join(saturnBuildDir, "report.json")
+	if err := deps.ObjdiffCLI("report", "generate", "-o", reportPath); err != nil {
+		return err
+	}
+	if err := removeDataMeasures(reportPath); err != nil {
+		return err
+	}
+	return summarizeSaturnReport(reportPath)
+}
+
+// temporarily remove data reporting on Saturn, as it's not accurate
+func removeDataMeasures(reportPath string) error {
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		return err
+	}
+	var report map[string]any
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return fmt.Errorf("parse %s: %w", reportPath, err)
+	}
+	stripDataMeasures(report["measures"])
+	units, _ := report["units"].([]any)
+	for _, u := range units {
+		unit, _ := u.(map[string]any)
+		if unit == nil {
+			continue
+		}
+		stripDataMeasures(unit["measures"])
+	}
+	out, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(reportPath, out, 0644)
+}
+
+func stripDataMeasures(rawMeasures any) {
+	measures, _ := rawMeasures.(map[string]any)
+	if measures == nil {
+		return
+	}
+	for _, key := range []string{
+		"total_data",
+		"matched_data",
+		"matched_data_percent",
+		"complete_data",
+		"complete_data_percent",
+	} {
+		delete(measures, key)
+	}
+}
+
+func buildSaturnTargetWithAsm() error {
+	if err := regenSaturnNinjaWithoutProgressReport(); err != nil {
+		return err
+	}
+	if err := buildSaturnObjects(); err != nil {
+		return fmt.Errorf("build saturn target: %w", err)
+	}
+	return nil
+}
+
+func buildSaturnBaseWithoutAsm() error {
+	if err := os.Setenv("SOTN_PROGRESS_REPORT", "1"); err != nil {
+		return err
+	}
+	if err := regenSaturnNinja(); err != nil {
+		return err
+	}
+	if err := deps.Ninja(); err != nil {
+		return fmt.Errorf("build saturn base: %w", err)
+	}
+	return nil
+}
+
+func regenSaturnNinjaWithoutProgressReport() error {
+	if err := os.Unsetenv("SOTN_PROGRESS_REPORT"); err != nil {
+		return err
+	}
+	return regenSaturnNinja()
+}
+
+func regenSaturnNinja() error {
+	if err := deps.GenSaturnNinja(); err != nil {
+		return err
+	}
+	if err := os.Remove(saturnNinjaStampFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func summarizeSaturnReport(reportPath string) error {
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		return err
+	}
+	var report struct {
+		Measures struct {
+			MatchedCodePercent float64 `json:"matched_code_percent"`
+			TotalCode          string  `json:"total_code"`
+		} `json:"measures"`
+		Units []struct {
+			Name     string `json:"name"`
+			Measures struct {
+				MatchedCodePercent float64 `json:"matched_code_percent"`
+			} `json:"measures"`
+		} `json:"units"`
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return fmt.Errorf("parse %s: %w", reportPath, err)
+	}
+	fmt.Printf("Saturn progress report written to %s\n", reportPath)
+	fmt.Printf("  overall matched code: %.2f%% (%s bytes total)\n",
+		report.Measures.MatchedCodePercent, report.Measures.TotalCode)
+	fmt.Printf("  units: %d\n", len(report.Units))
+	if strings.TrimSpace(report.Measures.TotalCode) == "" {
+		fmt.Println("  warning: no code measured; were the objects built?")
+	}
+	return nil
+}


### PR DESCRIPTION
With this change, it is expected the reporting to be added to https://decomp.dev/Xeeynamo/sotn-decomp .

https://sotn.xee.dev/ is not yet covered, as it would need some mapping between the PSP/PS1 stage names and the Saturn names.

```
Overlay    Code %    Data %    Code bytes    Data bytes
alucard     0.09%     0.00%        168992             0
game       44.75%    96.22%         89820         39510
maria       2.42%   100.00%        116312         76180
richter     7.19%     0.00%        105744             0
stage_02    2.03%   100.00%         68624         33808
t_bat      81.08%   100.00%         10232         18440
warp        0.00%   100.00%          7476          4392
zero       22.21%    69.52%        247220         61388
-------------------------------------------------------
TOTAL      14.16%    91.36%        814420        233718
```

the report data looks like the following. Only Code is going to be reported though, as I am not yet confident that Data is correct. More about this here: https://discord.com/channels/1079389589950705684/1079395324960981062/1529806215037849610