### PR TITLE
Start endian work, tests

### DIFF
--- a/.github/workflows/endian-tests.yml
+++ b/.github/workflows/endian-tests.yml
@@ -1,0 +1,23 @@
+name: Endian tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  endian-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install big-endian toolchains and emulators
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-powerpc-linux-gnu g++-powerpc-linux-gnu \
+            gcc-s390x-linux-gnu g++-s390x-linux-gnu \
+            qemu-user
+      - name: Run native, sanitized, optimized, and big-endian tests
+        run: tests/endian/run-matrix.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,15 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(CTest)
+option(SOTN_ENDIAN_TESTS_ONLY
+       "Configure only the dependency-light endian regression tests" OFF)
+
+if(SOTN_ENDIAN_TESTS_ONLY)
+    add_subdirectory(tests/endian)
+    return()
+endif()
+
 if (WIN32)
     set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 endif()
@@ -1055,3 +1064,7 @@ endforeach()
 add_overlay(tt_000 ${SOURCE_FILES_TT_000})
 add_overlay(tt_001 ${SOURCE_FILES_TT_001})
 add_overlay(tt_002 ${SOURCE_FILES_TT_002})
+
+if(BUILD_TESTING)
+    add_subdirectory(tests/endian)
+endif()

--- a/include/common.h
+++ b/include/common.h
@@ -105,12 +105,18 @@
 // Converts a given value to a fixed-point value, where
 // 16 bits represents the integer part and 16 bits for fractional part
 #define FIX(x) ((s32)((x) * 65536.0))
+#if defined(_MIPSEL) || defined(__MWERKS__)
 // Get the integer part of such a fixed-point value
 #define FIX_TO_I(x) ((s32)((x) >> 16))
 // Convert an integer value to fixed-point
 #define I_TO_FIX(x) ((s32)((x) << 16))
 // Get the fractional part of such a fixed-point value
 #define FIX_FRAC(x) (*(s16*)&(x))
+#else
+#define FIX_TO_I(x) ((s32)(s16)((u32)(x) >> 16))
+#define I_TO_FIX(x) ((s32)((u32)(s32)(x) << 16))
+#define FIX_FRAC(x) (F(x).i.lo)
+#endif
 
 // The second argument to CreateEntFactoryFromEntity has weird bit packing,
 // this takes the 2 relevant inputs and packs them up.

--- a/include/endian_utils.h
+++ b/include/endian_utils.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#ifndef SOTN_ENDIAN_UTILS_H
+#define SOTN_ENDIAN_UTILS_H
+
+#include "types.h"
+
+static inline u8 SotnNumericLowU8(u32 value) { return (u8)value; }
+
+static inline u16 SotnNumericLowU16(u32 value) { return (u16)value; }
+
+static inline s16 SotnNumericLowS16(s32 value) { return (s16)(u16)value; }
+
+static inline u16 SotnNumericHighU16(u32 value) { return (u16)(value >> 16); }
+
+static inline s16 SotnNumericHighS16(s32 value) {
+    return (s16)(u16)((u32)value >> 16);
+}
+
+static inline s16 SotnFixedInteger(s32 value) {
+    return SotnNumericHighS16(value);
+}
+
+#endif

--- a/include/sotn_endian.h
+++ b/include/sotn_endian.h
@@ -7,7 +7,8 @@
 #define SOTN_BIG_ENDIAN 1
 #elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define SOTN_BIG_ENDIAN 0
-#elif defined(_WIN32) || defined(_MIPSEL) || defined(VERSION)
+#elif defined(_WIN32) || defined(_MIPSEL) || defined(__MWERKS__) ||            \
+    defined(VERSION)
 #define SOTN_BIG_ENDIAN 0
 #else
 #error "Unable to determine target byte order"

--- a/include/sotn_endian.h
+++ b/include/sotn_endian.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#ifndef SOTN_ENDIAN_H
+#define SOTN_ENDIAN_H
+
+#ifndef SOTN_BIG_ENDIAN
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define SOTN_BIG_ENDIAN 1
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define SOTN_BIG_ENDIAN 0
+#elif defined(_WIN32) || defined(_MIPSEL) || defined(VERSION)
+#define SOTN_BIG_ENDIAN 0
+#else
+#error "Unable to determine target byte order"
+#endif
+#endif
+
+#if SOTN_BIG_ENDIAN != 0 && SOTN_BIG_ENDIAN != 1
+#error "SOTN_BIG_ENDIAN must be 0 or 1"
+#endif
+
+#endif

