### PR TITLE
sat: w_chr asset extraction

### DIFF
--- a/config/assets.saturn.yaml
+++ b/config/assets.saturn.yaml
@@ -98,3 +98,26 @@ assets:
     output: build/saturn/assets/SD
     files:
       - SDF0.PCM
+  # secondary player chr. subweapons, spells and hit sparks
+  # 4bpp raw
+  - name: weapon-maria
+    kind: weapon
+    profile: maria
+    source: disks/saturn/MAR_W.CHR
+    prg: disks/saturn/MARIA.PRG
+    path: assets/saturn/weapon/MAR_W
+    output: build/saturn/assets/MAR_W.CHR
+  - name: weapon-richter
+    kind: weapon
+    profile: richter
+    source: disks/saturn/RIC_W.CHR
+    prg: disks/saturn/RICHTER.PRG
+    path: assets/saturn/weapon/RIC_W
+    output: build/saturn/assets/RIC_W.CHR
+  - name: weapon-alucard
+    kind: weapon
+    profile: alucard
+    source: disks/saturn/ALC_W.CHR
+    prg: disks/saturn/ALUCARD.PRG
+    path: assets/saturn/weapon/ALC_W
+    output: build/saturn/assets/ALC_W.CHR

--- a/tools/saturn/assets/src/image.rs
+++ b/tools/saturn/assets/src/image.rs
@@ -1,7 +1,3 @@
-//! png reader/write for fonts
-//!
-//! orignals are 1 bit fonts but write 8-bit for compatiblity
-
 use crate::{Error, Result};
 use std::fs::File;
 use std::io::BufWriter;
@@ -32,29 +28,236 @@ impl Bilevel {
     }
 }
 
-pub fn write(path: &Path, atlas: &Bilevel) -> Result<()> {
+pub struct Indexed {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+pub const MAX_INDEX: u8 = 15;
+
+impl Indexed {
+    pub fn new(width: u32, height: u32) -> Self {
+        Indexed {
+            width,
+            height,
+            pixels: vec![0; (width as usize) * (height as usize)],
+        }
+    }
+
+    pub fn get(&self, x: u32, y: u32) -> u8 {
+        self.pixels[(y as usize) * (self.width as usize) + (x as usize)]
+    }
+
+    pub fn set(&mut self, x: u32, y: u32, value: u8) {
+        let width = self.width as usize;
+        self.pixels[(y as usize) * width + (x as usize)] = value;
+    }
+}
+
+fn display_ramp(pixels: &[u8]) -> Vec<u8> {
+    let highest = pixels.iter().copied().max().unwrap_or(0).max(1);
+    (0..=MAX_INDEX)
+        .flat_map(|index| {
+            if index <= highest {
+                let level = (index as u32 * 255 / highest as u32) as u8;
+                [level, level, level]
+            } else {
+                let spare = index - highest;
+                let level = 96 + (spare as u32 * 159 / (MAX_INDEX - highest).max(1) as u32) as u8;
+                [level, 0, 0]
+            }
+        })
+        .collect()
+}
+
+pub fn write_indexed(path: &Path, image: &Indexed) -> Result<()> {
+    write_indexed_palette(path, image, None)
+}
+
+pub fn write_indexed_palette(path: &Path, image: &Indexed, palette: Option<&[u8]>) -> Result<()> {
+    if let Some(bad) = image.pixels.iter().find(|&&p| p > MAX_INDEX) {
+        return Err(Error::Format(format!(
+            "{}: 4bpp image contains index {bad}, above {MAX_INDEX}",
+            path.display()
+        )));
+    }
+    if let Some(colours) = palette {
+        let entries = (MAX_INDEX as usize + 1) * 3;
+        if colours.len() != entries {
+            return Err(Error::Format(format!(
+                "{}: display palette is {} bytes, expected {entries} (RGB per index)",
+                path.display(),
+                colours.len()
+            )));
+        }
+    }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let file = File::create(path)?;
-    let mut encoder = png::Encoder::new(BufWriter::new(file), atlas.width, atlas.height);
+    let mut encoder = png::Encoder::new(BufWriter::new(file), image.width, image.height);
+    encoder.set_color(png::ColorType::Indexed);
+    encoder.set_depth(png::BitDepth::Eight);
+    match palette {
+        Some(colours) => {
+            encoder.set_palette(colours.to_vec());
+            encoder.set_trns(vec![0u8]);
+        }
+        None => encoder.set_palette(display_ramp(&image.pixels)),
+    }
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+    writer
+        .write_image_data(&image.pixels)
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+    Ok(())
+}
+
+pub struct Rgba {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
+}
+
+impl Rgba {
+    pub fn new(width: u32, height: u32, fill: [u8; 4]) -> Self {
+        Rgba {
+            width,
+            height,
+            pixels: fill
+                .iter()
+                .copied()
+                .cycle()
+                .take((width as usize) * (height as usize) * 4)
+                .collect(),
+        }
+    }
+
+    pub fn set(&mut self, x: u32, y: u32, colour: [u8; 4]) {
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        let at = ((y as usize) * (self.width as usize) + (x as usize)) * 4;
+        self.pixels[at..at + 4].copy_from_slice(&colour);
+    }
+
+    pub fn fill_rect(&mut self, x: u32, y: u32, width: u32, height: u32, colour: [u8; 4]) {
+        for row in y..y + height {
+            for column in x..x + width {
+                self.set(column, row, colour);
+            }
+        }
+    }
+}
+
+pub fn write_rgba(path: &Path, image: &Rgba) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = File::create(path)?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), image.width, image.height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder
+        .write_header()
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+    writer
+        .write_image_data(&image.pixels)
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+    Ok(())
+}
+
+pub fn read_indexed(path: &Path) -> Result<Indexed> {
+    if let Some(indexed) = read_palette_indices(path)? {
+        return Ok(indexed);
+    }
+    let (width, height, luminance) = read_luminance(path)?;
+    let highest = luminance.iter().copied().max().unwrap_or(0).max(1) as u16;
+    Ok(Indexed {
+        width,
+        height,
+        pixels: luminance
+            .iter()
+            .map(|&value| {
+                ((value as u16 * MAX_INDEX as u16 + highest / 2) / highest).min(MAX_INDEX as u16)
+                    as u8
+            })
+            .collect(),
+    })
+}
+
+fn read_palette_indices(path: &Path) -> Result<Option<Indexed>> {
+    let file = File::open(path)?;
+    let mut decoder = png::Decoder::new(file);
+    decoder.set_transformations(png::Transformations::IDENTITY);
+    let mut reader = decoder
+        .read_info()
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+    if reader.info().color_type != png::ColorType::Indexed {
+        return Ok(None);
+    }
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let info = reader
+        .next_frame(&mut buffer)
+        .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
+
+    let depth = info.bit_depth as u8 as u32;
+    let width = info.width as usize;
+    let row_bytes = (width * depth as usize).div_ceil(8);
+    let mut pixels = Vec::with_capacity(width * info.height as usize);
+    for row in buffer.chunks(row_bytes).take(info.height as usize) {
+        for x in 0..width {
+            let bit = x * depth as usize;
+            let byte = row[bit / 8];
+            let value = match depth {
+                8 => byte,
+                _ => (byte >> (8 - depth as usize - (bit % 8))) & ((1 << depth) - 1) as u8,
+            };
+            pixels.push(value);
+        }
+    }
+    Ok(Some(Indexed {
+        width: info.width,
+        height: info.height,
+        pixels,
+    }))
+}
+
+fn write_luminance(path: &Path, image: &Bilevel) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = File::create(path)?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), image.width, image.height);
     encoder.set_color(png::ColorType::Grayscale);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder
         .write_header()
         .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
-    let luminance: Vec<u8> = atlas
-        .pixels
-        .iter()
-        .map(|&b| if b != 0 { 255 } else { 0 })
-        .collect();
     writer
-        .write_image_data(&luminance)
+        .write_image_data(&image.pixels)
         .map_err(|e| Error::Png(format!("{}: {e}", path.display())))?;
     Ok(())
 }
 
