### PR TITLE
assets: support non-contiguous entity layout blocks

### DIFF
--- a/config/assets.us.yaml
+++ b/config/assets.us.yaml
@@ -594,7 +594,7 @@ files:
           - [0x90, paldef, palette_def]
           - [0x150, layers, layers]
           - [0x5B8, gfx_banks, graphics_banks]
-          - [0x778, skip] #- [0x778, layout, entity_layouts]
+          - [0x778, layout, entity_layouts]
           - [0x27E0, rooms, rooms]
           - [0x291C, skip]
           - [0x48A0, cmpgfx, stage_title_no0, 128, 128, 4]

--- a/tools/sotn-assets/assets/layout/handler.go
+++ b/tools/sotn-assets/assets/layout/handler.go
@@ -29,6 +29,9 @@ func (h *handler) Extract(e assets.ExtractArgs) error {
 		return err
 	}
 	layouts, _, err := readEntityLayout(r, e.OvlName, layoutOff, e.RamBase, entryCount, true)
+	if err != nil {
+		return err
+	}
 	return util.WriteJsonFile(assetPath(e.AssetDir, e.Name), layouts)
 }
 

--- a/tools/sotn-assets/assets/layout/handler.go
+++ b/tools/sotn-assets/assets/layout/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets/gfxbanks"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/datarange"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/sotn"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/util"
@@ -52,31 +53,50 @@ func (h *handler) Info(a assets.InfoArgs) (assets.InfoResult, error) {
 	if err != nil {
 		return assets.InfoResult{}, err
 	}
-	nLayouts := 53 // it seems there are always 53 elements?!
-	_, layoutsRange, err := readEntityLayout(r, "dummy", layoutOff, boundaries.StageBegin, nLayouts, true)
+	_, layoutRanges, err := readEntityLayout(
+		r, "dummy", layoutOff, boundaries.StageBegin, entryCount, true)
 	if err != nil {
 		return assets.InfoResult{}, fmt.Errorf("unable to gather all entity layouts: %w", err)
 	}
+	blockRanges, err := datarange.ConsolidateDataRanges(layoutRanges[1:])
+	if err != nil {
+		return assets.InfoResult{}, fmt.Errorf("unable to consolidate entity layouts: %w", err)
+	}
+
+	splatEntries := []assets.InfoSplatEntry{
+		{
+			DataRange: layoutRanges[0],
+			Name:      "e_laydef",
+			Comment:   "layout entries header",
+		},
+	}
+	for i, blockRange := range blockRanges {
+		name := "e_layout"
+		comment := "layout entries data"
+		if i > 0 {
+			name = fmt.Sprintf("e_layout_%d", i+1)
+			gapBegin := blockRanges[i-1].End()
+			comment = fmt.Sprintf(
+				"layout entries data, resuming after %d unclaimed bytes at 0x%X",
+				gapBegin.DistanceTo(blockRange.Begin()),
+				gapBegin.Real(boundaries.StageBegin))
+		}
+		splatEntries = append(splatEntries, assets.InfoSplatEntry{
+			DataRange: blockRange,
+			Name:      name,
+			Comment:   comment,
+		})
+	}
+
 	return assets.InfoResult{
 		AssetEntries: []assets.InfoAssetEntry{
 			{
-				DataRange: layoutsRange[0],
+				DataRange: layoutRanges[0],
 				Kind:      "layout",
 				Name:      "entity_layouts",
 			},
 		},
-		SplatEntries: []assets.InfoSplatEntry{
-			{
-				DataRange: layoutsRange[0],
-				Name:      "e_laydef",
-				Comment:   "layout entries header",
-			},
-			{
-				DataRange: layoutsRange[1],
-				Name:      "e_layout",
-				Comment:   "layout entries data",
-			},
-		},
+		SplatEntries: splatEntries,
 	}, nil
 }
 

