### PR TITLE
Improve Saturn build speed

### DIFF
--- a/tools/builds/dosemu_wrapper.sh
+++ b/tools/builds/dosemu_wrapper.sh
@@ -19,7 +19,8 @@ log_file="${TMPDIR:-/tmp}/sotn-dosemu-$$.log"
 # This wrapper is invoked as `sh dosemu_wrapper.sh`, ignoring the shebang, so
 # stick to POSIX sh (no PIPESTATUS, no process substitution).
 out_log="${TMPDIR:-/tmp}/sotn-dosemu-out-$$.log"
-dosemu -quiet -dumb -o "$log_file" -f ./dosemurc -K . \
+rc_file="${SOTN_DOSEMURC:-$(dirname "$0")/dosemurc}"
+dosemu -quiet -dumb -o "$log_file" -f "$rc_file" -K . \
     -E "TOOLS\BUILDS\BUILD.BAT $in $out $3" >"$out_log" 2>&1
 status=$?
 # The bundled Cygnus GCC 2.7 doesn't understand the linemarker format used by

--- a/tools/builds/dosemurc
+++ b/tools/builds/dosemurc
@@ -1,0 +1,11 @@
+$_cpu_vm = "emulated"
+$_cpu_vm_dpmi = "emulated"
+$_sound = (off)
+$_hogthreshold = (0)
+
+$_cpuspeed = (333.333)
+$_pci = (off)
+$_rdtsc = (off)
+$_term_color = (off)
+$_ipxsupport = (off)
+$_pktdriver = (off)


### PR DESCRIPTION
On Linux, our current bundled `dosemurc` gets ignored, which makes use of the dosemu defaults. Normally it would use KVM for 16-bit emulation, which is fast on longer runs but extremely slow at boot times. As CC1 gets called once per file, on my machine it takes 98% of the total compilation time, where most of of it is spent at initializing KVM.

I am now giving it a proper `dosemu` that emulates 16-bit instructions. This means much faster boot times. I slashed the total Saturn build time from 45s to 9.1s. The reason why this might not be a problem on CI is because nested virtualization is disabled, and KVM is not available.