--- a/include/types.h
+++ b/include/types.h
@@ -74,19 +74,31 @@ typedef signed int bool;
 #define S32_MAX INT32_MAX
 #define S16_MAX INT16_MAX
 
+#include "sotn_endian.h"
+
 typedef union {
     s32 val;
     struct {
+#if SOTN_BIG_ENDIAN
+        s16 hi;
+        s16 lo;
+#else
         s16 lo;
         s16 hi;
+#endif
     } i;
 } f32;
 
 typedef union {
     s16 val;
     struct {
+#if SOTN_BIG_ENDIAN
+        u8 hi;
+        u8 lo;
+#else
         u8 lo;
         u8 hi;
+#endif
     } i;
 } f16;
 

--- a/include/types.h
+++ b/include/types.h
@@ -58,6 +58,26 @@ typedef signed char byte;
 typedef unsigned short ushort;
 typedef unsigned int uint;
 
+// use negative array trick for compilers that can't _Static_assert
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define SOTN_STATIC_ASSERT(cond, name) static_assert(cond, #name)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L &&              \
+    (!defined(__GNUC__) || __GNUC__ >= 4)
+#define SOTN_STATIC_ASSERT(cond, name) _Static_assert(cond, #name)
+#else
+#define SOTN_STATIC_ASSERT(cond, name)                                         \
+    typedef char sotn_static_assert_##name[(cond) ? 1 : -1]
+#endif
+
+SOTN_STATIC_ASSERT(sizeof(s8) == 1, s8_is_1_byte);
+SOTN_STATIC_ASSERT(sizeof(u8) == 1, u8_is_1_byte);
+SOTN_STATIC_ASSERT(sizeof(s16) == 2, s16_is_2_bytes);
+SOTN_STATIC_ASSERT(sizeof(u16) == 2, u16_is_2_bytes);
+SOTN_STATIC_ASSERT(sizeof(s32) == 4, s32_is_4_bytes);
+SOTN_STATIC_ASSERT(sizeof(u32) == 4, u32_is_4_bytes);
+SOTN_STATIC_ASSERT(sizeof(s64) == 8, s64_is_8_bytes);
+SOTN_STATIC_ASSERT(sizeof(u64) == 8, u64_is_8_bytes);
+
 #ifdef VERSION_PC
 #include <stdbool.h>
 #else
@@ -101,6 +121,9 @@ typedef union {
 #endif
     } i;
 } f16;