--- a/tools/sotn-assets/assets/layout/layout.go
+++ b/tools/sotn-assets/assets/layout/layout.go
@@ -175,14 +175,20 @@ func readEntityLayout(r io.ReadSeeker, ovlName string, off, baseAddr psx.Addr, c
 		if err := hydrateYOrderFields(l, yLayouts); err != nil {
 			return layouts{}, nil, fmt.Errorf("unable to populate YOrder field: %w", err)
 		}
-		xMerged := datarange.MergeDataRanges(xRanges)
-		yMerged := yRanges[1]
-		return l, []datarange.DataRange{
-			datarange.MergeDataRanges([]datarange.DataRange{datarange.New(off, endOfArray), yRanges[0]}),
-			datarange.MergeDataRanges([]datarange.DataRange{xMerged, yMerged}),
-		}, nil
+		// Keep block ranges separate here. Info consolidates adjacent runs while
+		// leaving gaps unclaimed; Extract does not consume the ranges.
+		laydefRange, err := datarange.Merge([]datarange.DataRange{
+			datarange.New(off, endOfArray), yRanges[0]})
+		if err != nil {
+			return layouts{}, nil, err
+		}
+		layoutRanges := append(
+			[]datarange.DataRange{laydefRange}, xRanges...)
+		return l, append(layoutRanges, yRanges[1:]...), nil
 	} else {
-		return l, []datarange.DataRange{datarange.New(off, endOfArray), datarange.MergeDataRanges(xRanges)}, nil
+		return l, append(
+			[]datarange.DataRange{datarange.New(off, endOfArray)},
+			xRanges...), nil
 	}
 }
 

--- a/tools/sotn-assets/assets/layout/layout_test.go
+++ b/tools/sotn-assets/assets/layout/layout_test.go
@@ -1,0 +1,39 @@
+package layout
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/datarange"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
+)
+
+func TestReadEntityLayoutPreservesUnclaimedRanges(t *testing.T) {
+	const count = 2
+	base := psx.Addr(0x80180000)
+	data := make([]byte, 0xA0)
+
+	blockOffsets := []int{0x20, 0x40, 0x60, 0x80}
+	for i, off := range blockOffsets {
+		binary.LittleEndian.PutUint32(data[i*4:], uint32(base.Sum(off)))
+		binary.LittleEndian.PutUint16(data[off:], uint16(0xFFFE))
+		binary.LittleEndian.PutUint16(data[off+2:], uint16(0xFFFE))
+		binary.LittleEndian.PutUint16(data[off+10:], uint16(0xFFFF))
+		binary.LittleEndian.PutUint16(data[off+12:], uint16(0xFFFF))
+	}
+
+	layouts, ranges, err := readEntityLayout(
+		bytes.NewReader(data), "dummy", base, base, count, true)
+	require.NoError(t, err)
+	assert.Len(t, layouts.Entities, count)
+	assert.Equal(t, []datarange.DataRange{
+		datarange.New(base, base.Sum(0x10)),
+		datarange.New(base.Sum(0x20), base.Sum(0x34)),
+		datarange.New(base.Sum(0x40), base.Sum(0x54)),
+		datarange.New(base.Sum(0x60), base.Sum(0x74)),
+		datarange.New(base.Sum(0x80), base.Sum(0x94)),
+	}, ranges)
+}

--- a/tools/sotn-assets/assets/layout/layout_test.go
+++ b/tools/sotn-assets/assets/layout/layout_test.go
@@ -7,9 +7,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/assets"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/datarange"
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
 )
