### PR TITLE
Fix new crash on PC on non-demo runs

### DIFF
--- a/src/dra/demo.c
+++ b/src/dra/demo.c
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "dra.h"
 
-// BSS
+#ifdef VERSION_PC
+// mimic PSP behavior
+static u8* g_DemoPtr = DEMO_KEY_PTR;
+#else
 static u8* g_DemoPtr;
+#endif
 static s32 g_DemoKeyIdx;
 
 static u8 demo_stages[] = {


### PR DESCRIPTION
PC build was broken since #3433 . This fixes is by initializing the same way it's done on PSP