-pub fn read(path: &Path) -> Result<Bilevel> {
+pub fn write(path: &Path, atlas: &Bilevel) -> Result<()> {
+    write_luminance(
+        path,
+        &Bilevel {
+            width: atlas.width,
+            height: atlas.height,
+            pixels: atlas
+                .pixels
+                .iter()
+                .map(|&b| if b != 0 { 255 } else { 0 })
+                .collect(),
+        },
+    )
+}
+
+fn read_luminance(path: &Path) -> Result<(u32, u32, Vec<u8>)> {
     let file = File::open(path)?;
     let mut decoder = png::Decoder::new(file);
     decoder.set_transformations(png::Transformations::normalize_to_color8());
@@ -86,12 +289,20 @@ pub fn read(path: &Path) -> Result<Bilevel> {
         } else {
             sample
         };
-        pixels.push(u8::from(opaque && colour.iter().any(|&c| c != 0)));
+        pixels.push(if opaque {
+            colour.iter().copied().max().unwrap_or(0)
+        } else {
+            0
+        });
     }
+    Ok((info.width, info.height, pixels))
+}
 
+pub fn read(path: &Path) -> Result<Bilevel> {
+    let (width, height, luminance) = read_luminance(path)?;
     Ok(Bilevel {
-        width: info.width,
-        height: info.height,
-        pixels,
+        width,
+        height,
+        pixels: luminance.iter().map(|&v| u8::from(v != 0)).collect(),
     })
 }

--- a/tools/saturn/assets/src/lib.rs
+++ b/tools/saturn/assets/src/lib.rs
@@ -5,6 +5,8 @@ pub mod audio;
 pub mod font;
 pub mod image;
 pub mod wav;
+pub mod weapon;
+pub mod weapon_sheet;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/tools/saturn/assets/src/main.rs
+++ b/tools/saturn/assets/src/main.rs
@@ -3,7 +3,7 @@
 //! Driven from tools/sotn-assets and config/assets.saturn.yaml
 
 use clap::{Parser, Subcommand};
-use saturn_assets::{audio, font};
+use saturn_assets::{audio, font, weapon};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -22,6 +22,33 @@ enum Command {
     /// SD*.PCM music, mono and voice streams
     #[command(subcommand)]
     Audio(AudioCommand),
+    /// MAR_W / RIC_W / ALC_W secondary player CHR
+    #[command(subcommand)]
+    Weapon(WeaponCommand),
+}
+
+#[derive(Subcommand)]
+enum WeaponCommand {
+    /// Export the linear atlas and, with a PRG, the per-image sprite PNGs
+    Extract {
+        /// Character profile: maria, richter or alucard
+        character: String,
+        /// The retail MAR_W.CHR / RIC_W.CHR / ALC_W.CHR
+        chr_path: PathBuf,
+        output_dir: PathBuf,
+        /// The player PRG whose sprite tables partition this CHR. Without it
+        /// only the whole-file atlas is written.
+        #[arg(long)]
+        prg: Option<PathBuf>,
+    },
+    /// Reassemble the CHR from the atlas and the sprite PNGs
+    Rebuild { manifest: PathBuf, output: PathBuf },
+    /// Require a byte-identical no-edit rebuild
+    Verify {
+        manifest: PathBuf,
+        /// The retail CHR to compare against
+        chr_path: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -104,6 +131,29 @@ fn run(cli: Cli) -> saturn_assets::Result<()> {
             source_path,
         }) => {
             audio::verify(&manifest, &source_path)?;
+            println!("verify passed: exact retail match");
+        }
+        Command::Weapon(WeaponCommand::Extract {
+            character,
+            chr_path,
+            output_dir,
+            prg,
+        }) => {
+            let manifest = weapon::extract(&character, &chr_path, prg.as_deref(), &output_dir)?;
+            let images: usize = manifest.packages.iter().map(|p| p.images.len()).sum();
+            println!(
+                "{} bytes, {} package(s), {images} image record(s) -> {}",
+                manifest.source.size,
+                manifest.packages.len(),
+                output_dir.display()
+            );
+        }
+        Command::Weapon(WeaponCommand::Rebuild { manifest, output }) => {
+            let data = weapon::rebuild(&manifest, &output)?;
+            println!("wrote {} bytes -> {}", data.len(), output.display());
+        }
+        Command::Weapon(WeaponCommand::Verify { manifest, chr_path }) => {
+            weapon::verify(&manifest, &chr_path)?;
             println!("verify passed: exact retail match");
         }
     }