+
+func TestExtractPropagatesLayoutReadError(t *testing.T) {
+	base := psx.Addr(0x80180000)
+	data := make([]byte, 0x40)
+	binary.LittleEndian.PutUint32(data[0x1C:], uint32(base.Sum(0x40)))
+
+	err := Handler.Extract(assets.ExtractArgs{
+		Data:     data,
+		AssetDir: t.TempDir(),
+		Name:     "entity_layouts",
+		RamBase:  base,
+	})
+	assert.Error(t, err)
+}
 
 func TestReadEntityLayoutPreservesUnclaimedRanges(t *testing.T) {
 	const count = 2

--- a/tools/sotn-assets/datarange/data_range.go
+++ b/tools/sotn-assets/datarange/data_range.go
@@ -80,11 +80,16 @@ func Merge(ranges []DataRange) (DataRange, error) {
 // ConsolidateDataRanges collapses adjacent ranges while preserving gaps.
 // Overlapping ranges are rejected instead of being silently combined.
 func ConsolidateDataRanges(ranges []DataRange) ([]DataRange, error) {
-	if len(ranges) == 0 {
-		return nil, fmt.Errorf("no data range to consolidate")
+	sorted := make([]DataRange, 0, len(ranges))
+	for _, dataRange := range ranges {
+		if !dataRange.Empty() {
+			sorted = append(sorted, dataRange)
+		}
+	}
+	if len(sorted) == 0 {
+		return []DataRange{}, nil
 	}
 
-	sorted := append([]DataRange(nil), ranges...)
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i].begin < sorted[j].begin
 	})

--- a/tools/sotn-assets/datarange/data_range.go
+++ b/tools/sotn-assets/datarange/data_range.go
@@ -77,33 +77,34 @@ func Merge(ranges []DataRange) (DataRange, error) {
 	}, nil
 }
 
-func ConsolidateDataRanges(ranges []DataRange) []DataRange {
+// ConsolidateDataRanges collapses adjacent ranges while preserving gaps.
+// Overlapping ranges are rejected instead of being silently combined.
+func ConsolidateDataRanges(ranges []DataRange) ([]DataRange, error) {
 	if len(ranges) == 0 {
-		return []DataRange{}
+		return nil, fmt.Errorf("no data range to consolidate")
 	}
 
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].begin < ranges[j].begin
+	sorted := append([]DataRange(nil), ranges...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].begin < sorted[j].begin
 	})
 
