### PR TITLE
sotn-disk: Preserve Timestamps During Export

### DIFF
--- a/tools/sotn-disk/discs/extract.go
+++ b/tools/sotn-disk/discs/extract.go
@@ -13,6 +13,11 @@ func Extract(f iso9660.File, basePath string) error {
 		if err := os.Mkdir(basePath, 0744); err != nil {
 			return err
 		}
+
+	}
+	t := f.RecordingDateTime.ToTime()
+	if err := os.Chtimes(basePath, t, t); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Could not restore timestamp to %s: %v\n", basePath, err)
 	}
 
 	children, err := f.GetChildren()
@@ -34,7 +39,14 @@ func Extract(f iso9660.File, basePath string) error {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer func() {
+				f.Close()
+
+				t := child.RecordingDateTime.ToTime()
+				if err := os.Chtimes(outFilePath, t, t); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Could not restore timestamp to %s: %v\n", outFilePath, err)
+				}
+			}()
 
 			if err := child.ReadToFile(f); err != nil {
 				return err

--- a/tools/sotn-disk/iso9660/timestamp.go
+++ b/tools/sotn-disk/iso9660/timestamp.go
@@ -1,5 +1,9 @@
 package iso9660
 
+import (
+	"time"
+)
+
 type Timestamp struct {
 	Year   byte
 	Month  byte
@@ -77,4 +81,20 @@ func serializeTimestamp(t Timestamp) []byte {
 	data[6] = t.Offset
 
 	return data
+}
+
+func (t Timestamp) ToTime() time.Time {
+	offsetSeconds := int(int8(t.Offset)) * 15 * 60
+	tz := time.FixedZone("ISO-9660-Local", offsetSeconds)
+	year := int(t.Year) + 1900
+
+	return time.Date(
+		year,
+		time.Month(t.Month),
+		int(t.Day),
+		int(t.Hour),
+		int(t.Minute),
+		int(t.Second),
+		0,
+		tz)
 }


### PR DESCRIPTION
Preserves the ISO-9660 timestamp when exporting files from a disk image.