--- a/tools/saturn/assets/src/weapon.rs
+++ b/tools/saturn/assets/src/weapon.rs
@@ -1,0 +1,821 @@
+use crate::image::{self, Indexed};
+use crate::{sha256_hex, Error, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub const FORMAT: &str = "sotn-saturn-weapon-chr";
+pub const VERSION: u32 = 1;
+pub const MANIFEST_NAME: &str = "manifest.json";
+pub const LINEAR_NAME: &str = "linear.png";
+pub const CONTACT_NAME: &str = "contact.png";
+pub const SPRITES_DIR: &str = "sprites";
+pub const ENCODING: &str = "indexed4-linear-high-nibble-first";
+
+pub const LINEAR_WIDTH: u32 = 320;
+
+pub const VDP1_BASE: u32 = 0x25C0_0000;
+pub const DESTINATION_OFFSET_GLOBAL: u32 = 0x0605_BEC4;
+
+const RESOURCE_STRIDE: usize = 12;
+const OFFSET_UNIT: usize = 8;
+const MAX_IMAGES: usize = 512;
+pub const PALETTE_BANK_SIZE: usize = 16;
+
+#[derive(Clone, Copy)]
+pub struct Profile {
+    pub name: &'static str,
+    pub file: &'static str,
+    pub prg: &'static str,
+    pub load_address: u32,
+    pub resource_array_offset: usize,
+    pub resource_count: usize,
+    pub vdp1_offset: u32,
+}
+
+pub const PROFILES: &[Profile] = &[
+    Profile {
+        name: "maria",
+        file: "MAR_W.CHR",
+        prg: "MARIA.PRG",
+        load_address: 0x060A_5000,
+        resource_array_offset: 0x21D68,
+        resource_count: 13,
+        vdp1_offset: 0x1D980,
+    },
+    Profile {
+        name: "richter",
+        file: "RIC_W.CHR",
+        prg: "RICHTER.PRG",
+        load_address: 0x060A_5000,
+        resource_array_offset: 0x1DF2C,
+        resource_count: 10,
+        vdp1_offset: 0x1D980,
+    },
+    Profile {
+        name: "alucard",
+        file: "ALC_W.CHR",
+        prg: "ALUCARD.PRG",
+        load_address: 0x060A_5000,
+        resource_array_offset: 0x26DF8,
+        resource_count: 13,
+        vdp1_offset: 0x2A980,
+    },
+];
+
+pub fn profile(name: &str) -> Result<&'static Profile> {
+    PROFILES.iter().find(|p| p.name == name).ok_or_else(|| {
+        let known: Vec<&str> = PROFILES.iter().map(|p| p.name).collect();
+        Error::Format(format!(
+            "unknown weapon character {name:?}; known: {}",
+            known.join(", ")
+        ))
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Source {
+    pub name: String,
+    pub size: usize,
+    pub sha256: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PrgSource {
+    pub name: String,
+    pub size: usize,
+    pub sha256: String,
+    pub resource_array_offset: usize,
+    pub resource_count: usize,
+    pub first_resource: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Vdp1 {
+    pub destination_base: u32,
+    pub load_offset: u32,
+    pub load_address: u32,
+    pub destination_offset_global: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageRecord {
+    pub index: usize,
+    pub stored_width: u8,
+    pub stored_height: u8,
+    pub pixel_width: u32,
+    pub pixel_height: u32,
+    pub offset: usize,
+    pub byte_count: usize,
+    pub allocation_size: usize,
+    pub file_offset: usize,
+    pub sha256: String,
+    pub file: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Package {
+    pub resource_index: usize,
+    pub image_table_address: u32,
+    pub image_table_prg_offset: usize,
+    pub palette_table_address: u32,
+    pub palette_table_prg_offset: usize,
+    pub palette_banks: usize,
+    pub byte_count: usize,
+    pub file_offset: usize,
+    pub images: Vec<ImageRecord>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Manifest {
+    pub format: String,
+    pub version: u32,
+    pub character: String,
+    pub encoding: String,
+    pub linear: String,
+    pub linear_width: u32,
+    pub linear_height: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub contact: Option<String>,
+    pub valid_pixels: usize,
+    pub padding_pixels: usize,
+    pub vdp1: Vdp1,
+    pub source: Source,
+    pub prg: Option<PrgSource>,
+    #[serde(default)]
+    pub packages: Vec<Package>,
+}
+
+impl Manifest {
+    pub fn profile(&self) -> Result<&'static Profile> {
+        profile(&self.character)
+    }
+
+    pub fn records(&self) -> impl Iterator<Item = (&Package, &ImageRecord)> {
+        self.packages
+            .iter()
+            .flat_map(|package| package.images.iter().map(move |image| (package, image)))
+    }
+}
+
+pub fn unpack(data: &[u8]) -> Vec<u8> {
+    let mut pixels = Vec::with_capacity(data.len() * 2);
+    for &byte in data {
+        pixels.push(byte >> 4);
+        pixels.push(byte & 0xF);
+    }
+    pixels
+}
+
+pub fn pack(pixels: &[u8]) -> Result<Vec<u8>> {
+    if pixels.len() % 2 != 0 {
+        return Err(Error::Format(format!(
+            "packed 4bpp needs an even pixel count, got {}",
+            pixels.len()
+        )));
+    }
+    if let Some(bad) = pixels.iter().find(|&&p| p > image::MAX_INDEX) {
+        return Err(Error::Format(format!(
+            "4bpp image contains index {bad}, above {}",
+            image::MAX_INDEX
+        )));
+    }
+    Ok(pixels
+        .chunks_exact(2)
+        .map(|pair| (pair[0] << 4) | pair[1])
+        .collect())
+}
+
+pub fn to_linear(data: &[u8]) -> Indexed {
+    let pixels = unpack(data);
+    let height = (pixels.len() as u32).div_ceil(LINEAR_WIDTH).max(1);
+    let mut atlas = Indexed::new(LINEAR_WIDTH, height);
+    atlas.pixels[..pixels.len()].copy_from_slice(&pixels);
+    atlas
+}
+
+fn record_image(data: &[u8], record: &ImageRecord) -> Indexed {
+    let bytes = &data[record.file_offset..record.file_offset + record.byte_count];
+    Indexed {
+        width: record.pixel_width,
+        height: record.pixel_height,
+        pixels: unpack(bytes),
+    }
+}
+
+#[derive(Debug)]
+struct RawRecord {
+    index: usize,
+    stored_width: u8,
+    stored_height: u8,
+    offset: usize,
+    byte_count: usize,
+    allocation_size: usize,
+}
+
+fn parse_image_table(prg: &[u8], table_offset: usize) -> Result<(Vec<RawRecord>, usize)> {
+    let mut records: Vec<RawRecord> = Vec::new();
+    let mut cursor = table_offset;
+    let package_size = loop {
+        if records.len() >= MAX_IMAGES {
+            return Err(Error::Format(format!(
+                "image table at PRG 0x{table_offset:X} has no terminator in {MAX_IMAGES} entries"
+            )));
+        }
+        if cursor + 4 > prg.len() {
+            return Err(Error::Format(format!(
+                "image table at PRG 0x{table_offset:X} runs past the end of the PRG"
+            )));
+        }
+        let stored_width = prg[cursor];
+        let stored_height = prg[cursor + 1];
+        let units = u16::from_be_bytes([prg[cursor + 2], prg[cursor + 3]]) as usize;
+        if stored_width == 0 && stored_height == 0 {
+            if records.is_empty() {
+                return Err(Error::Format(format!(
+                    "image table at PRG 0x{table_offset:X} is empty"
+                )));
+            }
+            break units * OFFSET_UNIT;
+        }
+        if stored_width == 0 || stored_height == 0 {
+            return Err(Error::Format(format!(
+                "image {} at PRG 0x{table_offset:X} has a zero dimension",
+                records.len()
+            )));
+        }
+        let offset = units * OFFSET_UNIT;
+        let byte_count = stored_width as usize * stored_height as usize * 2;
+        if let Some(previous) = records.last() {
+            if offset < previous.offset + previous.byte_count {
+                return Err(Error::Format(format!(
+                    "image {} at PRG 0x{table_offset:X} overlaps image {}",
+                    records.len(),
+                    previous.index
+                )));
+            }
+        }
+        records.push(RawRecord {
+            index: records.len(),
+            stored_width,
+            stored_height,
+            offset,
+            byte_count,
+            allocation_size: 0,
+        });
+        cursor += 4;
+    };
+
+    let last = records.last().expect("checked non-empty above");
+    if last.offset + last.byte_count > package_size {
+        return Err(Error::Format(format!(
+            "image {} at PRG 0x{table_offset:X} ends past its {package_size}-byte package",
+            last.index
+        )));
+    }
+    for index in 0..records.len() {
+        let next = records
+            .get(index + 1)
+            .map(|record| record.offset)
+            .unwrap_or(package_size);
+        records[index].allocation_size = next - records[index].offset;
+    }
+    Ok((records, package_size))
+}
+
+fn read_palette_banks(prg: &[u8], offset: usize) -> Vec<Vec<[u8; 3]>> {
+    let bank_bytes = PALETTE_BANK_SIZE * 2;
+    if offset.saturating_add(2) > prg.len() {
+        return Vec::new();
+    }
+    let count = (u16::from_be_bytes([prg[offset], prg[offset + 1]]) & 0x3FFF) as usize;
+    let mut banks = Vec::with_capacity(count);
+    for bank in 0..count {
+        let base = offset + 2 + bank * bank_bytes;
+        if base.saturating_add(bank_bytes) > prg.len() {
+            break;
+        }
+        banks.push(
+            (0..PALETTE_BANK_SIZE)
+                .map(|index| {
+                    let word =
+                        u16::from_be_bytes([prg[base + index * 2], prg[base + index * 2 + 1]]);
+                    let channel = |shift: u32| ((word >> shift) & 0x1F) as u32 * 255 / 31;
+                    [channel(0) as u8, channel(5) as u8, channel(10) as u8]
+                })
+                .collect(),
+        );
+    }
+    banks
+}
+
+fn display_palette(banks: &[Vec<[u8; 3]>]) -> Option<Vec<u8>> {
+    let bank = banks.first()?;
+    if bank.len() != PALETTE_BANK_SIZE {
+        return None;
+    }
+    Some(bank.iter().flatten().copied().collect())
+}
+
+fn read_packages(prg: &[u8], profile: &Profile, chr_size: usize) -> Result<(usize, Vec<Package>)> {
+    struct Parsed {
+        image_table_address: u32,
+        image_table_prg_offset: usize,
+        palette_table_address: u32,
+        palette_table_prg_offset: usize,
+        byte_count: usize,
+        records: Vec<RawRecord>,
+    }
+
+    let mut parsed = Vec::with_capacity(profile.resource_count);
+    for index in 0..profile.resource_count {
+        let entry = profile.resource_array_offset + index * RESOURCE_STRIDE;
+        if entry + RESOURCE_STRIDE > prg.len() {
+            return Err(Error::Format(format!(
+                "resource array entry {index} runs past the end of the PRG"
+            )));
+        }
+        let image_table_address = u32::from_be_bytes(prg[entry..entry + 4].try_into().unwrap());
+        let palette_table_address =
+            u32::from_be_bytes(prg[entry + 4..entry + 8].try_into().unwrap());
+        let table_offset = image_table_address
+            .checked_sub(profile.load_address)
+            .map(|offset| offset as usize)
+            .filter(|&offset| offset < prg.len())
+            .ok_or_else(|| {
+                Error::Format(format!(
+                    "resource {index} image table 0x{image_table_address:08X} is outside the PRG"
+                ))
+            })?;
+        let (records, byte_count) = parse_image_table(prg, table_offset)?;
+        parsed.push(Parsed {
+            image_table_address,
+            image_table_prg_offset: table_offset,
+            palette_table_address,
+            palette_table_prg_offset: palette_table_address.wrapping_sub(profile.load_address)
+                as usize,
+            byte_count,
+            records,
+        });
+    }
+
+    let starts: Vec<usize> = (0..parsed.len())
+        .filter(|&start| {
+            parsed[start..]
+                .iter()
+                .map(|resource| resource.byte_count)
+                .sum::<usize>()
+                == chr_size
+        })
+        .collect();
+    if starts.len() != 1 {
+        return Err(Error::Format(format!(
+            "{} does not uniquely partition {} ({} bytes): {} candidate splits",
+            profile.prg,
+            profile.file,
+            chr_size,
+            starts.len()
+        )));
+    }
+    let first = starts[0];
+
+    let mut packages = Vec::with_capacity(parsed.len() - first);
+    let mut file_offset = 0usize;
+    for (position, resource) in parsed.into_iter().enumerate().skip(first) {
+        let banks = read_palette_banks(prg, resource.palette_table_prg_offset);
+        let images = resource
+            .records
+            .iter()
+            .map(|record| ImageRecord {
+                index: record.index,
+                stored_width: record.stored_width,
+                stored_height: record.stored_height,
+                pixel_width: record.stored_width as u32 * 2,
+                pixel_height: record.stored_height as u32 * 2,
+                offset: record.offset,
+                byte_count: record.byte_count,
+                allocation_size: record.allocation_size,
+                file_offset: file_offset + record.offset,
+                sha256: String::new(),
+                file: format!(
+                    "{SPRITES_DIR}/resource-{position:02}/image-{:03}.png",
+                    record.index
+                ),
+            })
+            .collect();
+        packages.push(Package {
+            resource_index: position,
+            image_table_address: resource.image_table_address,
+            image_table_prg_offset: resource.image_table_prg_offset,
+            palette_table_address: resource.palette_table_address,
+            palette_table_prg_offset: resource.palette_table_prg_offset,
+            palette_banks: banks.len(),
+            byte_count: resource.byte_count,
+            file_offset,
+            images,
+        });
+        file_offset += resource.byte_count;
+    }
+    if file_offset != chr_size {
+        return Err(Error::Format(format!(
+            "packages cover {file_offset} bytes of a {chr_size}-byte {}",
+            profile.file
+        )));
+    }
+    Ok((first, packages))
+}
+
+pub fn extract(
+    character: &str,
+    chr_path: &Path,
+    prg_path: Option<&Path>,
+    output_dir: &Path,
+) -> Result<Manifest> {
+    let profile = profile(character)?;
+    let data = std::fs::read(chr_path)?;
+    if data.is_empty() {
+        return Err(Error::Format(format!("{} is empty", chr_path.display())));
+    }
+
+    let atlas = to_linear(&data);
+    let valid_pixels = data.len() * 2;
+    let total_pixels = (atlas.width * atlas.height) as usize;
+
+    let prg = prg_path.map(std::fs::read).transpose()?;
+    let (prg_source, mut packages) = match (prg_path, &prg) {
+        (Some(path), Some(prg)) => {
+            let (first, packages) = read_packages(prg, profile, data.len())?;
+            (
+                Some(PrgSource {
+                    name: file_name(path),
+                    size: prg.len(),
+                    sha256: sha256_hex(prg),
+                    resource_array_offset: profile.resource_array_offset,
+                    resource_count: profile.resource_count,
+                    first_resource: first,
+                }),
+                packages,
+            )
+        }
+        _ => (None, Vec::new()),
+    };
+
+    std::fs::create_dir_all(output_dir)?;
+    image::write_indexed(&output_dir.join(LINEAR_NAME), &atlas)?;
+
+    for package in &mut packages {
+        let banks = prg
+            .as_deref()
+            .map(|prg| read_palette_banks(prg, package.palette_table_prg_offset))
+            .unwrap_or_default();
+        let palette = display_palette(&banks);
+        for record in &mut package.images {
+            record.sha256 =
+                sha256_hex(&data[record.file_offset..record.file_offset + record.byte_count]);
+            image::write_indexed_palette(
+                &safe_join(output_dir, &record.file)?,
+                &record_image(&data, record),
+                palette.as_deref(),
+            )?;
+        }
+    }
+
+    let manifest = Manifest {
+        format: FORMAT.to_string(),
+        version: VERSION,
+        character: profile.name.to_string(),
+        encoding: ENCODING.to_string(),
+        linear: LINEAR_NAME.to_string(),
+        linear_width: atlas.width,
+        linear_height: atlas.height,
+        contact: (!packages.is_empty()).then(|| CONTACT_NAME.to_string()),
+        valid_pixels,
+        padding_pixels: total_pixels - valid_pixels,
+        vdp1: Vdp1 {
+            destination_base: VDP1_BASE,
+            load_offset: profile.vdp1_offset,
+            load_address: VDP1_BASE + profile.vdp1_offset,
+            destination_offset_global: DESTINATION_OFFSET_GLOBAL,
+        },
+        source: Source {
+            name: file_name(chr_path),
+            size: data.len(),
+            sha256: sha256_hex(&data),
+        },
+        prg: prg_source,
+        packages,
+    };
+
+    if let Some(name) = &manifest.contact {
+        let banks = |package: &Package| {
+            prg.as_deref()
+                .map(|prg| read_palette_banks(prg, package.palette_table_prg_offset))
+                .unwrap_or_default()
+        };
+        let sheet = crate::weapon_sheet::build(
+            &manifest,
+            |_, record| record_image(&data, record).pixels,
+            |package| display_palette(&banks(package)),
+        );
+        image::write_rgba(&output_dir.join(name), &sheet)?;
+    }
+
+    let mut json = serde_json::to_string_pretty(&manifest)?;
+    json.push('\n');
+    std::fs::write(output_dir.join(MANIFEST_NAME), json)?;
+    Ok(manifest)
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
+    let path = Path::new(relative);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(Error::Format(format!(
+            "manifest contains an unsafe path: {relative}"
+        )));
+    }
+    Ok(root.join(path))
+}
+
+pub fn load_manifest(manifest_path: &Path) -> Result<Manifest> {
+    let text = std::fs::read_to_string(manifest_path)?;
+    let manifest: Manifest = serde_json::from_str(&text)?;
+    if manifest.format != FORMAT || manifest.version != VERSION {
+        return Err(Error::Format(format!(
+            "{} is not a {FORMAT} v{VERSION} manifest",
+            manifest_path.display()
+        )));
+    }
+    let profile = manifest.profile()?;
+    if manifest.encoding != ENCODING {
+        return Err(Error::Format(format!(
+            "{}: unsupported pixel encoding {:?}",
+            manifest_path.display(),
+            manifest.encoding
+        )));
+    }
+    let vdp1 = &manifest.vdp1;
+    if vdp1.destination_base != VDP1_BASE
+        || vdp1.load_offset != profile.vdp1_offset
+        || vdp1.load_address != VDP1_BASE + profile.vdp1_offset
+        || vdp1.destination_offset_global != DESTINATION_OFFSET_GLOBAL
+    {
+        return Err(Error::Format(format!(
+            "{}: VDP1 destination contract does not match the {} profile",
+            manifest_path.display(),
+            profile.name
+        )));
+    }
+    if manifest.valid_pixels != manifest.source.size * 2 {
+        return Err(Error::Format(format!(
+            "{}: valid_pixels does not match the source size",
+            manifest_path.display()
+        )));
+    }
+    Ok(manifest)
+}
+
+fn check_packages(manifest: &Manifest) -> Result<()> {
+    let mut expected = 0usize;
+    for package in &manifest.packages {
+        if package.file_offset != expected {
+            return Err(Error::Format(format!(
+                "resource {} starts at 0x{:X}, expected 0x{expected:X}",
+                package.resource_index, package.file_offset
+            )));
+        }
+        let end = expected + package.byte_count;
+        if end > manifest.source.size {
+            return Err(Error::Format(format!(
+                "resource {} ends past the end of the CHR",
+                package.resource_index
+            )));
+        }
+        for (position, record) in package.images.iter().enumerate() {
+            if record.index != position {
+                return Err(Error::Format(format!(
+                    "resource {} image indices are not sequential",
+                    package.resource_index
+                )));
+            }
+            if record.file_offset != package.file_offset + record.offset
+                || record.file_offset + record.byte_count > end
+                || record.allocation_size < record.byte_count
+                || record.byte_count
+                    != record.pixel_width as usize * record.pixel_height as usize / 2
+            {
+                return Err(Error::Format(format!(
+                    "resource {} image {} is inconsistent with its package",
+                    package.resource_index, record.index
+                )));
+            }
+        }
+        expected = end;
+    }
+    if !manifest.packages.is_empty() && expected != manifest.source.size {
+        return Err(Error::Format(format!(
+            "packages cover {expected} bytes of a {}-byte CHR",
+            manifest.source.size
+        )));
+    }
+    Ok(())
+}
+
+pub fn rebuild_bytes(manifest_path: &Path) -> Result<Vec<u8>> {
+    let manifest = load_manifest(manifest_path)?;
+    check_packages(&manifest)?;
+    let root = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+
+    let atlas = image::read_indexed(&safe_join(root, &manifest.linear)?)?;
+    if (atlas.width, atlas.height) != (manifest.linear_width, manifest.linear_height) {
+        return Err(Error::Format(format!(
+            "atlas is {}x{}, expected {}x{} (resizing is not supported)",
+            atlas.width, atlas.height, manifest.linear_width, manifest.linear_height
+        )));
+    }
+    if atlas.pixels.len() != manifest.valid_pixels + manifest.padding_pixels {
+        return Err(Error::Format(format!(
+            "atlas holds {} pixels, manifest describes {}",
+            atlas.pixels.len(),
+            manifest.valid_pixels + manifest.padding_pixels
+        )));
+    }
+    if let Some(position) = atlas.pixels[manifest.valid_pixels..]
+        .iter()
+        .position(|&pixel| pixel != 0)
+    {
+        let pixel = manifest.valid_pixels + position;
+        return Err(Error::Format(format!(
+            "{}: pixel ({}, {}) is past the end of the file -- the last row's \
+             padding is visualization only and cannot be edited",
+            manifest.linear,
+            pixel as u32 % manifest.linear_width,
+            pixel as u32 / manifest.linear_width
+        )));
+    }
+
+    let mut out = pack(&atlas.pixels[..manifest.valid_pixels])?;
+
+    for (package, record) in manifest.records() {
+        let start = record.file_offset;
+        let end = start + record.byte_count;
+        if sha256_hex(&out[start..end]) != record.sha256 {
+            return Err(Error::Format(format!(
+                "{} was edited at 0x{start:X}..0x{end:X}, which belongs to \
+                 resource {} image {}; edit {} instead",
+                manifest.linear, package.resource_index, record.index, record.file
+            )));
+        }
+        let sprite = image::read_indexed(&safe_join(root, &record.file)?)?;
+        if (sprite.width, sprite.height) != (record.pixel_width, record.pixel_height) {
+            return Err(Error::Format(format!(
+                "{} is {}x{}, expected {}x{} (resizing is not supported)",
+                record.file, sprite.width, sprite.height, record.pixel_width, record.pixel_height
+            )));
+        }
+        out[start..end].copy_from_slice(&pack(&sprite.pixels)?);
+    }
+
+    if out.len() != manifest.source.size {
+        return Err(Error::Format(format!(
+            "rebuilt {} bytes, retail is {}",
+            out.len(),
+            manifest.source.size
+        )));
+    }
+    Ok(out)
+}
+
+pub fn rebuild(manifest_path: &Path, output_path: &Path) -> Result<Vec<u8>> {
+    let data = rebuild_bytes(manifest_path)?;
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output_path, &data)?;
+    Ok(data)
+}
+
+pub fn verify(manifest_path: &Path, chr_path: &Path) -> Result<()> {
+    let rebuilt = rebuild_bytes(manifest_path)?;
+    let retail = std::fs::read(chr_path)?;
+    if rebuilt == retail {
+        return Ok(());
+    }
+    let detail = if rebuilt.len() != retail.len() {
+        format!("{} bytes rebuilt vs {} retail", rebuilt.len(), retail.len())
+    } else {
+        let at = rebuilt
+            .iter()
+            .zip(&retail)
+            .position(|(a, b)| a != b)
+            .unwrap_or(0);
+        format!("first difference at offset 0x{at:X}")
+    };
+    Err(Error::Mismatch(format!(
+        "rebuilt weapon CHR does not match {} ({detail})",
+        chr_path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nibbles_round_trip_left_pixel_first() {
+        let data: Vec<u8> = (0..=255u8).collect();
+        let pixels = unpack(&data);
+        assert_eq!(&pixels[..4], &[0x0, 0x0, 0x0, 0x1]);
+        assert_eq!(pack(&pixels).unwrap(), data);
+    }
+
+    #[test]
+    fn the_atlas_round_trips_and_pads_the_last_row() {
+        let data: Vec<u8> = (0..(LINEAR_WIDTH as usize / 2) * 3 - 1)
+            .map(|i| (i * 31 + 7) as u8)
+            .collect();
+        let atlas = to_linear(&data);
+        assert_eq!((atlas.width, atlas.height), (LINEAR_WIDTH, 3));
+        assert_eq!(pack(&atlas.pixels[..data.len() * 2]).unwrap(), data);
+        assert_eq!(&atlas.pixels[data.len() * 2..], &[0, 0]);
+    }
+
+    #[test]
+    fn an_index_above_fifteen_is_refused() {
+        let err = pack(&[0, 16]).unwrap_err();
+        assert!(matches!(err, Error::Format(_)), "{err}");
+    }
+
+    #[test]
+    fn every_profile_names_a_distinct_character_and_file() {
+        for profile in PROFILES {
+            assert_eq!(super::profile(profile.name).unwrap().file, profile.file);
+        }
+        assert!(super::profile("dracula").is_err());
+    }
+
+    #[test]
+    fn an_image_table_decodes_offsets_dimensions_and_gaps() {
+        let mut prg = vec![0u8; 64];
+        prg[0..4].copy_from_slice(&[4, 4, 0, 0]);
+        prg[4..8].copy_from_slice(&[2, 3, 0, 8]);
+        prg[8..12].copy_from_slice(&[0, 0, 0, 16]);
+        let (records, size) = parse_image_table(&prg, 0).unwrap();
+        assert_eq!(size, 128);
+        assert_eq!(records.len(), 2);
+        assert_eq!((records[0].offset, records[0].byte_count), (0, 32));
+        assert_eq!(records[0].allocation_size, 64);
+        assert_eq!((records[1].offset, records[1].byte_count), (64, 12));
+        assert_eq!(records[1].allocation_size, 64);
+    }
+
+    #[test]
+    fn overlapping_image_records_are_refused() {
+        let mut prg = vec![0u8; 32];
+        prg[0..4].copy_from_slice(&[4, 4, 0, 0]);
+        prg[4..8].copy_from_slice(&[2, 2, 0, 1]);
+        prg[8..12].copy_from_slice(&[0, 0, 0, 16]);
+        let err = parse_image_table(&prg, 0).unwrap_err();
+        assert!(matches!(err, Error::Format(_)), "{err}");
+    }
+
+    #[test]
+    fn an_unterminated_image_table_is_refused() {
+        let prg = vec![1u8; MAX_IMAGES * 8];
+        let err = parse_image_table(&prg, 0).unwrap_err();
+        assert!(matches!(err, Error::Format(_)), "{err}");
+    }
+
+    #[test]
+    fn rgb555_expands_to_full_range() {
+        let prg = [0x00, 0x01, 0xFC, 0x00, 0x83, 0xE0, 0x80, 0x1F]
+            .into_iter()
+            .chain(std::iter::repeat(0).take(64))
+            .collect::<Vec<u8>>();
+        let banks = read_palette_banks(&prg, 0);
+        assert_eq!(banks.len(), 1);
+        assert_eq!(banks[0][0], [0, 0, 255]);
+        assert_eq!(banks[0][1], [0, 255, 0]);
+        assert_eq!(banks[0][2], [255, 0, 0]);
+        assert_eq!(
+            display_palette(&banks).unwrap().len(),
+            PALETTE_BANK_SIZE * 3
+        );
+    }
+
+    #[test]
+    fn a_path_escaping_the_extract_is_refused() {
+        let root = Path::new("/tmp/extract");
+        assert!(safe_join(root, "sprites/resource-01/image-000.png").is_ok());
+        assert!(safe_join(root, "../../etc/passwd").is_err());
+        assert!(safe_join(root, "/etc/passwd").is_err());
+    }
+}

--- a/tools/saturn/assets/src/weapon_sheet.rs
+++ b/tools/saturn/assets/src/weapon_sheet.rs
@@ -1,0 +1,261 @@
+use crate::image::Rgba;
+use crate::weapon::{ImageRecord, Manifest, Package, PALETTE_BANK_SIZE};
+
+pub const SHEET_WIDTH: u32 = 640;
+const MARGIN: u32 = 8;
+const GUTTER: u32 = 6;
+const HEADER_HEIGHT: u32 = 18;
+const LABEL_HEIGHT: u32 = GLYPH_HEIGHT + 3;
+
+const BACKGROUND: [u8; 4] = [22, 22, 27, 255];
+const HEADER_BAND: [u8; 4] = [50, 50, 62, 255];
+const HEADER_TEXT: [u8; 4] = [236, 236, 246, 255];
+const LABEL_TEXT: [u8; 4] = [140, 140, 158, 255];
+const RECORD_BACKING: [u8; 4] = [38, 38, 46, 255];
+
+const DIGITS: [[u8; 5]; 10] = [
+    [0b111, 0b101, 0b101, 0b101, 0b111],
+    [0b010, 0b110, 0b010, 0b010, 0b111],
+    [0b111, 0b001, 0b111, 0b100, 0b111],
+    [0b111, 0b001, 0b111, 0b001, 0b111],
+    [0b101, 0b101, 0b111, 0b001, 0b001],
+    [0b111, 0b100, 0b111, 0b001, 0b111],
+    [0b111, 0b100, 0b111, 0b101, 0b111],
+    [0b111, 0b001, 0b001, 0b001, 0b001],
+    [0b111, 0b101, 0b111, 0b101, 0b111],
+    [0b111, 0b101, 0b111, 0b001, 0b111],
+];
+const GLYPH_WIDTH: u32 = 3;
+const GLYPH_HEIGHT: u32 = 5;
+const GLYPH_SPACING: u32 = 1;
+
+fn digits_of(value: usize, min_width: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut value = value;
+    while value > 0 {
+        out.push(value % 10);
+        value /= 10;
+    }
+    while out.len() < min_width.max(1) {
+        out.push(0);
+    }
+    out.reverse();
+    out
+}
+
+fn number_width(count: usize, scale: u32) -> u32 {
+    if count == 0 {
+        return 0;
+    }
+    (count as u32) * (GLYPH_WIDTH + GLYPH_SPACING) * scale - GLYPH_SPACING * scale
+}
+
+fn draw_number(
+    sheet: &mut Rgba,
+    x: u32,
+    y: u32,
+    value: usize,
+    min_width: usize,
+    scale: u32,
+    colour: [u8; 4],
+) {
+    let mut cursor = x;
+    for digit in digits_of(value, min_width) {
+        let glyph = DIGITS[digit];
+        for (row, bits) in glyph.iter().enumerate() {
+            for column in 0..GLYPH_WIDTH {
+                if bits & (1 << (GLYPH_WIDTH - 1 - column)) == 0 {
+                    continue;
+                }
+                sheet.fill_rect(
+                    cursor + column * scale,
+                    y + (row as u32) * scale,
+                    scale,
+                    scale,
+                    colour,
+                );
+            }
+        }
+        cursor += (GLYPH_WIDTH + GLYPH_SPACING) * scale;
+    }
+}
+
+struct Placement {
+    x: u32,
+    y: u32,
+}
+
+fn place(records: &[ImageRecord], top: u32) -> (Vec<Placement>, u32) {
+    let mut placements = Vec::with_capacity(records.len());
+    let mut x = MARGIN;
+    let mut y = top;
+    let mut shelf = 0u32;
+    for record in records {
+        let height = record.pixel_height + LABEL_HEIGHT;
+        if x > MARGIN && x + record.pixel_width > SHEET_WIDTH - MARGIN {
+            x = MARGIN;
+            y += shelf + GUTTER;
+            shelf = 0;
+        }
+        placements.push(Placement { x, y });
+        x += record.pixel_width + GUTTER;
+        shelf = shelf.max(height);
+    }
+    (placements, y + shelf - top)
+}
+
+fn colour_of(palette: Option<&Vec<u8>>, index: u8) -> [u8; 4] {
+    if index == 0 {
+        return RECORD_BACKING;
+    }
+    match palette {
+        Some(rgb) if rgb.len() == PALETTE_BANK_SIZE * 3 => {
+            let at = index as usize * 3;
+            [rgb[at], rgb[at + 1], rgb[at + 2], 255]
+        }
+        _ => {
+            let level = index * 17;
+            [level, level, level, 255]
+        }
+    }
+}
+
+fn draw_record(
+    sheet: &mut Rgba,
+    at: &Placement,
+    record: &ImageRecord,
+    pixels: &[u8],
+    palette: Option<&Vec<u8>>,
+) {
+    sheet.fill_rect(
+        at.x,
+        at.y,
+        record.pixel_width,
+        record.pixel_height,
+        RECORD_BACKING,
+    );
+    for y in 0..record.pixel_height {
+        for x in 0..record.pixel_width {
+            let index = pixels[(y * record.pixel_width + x) as usize];
+            sheet.set(at.x + x, at.y + y, colour_of(palette, index));
+        }
+    }
+    draw_number(
+        sheet,
+        at.x,
+        at.y + record.pixel_height + 2,
+        record.index,
+        1,
+        1,
+        LABEL_TEXT,
+    );
+}
+
+pub fn build<'a>(
+    manifest: &'a Manifest,
+    pixels_of: impl Fn(&Package, &ImageRecord) -> Vec<u8>,
+    palette_of: impl Fn(&Package) -> Option<Vec<u8>>,
+) -> Rgba {
+    let mut height = MARGIN;
+    let mut groups = Vec::with_capacity(manifest.packages.len());
+    for package in &manifest.packages {
+        height += HEADER_HEIGHT;
+        let (placements, used) = place(&package.images, height);
+        groups.push(placements);
+        height += used + GUTTER * 2;
+    }
+    height = height.max(MARGIN * 2);
+
+    let mut sheet = Rgba::new(SHEET_WIDTH, height, BACKGROUND);
+    let mut cursor = MARGIN;
+    for (package, placements) in manifest.packages.iter().zip(&groups) {
+        sheet.fill_rect(0, cursor, SHEET_WIDTH, HEADER_HEIGHT, HEADER_BAND);
+        draw_number(
+            &mut sheet,
+            MARGIN,
+            cursor + 4,
+            package.resource_index,
+            2,
+            2,
+            HEADER_TEXT,
+        );
+        let after = MARGIN + number_width(2, 2) + 8;
+        draw_number(
+            &mut sheet,
+            after,
+            cursor + 7,
+            package.images.len(),
+            1,
+            1,
+            LABEL_TEXT,
+        );
+        cursor += HEADER_HEIGHT;
+
+        let palette = palette_of(package);
+        let mut used = 0;
+        for (record, at) in package.images.iter().zip(placements) {
+            draw_record(
+                &mut sheet,
+                at,
+                record,
+                &pixels_of(package, record),
+                palette.as_ref(),
+            );
+            used = used.max(at.y + record.pixel_height + LABEL_HEIGHT - cursor);
+        }
+        cursor += used + GUTTER * 2;
+    }
+    sheet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digits_pad_and_order_most_significant_first() {
+        assert_eq!(digits_of(0, 2), vec![0, 0]);
+        assert_eq!(digits_of(7, 2), vec![0, 7]);
+        assert_eq!(digits_of(123, 2), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn a_number_is_drawn_inside_its_measured_width() {
+        let mut sheet = Rgba::new(64, 16, BACKGROUND);
+        draw_number(&mut sheet, 0, 0, 90, 2, 1, HEADER_TEXT);
+        let width = number_width(2, 1);
+        assert!((0..width).any(|x| (0..GLYPH_HEIGHT).any(|y| lit(&sheet, x, y))));
+        assert!(!(width..64).any(|x| (0..16).any(|y| lit(&sheet, x, y))));
+    }
+
+    fn lit(sheet: &Rgba, x: u32, y: u32) -> bool {
+        let at = ((y * sheet.width + x) * 4) as usize;
+        sheet.pixels[at..at + 4] != BACKGROUND
+    }
+
+    #[test]
+    fn records_wrap_onto_a_new_shelf_instead_of_running_off_the_sheet() {
+        let record = |index: usize, width: u32| ImageRecord {
+            index,
+            stored_width: (width / 2) as u8,
+            stored_height: 8,
+            pixel_width: width,
+            pixel_height: 16,
+            offset: 0,
+            byte_count: 0,
+            allocation_size: 0,
+            file_offset: 0,
+            sha256: String::new(),
+            file: String::new(),
+        };
+        let records = vec![record(0, 300), record(1, 300), record(2, 300)];
+        let (placements, height) = place(&records, 0);
+        assert_eq!(placements[0].y, placements[1].y, "two fit on one shelf");
+        assert!(placements[2].y > placements[1].y, "the third must wrap");
+        assert!(
+            placements[2].x == MARGIN,
+            "a wrapped record starts at the margin"
+        );
+        assert!(height >= (16 + LABEL_HEIGHT) * 2);
+    }
+}

--- a/tools/saturn/assets/tests/retail_weapons.rs
+++ b/tools/saturn/assets/tests/retail_weapons.rs
@@ -1,0 +1,282 @@
+use saturn_assets::{image, weapon};
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("crate is three levels below the repo root")
+        .to_path_buf()
+}
+
+fn available() -> Vec<(&'static weapon::Profile, PathBuf, PathBuf)> {
+    let dir = repo_root().join("disks/saturn");
+    weapon::PROFILES
+        .iter()
+        .filter_map(|profile| {
+            let chr = dir.join(profile.file);
+            let prg = dir.join(profile.prg);
+            (chr.exists() && prg.exists()).then_some((profile, chr, prg))
+        })
+        .collect()
+}
+
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("saturn-weapon-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn one_extract(name: &str) -> Option<(PathBuf, PathBuf, weapon::Manifest)> {
+    let (profile, chr, prg) = available().into_iter().next()?;
+    let out = scratch(name);
+    let manifest = weapon::extract(profile.name, &chr, Some(&prg), &out).expect("extract");
+    Some((out, chr, manifest))
+}
+
+#[test]
+fn every_retail_weapon_chr_round_trips_byte_for_byte() {
+    let profiles = available();
+    if profiles.is_empty() {
+        eprintln!("skipping: no weapon CHR/PRG pairs present");
+        return;
+    }
+
+    let mut failures = Vec::new();
+    for (profile, chr, prg) in &profiles {
+        let out = scratch(profile.name);
+        match weapon::extract(profile.name, chr, Some(prg), &out) {
+            Ok(manifest) => {
+                if manifest.packages.is_empty() {
+                    failures.push(format!("{}: no packages found", profile.name));
+                }
+                let covered: usize = manifest.packages.iter().map(|p| p.byte_count).sum();
+                if covered != manifest.source.size {
+                    failures.push(format!(
+                        "{}: packages cover {covered} of {} bytes",
+                        profile.name, manifest.source.size
+                    ));
+                }
+                for (_, record) in manifest.records() {
+                    if !out.join(&record.file).exists() {
+                        failures.push(format!("{}: {} missing", profile.name, record.file));
+                    }
+                }
+                if let Err(e) = weapon::verify(&out.join(weapon::MANIFEST_NAME), chr) {
+                    failures.push(format!("{}: {e}", profile.name));
+                }
+            }
+            Err(e) => failures.push(format!("{}: extract: {e}", profile.name)),
+        }
+        std::fs::remove_dir_all(&out).ok();
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} weapon CHRs did not round-trip:\n  {}",
+        failures.len(),
+        profiles.len(),
+        failures.join("\n  ")
+    );
+    eprintln!("{} weapon CHRs round-tripped byte-exactly", profiles.len());
+}
+
+#[test]
+fn an_edited_sprite_reaches_exactly_its_own_bytes() {
+    let Some((out, chr, manifest_data)) = one_extract("sprite-edit") else {
+        eprintln!("skipping: no weapon CHR/PRG pairs present");
+        return;
+    };
+    let manifest = out.join(weapon::MANIFEST_NAME);
+    weapon::verify(&manifest, &chr).expect("unedited verify");
+
+    let (_, record) = manifest_data
+        .records()
+        .max_by_key(|(_, record)| record.byte_count)
+        .expect("at least one image record");
+    let sprite_path = out.join(&record.file);
+    let mut sprite = image::read_indexed(&sprite_path).expect("read sprite");
+    let before = sprite.get(1, 1);
+    sprite.set(1, 1, if before == 15 { 0 } else { before + 1 });
+    image::write_indexed(&sprite_path, &sprite).expect("write sprite");
+
+    let rebuilt = weapon::rebuild_bytes(&manifest).expect("rebuild");
+    let retail = std::fs::read(&chr).expect("read CHR");
+    assert_eq!(rebuilt.len(), retail.len(), "CHR changed size");
+    assert_ne!(rebuilt, retail, "the sprite edit was dropped");
+
+    let moved: Vec<usize> = rebuilt
+        .iter()
+        .zip(&retail)
+        .enumerate()
+        .filter(|(_, (a, b))| a != b)
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(moved.len(), 1, "one pixel touched {} bytes", moved.len());
+    let inside = record.file_offset..record.file_offset + record.byte_count;
+    assert!(
+        inside.contains(&moved[0]),
+        "edit landed at 0x{:X}, outside {} at 0x{:X}..0x{:X}",
+        moved[0],
+        record.file,
+        inside.start,
+        inside.end
+    );
+    assert!(
+        weapon::verify(&manifest, &chr).is_err(),
+        "verify passed on an edited sprite"
+    );
+
+    std::fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn a_linear_edit_in_an_unclaimed_byte_reaches_the_file() {
+    let Some((out, chr, manifest_data)) = one_extract("linear-gap") else {
+        eprintln!("skipping: no weapon CHR/PRG pairs present");
+        return;
+    };
+    let manifest = out.join(weapon::MANIFEST_NAME);
+
+    let gap = manifest_data.records().find_map(|(_, record)| {
+        (record.allocation_size > record.byte_count)
+            .then_some(record.file_offset + record.byte_count)
+    });
+    let Some(gap) = gap else {
+        eprintln!("skipping: this build's image tables leave no gaps");
+        std::fs::remove_dir_all(&out).ok();
+        return;
+    };
+
+    let linear_path = out.join(&manifest_data.linear);
+    let mut linear = image::read_indexed(&linear_path).expect("read linear dump");
+    let pixel = gap * 2;
+    let (x, y) = (
+        pixel as u32 % manifest_data.linear_width,
+        pixel as u32 / manifest_data.linear_width,
+    );
+    let before = linear.get(x, y);
+    linear.set(x, y, if before == 15 { 0 } else { before + 1 });
+    image::write_indexed(&linear_path, &linear).expect("write linear dump");
+
+    let rebuilt = weapon::rebuild_bytes(&manifest).expect("rebuild");
+    let retail = std::fs::read(&chr).expect("read CHR");
+    assert_eq!(rebuilt.len(), retail.len(), "CHR changed size");
+    assert_ne!(
+        rebuilt[gap], retail[gap],
+        "the linear-dump edit was dropped"
+    );
+    assert_eq!(
+        rebuilt.iter().zip(&retail).filter(|(a, b)| a != b).count(),
+        1,
+        "a linear-dump edit in a gap touched more than its own byte"
+    );
+
+    std::fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn a_linear_edit_inside_a_record_is_refused_by_name() {
+    let Some((out, _chr, manifest_data)) = one_extract("linear-claimed") else {
+        eprintln!("skipping: no weapon CHR/PRG pairs present");
+        return;
+    };
+    let manifest = out.join(weapon::MANIFEST_NAME);
+    let (_, record) = manifest_data
+        .records()
+        .max_by_key(|(_, record)| record.byte_count)
+        .expect("at least one image record");
+
+    let linear_path = out.join(&manifest_data.linear);
+    let mut linear = image::read_indexed(&linear_path).expect("read linear dump");
+    let pixel = record.file_offset * 2;
+    let (x, y) = (
+        pixel as u32 % manifest_data.linear_width,
+        pixel as u32 / manifest_data.linear_width,
+    );
+    let before = linear.get(x, y);
+    linear.set(x, y, if before == 15 { 0 } else { before + 1 });
+    image::write_indexed(&linear_path, &linear).expect("write linear dump");
+
+    let err = weapon::rebuild_bytes(&manifest).expect_err("rebuild accepted a two-writer edit");
+    let message = err.to_string();
+    assert!(
+        message.contains(&record.file),
+        "the refusal must name the file to edit instead, got: {message}"
+    );
+
+    std::fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn an_edit_to_the_linear_padding_is_refused() {
+    let row_bytes = weapon::LINEAR_WIDTH as u64 / 2;
+    let Some((profile, chr, prg)) = available()
+        .into_iter()
+        .find(|(_, chr, _)| std::fs::metadata(chr).is_ok_and(|meta| meta.len() % row_bytes != 0))
+    else {
+        eprintln!("skipping: no weapon CHR has a partial final row");
+        return;
+    };
+    let out = scratch("padding");
+    let manifest_data = weapon::extract(profile.name, &chr, Some(&prg), &out).expect("extract");
+    assert!(manifest_data.padding_pixels > 0, "expected padding");
+    let manifest = out.join(weapon::MANIFEST_NAME);
+    weapon::verify(&manifest, &chr).expect("unedited verify");
+
+    let linear_path = out.join(&manifest_data.linear);
+    let mut linear = image::read_indexed(&linear_path).expect("read linear dump");
+    let pixel = manifest_data.valid_pixels;
+    linear.set(
+        pixel as u32 % manifest_data.linear_width,
+        pixel as u32 / manifest_data.linear_width,
+        7,
+    );
+    image::write_indexed(&linear_path, &linear).expect("write linear dump");
+
+    let err = weapon::rebuild_bytes(&manifest).expect_err("rebuild accepted painted padding");
+    assert!(
+        err.to_string().contains("padding"),
+        "the refusal must explain the padding, got: {err}"
+    );
+
+    std::fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn the_contact_sheet_is_written_and_owns_nothing() {
+    let Some((out, chr, manifest_data)) = one_extract("contact") else {
+        eprintln!("skipping: no weapon CHR/PRG pairs present");
+        return;
+    };
+    let manifest = out.join(weapon::MANIFEST_NAME);
+    let name = manifest_data
+        .contact
+        .as_ref()
+        .expect("a sheet was declared");
+    let sheet = out.join(name);
+    assert!(sheet.exists(), "{name} was declared but not written");
+
+    let mut scribbled = image::Rgba::new(64, 64, [255, 0, 255, 255]);
+    scribbled.fill_rect(0, 0, 64, 64, [0, 255, 0, 255]);
+    image::write_rgba(&sheet, &scribbled).expect("overwrite sheet");
+    weapon::verify(&manifest, &chr).expect("a derived sheet must not affect the rebuild");
+
+    std::fs::remove_dir_all(&out).ok();
+}
+
+#[test]
+fn an_extract_without_a_prg_still_round_trips() {
+    let Some((profile, chr, _)) = available().into_iter().next() else {
+        eprintln!("skipping: no weapon CHR present");
+        return;
+    };
+    let out = scratch("no-prg");
+    let manifest_data = weapon::extract(profile.name, &chr, None, &out).expect("extract");
+    assert!(manifest_data.packages.is_empty());
+    assert!(manifest_data.prg.is_none());
+    assert!(manifest_data.contact.is_none());
+    weapon::verify(&out.join(weapon::MANIFEST_NAME), &chr).expect("verify");
+    std::fs::remove_dir_all(&out).ok();
+}

--- a/tools/sotn-assets/saturn_assets.go
+++ b/tools/sotn-assets/saturn_assets.go
@@ -30,6 +30,8 @@ type saturnAsset struct {
 	Codec string `yaml:"codec"`
 	// retail file
 	Source string `yaml:"source"`
+	// the player overlay whose tables partition a weapon CHR
+	Prg string `yaml:"prg"`
 	// or a directory of retail files
 	Dir   string   `yaml:"dir"`
 	Files []string `yaml:"files"`
@@ -47,6 +49,7 @@ type saturnUnit struct {
 	source  string
 	path    string
 	output  string
+	prg     string
 }
 
 const saturnAssetOutputDir = "build/saturn/assets"
@@ -64,6 +67,15 @@ func (a saturnAsset) variant() (string, error) {
 			return "", fmt.Errorf("asset %q: audio needs a codec", a.Name)
 		}
 		return a.Codec, nil
+	case "weapon":
+		if a.Profile == "" {
+			return "", fmt.Errorf("asset %q: weapon needs a profile", a.Name)
+		}
+		// prg has the info to cut the chr into sprites
+		if a.Prg == "" {
+			return "", fmt.Errorf("asset %q: weapon needs the player prg", a.Name)
+		}
+		return a.Profile, nil
 	default:
 		return "", fmt.Errorf("unknown Saturn asset kind %q in asset %q", a.Kind, a.Name)
 	}
@@ -90,6 +102,7 @@ func (a saturnAsset) units() ([]saturnUnit, error) {
 			source:  a.Source,
 			path:    a.Path,
 			output:  output,
+			prg:     a.Prg,
 		}}, nil
 	}
 
@@ -160,7 +173,12 @@ func saturnUnitArgs(u saturnUnit, command string) ([]string, error) {
 	manifest := filepath.Join(u.path, "manifest.json")
 	switch command {
 	case "extract":
-		return []string{u.kind, "extract", u.variant, u.source, u.path}, nil
+		args := []string{u.kind, "extract", u.variant, u.source, u.path}
+		// weapon chr uses tables in player prg
+		if u.kind == "weapon" {
+			args = append(args, "--prg", u.prg)
+		}
+		return args, nil
 	case "rebuild":
 		return []string{u.kind, "rebuild", manifest, u.output}, nil
 	case "verify":


### PR DESCRIPTION
This adds player W_CHR file extraction to the assets tool. Example:
<img width="640" height="796" alt="contact" src="https://github.com/user-attachments/assets/5e20ff50-c3c7-462c-9657-a90079ac5e89" />