+
+SOTN_STATIC_ASSERT(sizeof(f32) == 4, f32_is_4_bytes);
+SOTN_STATIC_ASSERT(sizeof(f16) == 2, f16_is_2_bytes);
 
 typedef struct {
     /* 0x0 */ s16 x;

--- a/tests/endian/CMakeLists.txt
+++ b/tests/endian/CMakeLists.txt
@@ -1,0 +1,45 @@
+add_executable(sotn_endian_tests
+    test_endian.c
+    common/test_endian_utils.c
+    common/test_types.c
+)
+
+option(SOTN_ENDIAN_SANITIZERS
+       "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+target_include_directories(sotn_endian_tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_compile_definitions(sotn_endian_tests PRIVATE
+    VERSION_PC
+    PERMUTER
+    NON_MATCHING
+    HARD_LINK
+    _internal_version_us
+    __psyz
+    NO_LOGS
+)
+
+if(MSVC)
+    target_compile_options(sotn_endian_tests PRIVATE /W4)
+else()
+    target_compile_options(sotn_endian_tests PRIVATE
+        -Wall
+        -Wextra
+        -Werror
+        -funsigned-char
+    )
+    if(SOTN_ENDIAN_SANITIZERS)
+        target_compile_options(sotn_endian_tests PRIVATE
+            -fsanitize=address,undefined
+            -fno-omit-frame-pointer
+        )
+        target_link_options(sotn_endian_tests PRIVATE
+            -fsanitize=address,undefined
+        )
+    endif()
+endif()
+
+add_test(NAME endian.contracts COMMAND sotn_endian_tests)

--- a/tests/endian/common/test_endian_utils.c
+++ b/tests/endian/common/test_endian_utils.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "test_common.h"
+
+void test_numeric_parts(void) {
+    const u32 value = UINT32_C(0x12345678);
+    const s32 negative = (s32)UINT32_C(0xFFFEA000);
+
+    CHECK_EQ_HEX("numeric.low_u8", 0x78, SotnNumericLowU8(value));
+    CHECK_EQ_HEX("numeric.low_u16", 0x5678, SotnNumericLowU16(value));
+    CHECK_EQ_S32("numeric.low_s16", 0x5678,
+                 SotnNumericLowS16((s32)value));
+    CHECK_EQ_HEX("numeric.high_u16", 0x1234, SotnNumericHighU16(value));
+    CHECK_EQ_S32("numeric.high_s16", 0x1234,
+                 SotnNumericHighS16((s32)value));
+    CHECK_EQ_S32("numeric.high_s16.negative", -2,
+                 SotnNumericHighS16(negative));
+    CHECK_EQ_S32("numeric.low_s16.negative", (s16)UINT16_C(0xA000),
+                 SotnNumericLowS16(negative));
+    CHECK_EQ_S32("fixed.integer.negative", -2,
+                 SotnFixedInteger(negative));
+    CHECK_EQ_S32("fixed_to_i.negative", -2, FIX_TO_I(negative));
+    CHECK_EQ_HEX("i_to_fix.negative", UINT32_C(0xFFFC0000),
+                 (u32)I_TO_FIX(-4));
+}

--- a/tests/endian/common/test_types.c
+++ b/tests/endian/common/test_types.c
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "test_common.h"
+
+_Static_assert(sizeof(s8) == 1, "s8 must be 8 bits");
+_Static_assert(sizeof(u8) == 1, "u8 must be 8 bits");
+_Static_assert(sizeof(s16) == 2, "s16 must be 16 bits");
+_Static_assert(sizeof(u16) == 2, "u16 must be 16 bits");
+_Static_assert(sizeof(s32) == 4, "s32 must be 32 bits");
+_Static_assert(sizeof(u32) == 4, "u32 must be 32 bits");
+_Static_assert(sizeof(f16) == 2, "f16 must be 2 bytes");
+_Static_assert(sizeof(f32) == 4, "f32 must be 4 bytes");
+
+void test_target_byte_order(void) {
+    const uint32_t value = UINT32_C(0x01020304);
+    uint8_t bytes[sizeof(value)];
+
+    memcpy(bytes, &value, sizeof(bytes));
+#if SOTN_BIG_ENDIAN
+    CHECK_EQ_HEX("target.byte_order.big", 0x01, bytes[0]);
+#else
+    CHECK_EQ_HEX("target.byte_order.little", 0x04, bytes[0]);
+#endif
+}
+
+void test_f32_read_views(void) {
+    static const struct {
+        uint32_t val;
+        int16_t hi;
+        uint16_t lo;
+    } cases[] = {
+        {UINT32_C(0x12345678), INT16_C(0x1234), UINT16_C(0x5678)},
+        {UINT32_C(0xFFFF8000), INT16_C(-1), UINT16_C(0x8000)},
+        {UINT32_C(0x80000001), INT16_MIN, UINT16_C(0x0001)},
+        {UINT32_C(0x007B4567), INT16_C(123), UINT16_C(0x4567)},
+        {UINT32_C(0xFFFE4000), INT16_C(-2), UINT16_C(0x4000)},
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        f32 value;
+        memcpy(&value.val, &cases[i].val, sizeof(value.val));
+        CHECK_EQ_S32("f32.read.hi", cases[i].hi, value.i.hi);
+        CHECK_EQ_HEX("f32.read.lo", cases[i].lo, s16_bits(value.i.lo));
+    }
+}
+
+void test_f32_write_views(void) {
+    f32 value;
+
+    value.val = (s32)UINT32_C(0x12345678);
+    value.i.hi = (s16)UINT16_C(0x9ABC);
+    CHECK_EQ_HEX("f32.write.hi.value", UINT32_C(0x9ABC5678),
+                 f32_bits(value));
+    CHECK_EQ_HEX("f32.write.hi.preserve_lo", UINT16_C(0x5678),
+                 s16_bits(value.i.lo));
+
+    value.i.lo = (s16)UINT16_C(0xDEF0);
+    CHECK_EQ_HEX("f32.write.lo.value", UINT32_C(0x9ABCDEF0),
+                 f32_bits(value));
+    CHECK_EQ_HEX("f32.write.lo.preserve_hi", UINT16_C(0x9ABC),
+                 s16_bits(value.i.hi));
+
+    value.i.lo = 0;
+    CHECK_EQ_HEX("f32.clear.fraction", UINT32_C(0x9ABC0000),
+                 f32_bits(value));
+}
+
+void test_f16_views(void) {
+    static const uint16_t cases[] = {0x1234, 0x80FF, 0xFFFF};
+    size_t i;
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        f16 value;
+        memcpy(&value.val, &cases[i], sizeof(value.val));
+        CHECK_EQ_HEX("f16.read.hi", cases[i] >> 8, value.i.hi);
+        CHECK_EQ_HEX("f16.read.lo", cases[i] & 0xFF, value.i.lo);
+    }
+
+    {
+        f16 value;
+        value.val = (s16)UINT16_C(0x1234);
+        value.i.hi = 0xAB;
+        CHECK_EQ_HEX("f16.write.hi", UINT16_C(0xAB34),
+                     s16_bits(value.val));
+        value.i.lo = 0xCD;
+        CHECK_EQ_HEX("f16.write.lo", UINT16_C(0xABCD),
+                     s16_bits(value.val));
+    }
+}
+
+void test_fixed_arithmetic(void) {
+    f32 value;
+
+    value.val = FIX(10.75);
+    value.val += FIX(0.5);
+    CHECK_EQ_HEX("fixed.positive_carry.val", UINT32_C(0x000B4000),
+                 f32_bits(value));
+    CHECK_EQ_S32("fixed.positive_carry.hi", 11, value.i.hi);
+
+    value.val = FIX(-1.25);
+    value.val += FIX(-0.875);
+    CHECK_EQ_HEX("fixed.negative_borrow.val", UINT32_C(0xFFFDE000),
+                 f32_bits(value));
+    CHECK_EQ_S32("fixed.negative_borrow.hi", -3, value.i.hi);
+
+    value.val = FIX(-0.25);
+    value.val += FIX(0.5);
+    CHECK_EQ_HEX("fixed.zero_crossing.val", UINT32_C(0x00004000),
+                 f32_bits(value));
+    CHECK_EQ_S32("fixed.zero_crossing.hi", 0, value.i.hi);
+}
+
+void test_fix_frac(void) {
+    s32 positive = (s32)UINT32_C(0x007B4567);
+    s32 negative = (s32)UINT32_C(0xFFFEA000);
+
+    CHECK_EQ_HEX("fix_frac.positive", UINT16_C(0x4567),
+                 s16_bits(FIX_FRAC(positive)));
+    CHECK_EQ_HEX("fix_frac.negative", UINT16_C(0xA000),
+                 s16_bits(FIX_FRAC(negative)));
+    FIX_FRAC(positive) = (s16)UINT16_C(0xBEEF);
+    CHECK_EQ_HEX("fix_frac.write", UINT32_C(0x007BBEEF), (u32)positive);
+}

