### PR TITLE
Bump MetroWrap to 0.2.2

### DIFF
--- a/tools/sotn-assets/deps/build_deps.go
+++ b/tools/sotn-assets/deps/build_deps.go
@@ -82,7 +82,7 @@ func ensurePSPDeps(eg *errgroup.Group) {
 		)
 	})
 	eg.Go(func() error {
-		const MetroWrapVersion = "0.2.1"
+		const MetroWrapVersion = "0.2.2"
 		_, err := os.Stat("bin/.mw-version-" + MetroWrapVersion)
 		if err == nil {
 			return nil


### PR DESCRIPTION
Better error messages and ASM files are included in dependency output.

The dependency changes ensure builds are done when symbol files or anything else that changes splat output is modified but the source file affected is not changed.