-	for ranges[0].Empty() {
-		ranges = ranges[1:]
-	}
-
-	consolidated := []DataRange{}
-	first := 0
-	for i := 0; i < len(ranges)-1; i++ {
-		if ranges[i].end != ranges[i+1].begin {
-			consolidated = append(consolidated, DataRange{
-				begin: ranges[first].begin,
-				end:   ranges[i].end,
-			})
-			first = i + 1
+	var consolidated []DataRange
+	begin := sorted[0].begin
+	for i := 0; i < len(sorted)-1; i++ {
+		switch {
+		case sorted[i].end > sorted[i+1].begin:
+			return nil, fmt.Errorf(
+				"overlap between data detected: %s > %s",
+				sorted[i].end,
+				sorted[i+1].begin)
+		case sorted[i].end < sorted[i+1].begin:
+			consolidated = append(
+				consolidated, New(begin, sorted[i].end))
+			begin = sorted[i+1].begin
 		}
 	}
 
-	return append(consolidated, DataRange{
-		begin: ranges[first].begin,
-		end:   ranges[len(ranges)-1].end,
-	})
+	return append(
+		consolidated, New(begin, sorted[len(sorted)-1].end)), nil
 }

--- a/tools/sotn-assets/datarange/data_range_test.go
+++ b/tools/sotn-assets/datarange/data_range_test.go
@@ -14,11 +14,19 @@ func TestConsolidateDataRanges(t *testing.T) {
 	}
 
 	t.Run("adjacent ranges collapse", func(t *testing.T) {
-		input := []DataRange{r(0x20, 0x30), r(0x10, 0x20)}
+		input := []DataRange{
+			r(0x20, 0x30),
+			{},
+			r(0x10, 0x20),
+		}
 		got, err := ConsolidateDataRanges(input)
 		require.NoError(t, err)
 		assert.Equal(t, []DataRange{r(0x10, 0x30)}, got)
-		assert.Equal(t, []DataRange{r(0x20, 0x30), r(0x10, 0x20)}, input)
+		assert.Equal(t, []DataRange{
+			r(0x20, 0x30),
+			{},
+			r(0x10, 0x20),
+		}, input)
 	})
 
 	t.Run("gap starts a new run", func(t *testing.T) {
@@ -38,8 +46,9 @@ func TestConsolidateDataRanges(t *testing.T) {
 		assert.ErrorContains(t, err, "overlap")
 	})
 
-	t.Run("empty input is rejected", func(t *testing.T) {
-		_, err := ConsolidateDataRanges(nil)
-		assert.Error(t, err)
+	t.Run("empty input stays empty", func(t *testing.T) {
+		got, err := ConsolidateDataRanges(nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
 	})
 }

--- a/tools/sotn-assets/datarange/data_range_test.go
+++ b/tools/sotn-assets/datarange/data_range_test.go
@@ -1,0 +1,45 @@
+package datarange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/psx"
+)
+
+func TestConsolidateDataRanges(t *testing.T) {
+	r := func(begin, end uint32) DataRange {
+		return New(psx.Addr(begin), psx.Addr(end))
+	}
+
+	t.Run("adjacent ranges collapse", func(t *testing.T) {
+		input := []DataRange{r(0x20, 0x30), r(0x10, 0x20)}
+		got, err := ConsolidateDataRanges(input)
+		require.NoError(t, err)
+		assert.Equal(t, []DataRange{r(0x10, 0x30)}, got)
+		assert.Equal(t, []DataRange{r(0x20, 0x30), r(0x10, 0x20)}, input)
+	})
+
+	t.Run("gap starts a new run", func(t *testing.T) {
+		input := []DataRange{r(0x10, 0x20), r(0x30, 0x40)}
+		assert.Panics(t, func() {
+			MergeDataRanges(append([]DataRange(nil), input...))
+		})
+
+		got, err := ConsolidateDataRanges(input)
+		require.NoError(t, err)
+		assert.Equal(t, input, got)
+	})
+
+	t.Run("overlap is rejected", func(t *testing.T) {
+		_, err := ConsolidateDataRanges(
+			[]DataRange{r(0x10, 0x25), r(0x20, 0x30)})
+		assert.ErrorContains(t, err, "overlap")
+	})
+
+	t.Run("empty input is rejected", func(t *testing.T) {
+		_, err := ConsolidateDataRanges(nil)
+		assert.Error(t, err)
+	})
+}

--- a/tools/sotn-assets/info_test.go
+++ b/tools/sotn-assets/info_test.go
@@ -121,6 +121,7 @@ func TestStagesCompatibility(t *testing.T) {
 		"disks/us/ST/DAI/DAI.BIN",
 		"disks/us/ST/DRE/DRE.BIN",
 		"disks/us/ST/LIB/LIB.BIN",
+		"disks/us/ST/NO0/NO0.BIN",
 		"disks/us/ST/NO1/NO1.BIN",
 		"disks/us/ST/NO2/NO2.BIN",
 		"disks/us/ST/NO3/NO3.BIN",
@@ -167,7 +168,6 @@ func TestStagesCompatibility(t *testing.T) {
 	// A test failure here should be good news and it should be moved to the test above
 	for _, ovlPath := range []string{
 		"disks/us/ST/SEL/SEL.BIN",
-		"disks/us/ST/NO0/NO0.BIN",
 		"disks/us/BOSS/BO4/BO4.BIN",
 		"disks/us/BOSS/RBO5/RBO5.BIN",
 	} {


### PR DESCRIPTION
![](https://media1.tenor.com/m/YZBRIdXRgCsAAAAC/sotn-symphony-of-the-night.gif)

## Summary
This PR addresses the layout gaps identified by @JoshSchreuder in #3508.

`NO0` contains four gaps between referenced entity-layout blocks. Previously, the layout handler attempted to merge every block into one contiguous range, causing `sotn-assets info` and asset extraction to fail.

The changes:
- preserve individual entity-layout block ranges during decoding
- consolidate only adjacent ranges when producing `info` output
- leave unexplained gaps unclaimed while continuing to reject overlaps
- propagate layout decoding errors during extraction
- enable US `NO0` entity-layout extraction
- move `NO0` into the passing stage compatibility list

The decoded layout data is unchanged. A fresh extraction produces 29 unique blocks referenced by 53 layout-table entries.

## Validation
- focused layout and data-range tests pass
- the complete stage compatibility test passes
- forced clean `NO0` extraction succeeds 
- US, HD, and PSP-EU builds still byte match the pinned retail bins

Closes #3508