--- a/tests/endian/common/test_types.c
+++ b/tests/endian/common/test_types.c
@@ -1,15 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "test_common.h"
 
-_Static_assert(sizeof(s8) == 1, "s8 must be 8 bits");
-_Static_assert(sizeof(u8) == 1, "u8 must be 8 bits");
-_Static_assert(sizeof(s16) == 2, "s16 must be 16 bits");
-_Static_assert(sizeof(u16) == 2, "u16 must be 16 bits");
-_Static_assert(sizeof(s32) == 4, "s32 must be 32 bits");
-_Static_assert(sizeof(u32) == 4, "u32 must be 32 bits");
-_Static_assert(sizeof(f16) == 2, "f16 must be 2 bytes");
-_Static_assert(sizeof(f32) == 4, "f32 must be 4 bytes");
-
 void test_target_byte_order(void) {
     const uint32_t value = UINT32_C(0x01020304);
     uint8_t bytes[sizeof(value)];

--- a/tests/endian/run-matrix.sh
+++ b/tests/endian/run-matrix.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+build_root=${SOTN_ENDIAN_BUILD_ROOT:-"${repo_root}/build/endian-matrix"}
+
+run_native() {
+    local name=$1
+    shift
+    cmake -S "${repo_root}" -B "${build_root}/${name}" \
+        -DSOTN_ENDIAN_TESTS_ONLY=ON "$@"
+    cmake --build "${build_root}/${name}" --parallel
+    ctest --test-dir "${build_root}/${name}" --output-on-failure
+}
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "endian test matrix requires '$1'" >&2
+        exit 1
+    fi
+}
+
+run_cross() {
+    local name=$1
+    local prefix=$2
+    local qemu=$3
+    local sysroot=$4
+
+    require_tool "${prefix}-gcc"
+    require_tool "${prefix}-g++"
+    require_tool "${qemu}"
+    cmake -S "${repo_root}" -B "${build_root}/${name}" \
+        -DSOTN_ENDIAN_TESTS_ONLY=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_SYSTEM_NAME=Linux \
+        -DCMAKE_C_COMPILER="${prefix}-gcc" \
+        -DCMAKE_CXX_COMPILER="${prefix}-g++" \
+        -DCMAKE_CROSSCOMPILING_EMULATOR="${qemu};-L;${sysroot}"
+    cmake --build "${build_root}/${name}" --parallel
+    ctest --test-dir "${build_root}/${name}" --output-on-failure
+}
+
+run_native native-debug -DCMAKE_BUILD_TYPE=Debug
+run_native native-sanitized -DCMAKE_BUILD_TYPE=Debug \
+    -DSOTN_ENDIAN_SANITIZERS=ON
+run_native native-optimized -DCMAKE_BUILD_TYPE=Release
+run_cross s390x-be s390x-linux-gnu qemu-s390x /usr/s390x-linux-gnu
+run_cross ppc32-be powerpc-linux-gnu qemu-ppc /usr/powerpc-linux-gnu

--- a/tests/endian/test_common.h
+++ b/tests/endian/test_common.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#ifndef SOTN_ENDIAN_TEST_COMMON_H
+#define SOTN_ENDIAN_TEST_COMMON_H
+
+#include <common.h>
+#include <endian_utils.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+extern unsigned g_failures;
+
+static inline uint32_t f32_bits(f32 value) {
+    uint32_t bits;
+    memcpy(&bits, &value.val, sizeof(bits));
+    return bits;
+}
+
+static inline uint16_t s16_bits(s16 value) {
+    uint16_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+#define CHECK_EQ_HEX(test_name, expected, actual)                              \
+    do {                                                                       \
+        uint64_t check_expected = (uint64_t)(expected);                        \
+        uint64_t check_actual = (uint64_t)(actual);                            \
+        if (check_expected != check_actual) {                                  \
+            fprintf(stderr, "%s: expected 0x%" PRIX64                        \
+                            ", got 0x%" PRIX64 "\n",                         \
+                    test_name, check_expected, check_actual);                  \
+            g_failures++;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_EQ_S32(test_name, expected, actual)                              \
+    do {                                                                       \
+        int32_t check_expected = (int32_t)(expected);                          \
+        int32_t check_actual = (int32_t)(actual);                              \
+        if (check_expected != check_actual) {                                  \
+            fprintf(stderr, "%s: expected %" PRId32 ", got %" PRId32        \
+                            " (0x%08" PRIX32 ")\n",                          \
+                    test_name, check_expected, check_actual,                   \
+                    (uint32_t)check_actual);                                   \
+            g_failures++;                                                      \
+        }                                                                      \
+    } while (0)
+
+#endif

--- a/tests/endian/test_endian.c
+++ b/tests/endian/test_endian.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "test_common.h"
+
+unsigned g_failures;
+
+void test_target_byte_order(void);
+void test_f32_read_views(void);
+void test_f32_write_views(void);
+void test_f16_views(void);
+void test_fixed_arithmetic(void);
+void test_fix_frac(void);
+void test_numeric_parts(void);
+
+int main(void) {
+    test_target_byte_order();
+    test_f32_read_views();
+    test_f32_write_views();
+    test_f16_views();
+    test_fixed_arithmetic();
+    test_fix_frac();
+    test_numeric_parts();
+
+    if (g_failures != 0) {
+        fprintf(stderr, "endian contracts: %u failure(s)\n", g_failures);
+        return 1;
+    }
+    puts("endian contracts: all tests passed");
+    return 0;
+}


### PR DESCRIPTION
I've discovered that sotn has a lot of issues with big endian platforms. This is a part of a series of PRs to add tests and fix dra/ric and st0 so that part of the game functions on big endian. The tests get run in 32-bit powerpc and 64-bit s390x to check.