### PR TITLE
sat: decode the CRT sequence and tone banks

### DIFF
--- a/tools/saturn/assets/src/crt.rs
+++ b/tools/saturn/assets/src/crt.rs
@@ -1,10 +1,10 @@
 
-use crate::{sha256_hex, Error, Result};
+use crate::{seq, sha256_hex, tone, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 pub const FORMAT: &str = "sotn-saturn-sound-package";
-pub const VERSION: u32 = 1;
+pub const VERSION: u32 = 2;
 pub const MANIFEST_NAME: &str = "manifest.json";
 pub const AREAS_DIR: &str = "areas";
 
@@ -30,16 +30,24 @@ pub struct Area {
 #[serde(rename_all = "lowercase")]
 pub enum Contents {
     Sequence,
-    Other,
+    Tone,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Song {
-    pub index: usize,
-    pub offset: u32,
-    pub resolution: u16,
-    pub track_offset: u16,
-    pub tempo_offset: u16,
+impl Contents {
+    pub fn of(id: u8) -> Option<Contents> {
+        match id & 0xF0 {
+            0x10 => Some(Contents::Sequence),
+            0x00 => Some(Contents::Tone),
+            _ => None,
+        }
+    }
+
+    fn suffix(self) -> &'static str {
+        match self {
+            Contents::Sequence => "seq.json",
+            Contents::Tone => "tone.json",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,8 +60,8 @@ pub struct AreaFile {
     pub contents: Contents,
     pub sha256: String,
     pub file: String,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub songs: Vec<Song>,
+    pub decoded: String,
+    pub entries: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -95,16 +103,6 @@ fn safe_join(root: &Path, relative: &str) -> Result<PathBuf> {
         )));
     }
     Ok(root.join(path))
-}
-
-fn read_u16(data: &[u8], at: usize) -> Option<u16> {
-    data.get(at..at + 2)
-        .map(|b| u16::from_be_bytes([b[0], b[1]]))
-}
-
-fn read_u32(data: &[u8], at: usize) -> Option<u32> {
-    data.get(at..at + 4)
-        .map(|b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
 }
 
 fn boot(game: &[u8]) -> Result<()> {
@@ -178,35 +176,6 @@ pub fn base_area(game: &[u8], crt_name: &str) -> Result<u8> {
         })
 }
 
-fn songs(data: &[u8]) -> Option<Vec<Song>> {
-    let count = read_u16(data, 0)? as usize;
-    if count == 0 || count > 128 {
-        return None;
-    }
-    let mut songs = Vec::with_capacity(count);
-    for index in 0..count {
-        let offset = read_u32(data, 2 + index * 4)?;
-        let song = data.get(offset as usize..)?;
-        let resolution = read_u16(song, 0)?;
-        let track_offset = read_u16(song, 4)?;
-        let tempo_offset = read_u16(song, 6)?;
-        if !(24..=960).contains(&resolution)
-            || song.len() <= track_offset as usize
-            || song.len() < tempo_offset as usize + 8
-        {
-            return None;
-        }
-        songs.push(Song {
-            index,
-            offset,
-            resolution,
-            track_offset,
-            tempo_offset,
-        });
-    }
-    Some(songs)
-}
-
 pub fn areas_of(game: &[u8], crt_name: &str, size: usize) -> Result<(u8, u32, Vec<Area>)> {
     let base = base_area(game, crt_name)?;
     let map = area_map(game)?;
@@ -227,6 +196,75 @@ pub fn areas_of(game: &[u8], crt_name: &str, size: usize) -> Result<(u8, u32, Ve
         )));
     }
     Ok((base, start, contained))
+}
+
+fn decode_area(
+    bytes: &[u8],
+    contents: Contents,
+    id: u8,
+    output_dir: &Path,
+    decoded: &str,
+) -> Result<usize> {
+    let path = safe_join(output_dir, decoded)?;
+    match contents {
+        Contents::Sequence => {
+            let bank = seq::decode(bytes)?;
+            let songs = bank.songs.len();
+            seq::write(&bank, &path)?;
+            Ok(songs)
+        }
+        Contents::Tone => {
+            let samples_file = format!("{id:02X}.samples.bin");
+            let bank = tone::decode(bytes, &samples_file)?;
+            let layers = tone::layer_count(&bank);
+            tone::write(&bank, &path, &bytes[bank.samples.offset..])?;
+            Ok(layers)
+        }
+    }
+}
+
+pub fn encode_area(root: &Path, area: &AreaFile) -> Result<Vec<u8>> {
+    let path = safe_join(root, &area.decoded)?;
+    match area.contents {
+        Contents::Sequence => seq::encode(&seq::load(&path)?),
+        Contents::Tone => {
+            let bank = tone::load(&path)?;
+            let samples = std::fs::read(
+                path.parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .join(&bank.samples.file),
+            )?;
+            tone::encode(&bank, &samples)
+        }
+    }
+}
+
+pub fn verify_banks(manifest_path: &Path) -> Result<()> {
+    let manifest = load_manifest(manifest_path)?;
+    let root = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    for area in &manifest.areas {
+        let retail = std::fs::read(safe_join(root, &area.file)?)?;
+        let rebuilt = encode_area(root, area)
+            .map_err(|e| Error::Format(format!("area 0x{:02X}: {e}", area.id)))?;
+        if rebuilt == retail {
+            continue;
+        }
+        let detail = if rebuilt.len() != retail.len() {
+            format!("{} bytes rebuilt vs {} in the area", rebuilt.len(), retail.len())
+        } else {
+            let at = rebuilt
+                .iter()
+                .zip(&retail)
+                .position(|(a, b)| a != b)
+                .unwrap_or(0);
+            format!("first difference at offset 0x{at:X}")
+        };
+        return Err(Error::Mismatch(format!(
+            "{} does not re-encode to area 0x{:02X} ({detail})",
+            area.decoded, area.id
+        )));
+    }
+    Ok(())
 }
 
 pub fn extract(game_path: &Path, crt_path: &Path, output_dir: &Path) -> Result<Manifest> {
@@ -250,23 +288,29 @@ pub fn extract(game_path: &Path, crt_path: &Path, output_dir: &Path) -> Result<M
             )));
         }
         let bytes = &data[offset..end];
-        let songs = songs(bytes);
+        let contents = Contents::of(area.id).ok_or_else(|| {
+            Error::Format(format!(
+                "area 0x{:02X} is neither a sequence bank (0x1x) nor a tone bank (0x0x), and \
+                 nothing on the retail disc is",
+                area.id
+            ))
+        })?;
         let file = format!("{AREAS_DIR}/{:02X}.bin", area.id);
+        let decoded = format!("{AREAS_DIR}/{:02X}.{}", area.id, contents.suffix());
         std::fs::write(safe_join(output_dir, &file)?, bytes)?;
+        let entries = decode_area(bytes, contents, area.id, output_dir, &decoded)
+            .map_err(|e| Error::Format(format!("area 0x{:02X} of {name}: {e}", area.id)))?;
         files.push(AreaFile {
             id: area.id,
             address: area.address,
             offset,
             size: bytes.len(),
             loadable: area.loadable,
-            contents: if songs.is_some() {
-                Contents::Sequence
-            } else {
-                Contents::Other
-            },
+            contents,
             sha256: sha256_hex(bytes),
             file,
-            songs: songs.unwrap_or_default(),
+            decoded,
+            entries,
         });
     }
 

--- a/tools/saturn/assets/src/lib.rs
+++ b/tools/saturn/assets/src/lib.rs
@@ -10,10 +10,13 @@ pub mod image;
 pub mod lzss;
 pub mod map;
 pub mod map_render;
+pub mod midi;
 pub mod player;
+pub mod seq;
 pub mod sheet;
 pub mod sprite;
 pub mod stage;
+pub mod tone;
 pub mod wav;
 pub mod weapon;
 

--- a/tools/saturn/assets/src/main.rs
+++ b/tools/saturn/assets/src/main.rs
@@ -3,7 +3,7 @@
 //! Driven from tools/sotn-assets and config/assets.saturn.yaml
 
 use clap::{Parser, Subcommand};
-use saturn_assets::{audio, bitmap, crt, familiar, font, map, player, stage, weapon};
+use saturn_assets::{audio, bitmap, crt, familiar, font, map, midi, player, seq, stage, weapon};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -54,6 +54,11 @@ enum CrtCommand {
     Verify {
         manifest: PathBuf,
         crt_path: PathBuf,
+    },
+    Banks { manifest: PathBuf },
+    Midi {
+        seq_path: PathBuf,
+        output_dir: PathBuf,
     },
     Areas {
         game_path: PathBuf,
@@ -365,16 +370,45 @@ fn run(cli: Cli) -> saturn_assets::Result<()> {
             output_dir,
         }) => {
             let manifest = crt::extract(&game_path, &crt_path, &output_dir)?;
-            let sequences = manifest
-                .areas
-                .iter()
-                .filter(|area| area.contents == crt::Contents::Sequence)
-                .count();
+            let count = |kind| {
+                manifest
+                    .areas
+                    .iter()
+                    .filter(|area| area.contents == kind)
+                    .map(|area| area.entries)
+                    .sum::<usize>()
+            };
             println!(
-                "{} areas ({sequences} sequence), base 0x{:02X} at 0x{:06X} -> {}",
+                "{} areas, base 0x{:02X} at 0x{:06X}: {} songs and {} tone layers -> {}",
                 manifest.areas.len(),
                 manifest.base_area,
                 manifest.base_address,
+                count(crt::Contents::Sequence),
+                count(crt::Contents::Tone),
+                output_dir.display()
+            );
+        }
+        Command::Crt(CrtCommand::Banks { manifest }) => {
+            crt::verify_banks(&manifest)?;
+            let loaded = crt::load_manifest(&manifest)?;
+            println!(
+                "every one of the {} decoded banks re-encodes to its area exactly",
+                loaded.areas.len()
+            );
+        }
+        Command::Crt(CrtCommand::Midi {
+            seq_path,
+            output_dir,
+        }) => {
+            let bank = seq::load(&seq_path)?;
+            let stem = seq_path
+                .file_name()
+                .map(|name| name.to_string_lossy().replace(".seq.json", ""))
+                .unwrap_or_else(|| "song".to_string());
+            let written = midi::export_bank(&bank, &output_dir, &stem)?;
+            println!(
+                "wrote {} songs as MIDI -> {}",
+                written.len(),
                 output_dir.display()
             );
         }

--- a/tools/saturn/assets/src/midi.rs
+++ b/tools/saturn/assets/src/midi.rs
@@ -1,0 +1,484 @@
+
+use crate::seq::{Bank, Event, Song};
+use crate::{Error, Result};
+use std::path::{Path, PathBuf};
+
+const OPERATION_LIMIT: usize = 1 << 20;
+
+struct Message {
+    tick: u64,
+    order: usize,
+    port: u8,
+    bytes: Vec<u8>,
+}
+
+fn variable_length(value: u32, out: &mut Vec<u8>) {
+    let mut buffer = [0u8; 4];
+    let mut count = 0;
+    let mut value = value;
+    loop {
+        buffer[count] = (value & 0x7F) as u8;
+        count += 1;
+        value >>= 7;
+        if value == 0 {
+            break;
+        }
+    }
+    for index in (0..count).rev() {
+        out.push(buffer[index] | if index == 0 { 0 } else { 0x80 });
+    }
+}
+
+fn chunk(tag: &[u8; 4], body: &[u8], out: &mut Vec<u8>) {
+    out.extend_from_slice(tag);
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(body);
+}
+
+fn track(messages: &mut Vec<Message>) -> Vec<u8> {
+    messages.sort_by_key(|message| (message.tick, message.order));
+    let mut body = Vec::new();
+    let mut previous = 0u64;
+    for message in messages.iter() {
+        variable_length((message.tick - previous) as u32, &mut body);
+        body.extend_from_slice(&message.bytes);
+        previous = message.tick;
+    }
+    variable_length(0, &mut body);
+    body.extend_from_slice(&[0xFF, 0x2F, 0x00]);
+    body
+}
+
+fn meta(kind: u8, payload: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0xFF, kind];
+    variable_length(payload.len() as u32, &mut bytes);
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn offsets(song: &Song) -> Result<Vec<usize>> {
+    let mut out = Vec::with_capacity(song.events.len());
+    let mut at = 0;
+    for event in &song.events {
+        out.push(at);
+        at += crate::seq::encoded_size(event)?;
+    }
+    Ok(out)
+}
+
+fn play(song: &Song) -> Result<(Vec<Message>, Vec<Message>)> {
+    let offsets = offsets(song)?;
+    let mut events = Vec::new();
+    let mut markers = Vec::new();
+    let mut order = 0usize;
+    let mut now = 0u64;
+    let mut gate = 0u32;
+    let mut delta = 0u32;
+    let mut cursor = 0usize;
+    let mut return_to = 0usize;
+    let mut reference_count = 0u8;
+    let mut loop_point: Option<usize> = None;
+
+    let mut emit = |messages: &mut Vec<Message>, tick: u64, port: u8, bytes: Vec<u8>| {
+        order += 1;
+        messages.push(Message {
+            tick,
+            order,
+            port,
+            bytes,
+        });
+    };
+
+    for _ in 0..OPERATION_LIMIT {
+        let Some(event) = song.events.get(cursor) else {
+            return Err(Error::Format(
+                "the song runs off the end of its event list".to_string(),
+            ));
+        };
+        cursor += 1;
+
+        let (port, message, advance) = match *event {
+            Event::GateAdd { value } => {
+                gate += u32::from(value);
+                continue;
+            }
+            Event::DeltaAdd { value } => {
+                delta += u32::from(value);
+                continue;
+            }
+            Event::Reference { target, count } => {
+                if reference_count != 0 {
+                    return Err(Error::Format(
+                        "a referenced run contains a reference of its own, which the driver \
+                         cannot nest"
+                        .to_string(),
+                    ));
+                }
+                let Some(index) = offsets.iter().position(|&at| at == usize::from(target)) else {
+                    return Err(Error::Format(format!(
+                        "a reference targets 0x{target:X}, which is not the start of an event"
+                    )));
+                };
+                return_to = cursor;
+                reference_count = count;
+                cursor = index;
+                continue;
+            }
+            Event::Loop { delta: step } => {
+                delta += u32::from(step);
+                match loop_point {
+                    None => {
+                        emit(&mut markers, now, 0, meta(0x06, b"loop start"));
+                        loop_point = Some(cursor);
+                    }
+                    Some(_) => {
+                        emit(&mut markers, now, 0, meta(0x06, b"loop end"));
+                        break;
+                    }
+                }
+                continue;
+            }
+            Event::End => break,
+            Event::Note {
+                channel,
+                port,
+                key,
+                velocity,
+                gate: own_gate,
+                delta: own_delta,
+            } => {
+                let held = gate + u32::from(own_gate);
+                emit(
+                    &mut events,
+                    now,
+                    port,
+                    vec![0x90 | channel, key, velocity.max(1)],
+                );
+                emit(
+                    &mut events,
+                    now + u64::from(held),
+                    port,
+                    vec![0x80 | channel, key, 0x40],
+                );
+                (port, None, delta + u32::from(own_delta))
+            }
+            Event::Aftertouch {
+                channel,
+                port,
+                key,
+                pressure,
+                delta: own_delta,
+            } => (
+                port,
+                Some(vec![0xA0 | channel, key, pressure]),
+                delta + u32::from(own_delta),
+            ),
+            Event::Control {
+                channel,
+                port,
+                controller,
+                value,
+                delta: own_delta,
+            } => (
+                port,
+                Some(vec![0xB0 | channel, controller, value]),
+                delta + u32::from(own_delta),
+            ),
+            Event::Program {
+                channel,
+                port,
+                program,
+                delta: own_delta,
+            } => (
+                port,
+                Some(vec![0xC0 | channel, program]),
+                delta + u32::from(own_delta),
+            ),
+            Event::Pressure {
+                channel,
+                port,
+                pressure,
+                delta: own_delta,
+            } => (
+                port,
+                Some(vec![0xD0 | channel, pressure]),
+                delta + u32::from(own_delta),
+            ),
+            Event::Bend {
+                channel,
+                value,
+                delta: own_delta,
+            } => (
+                0,
+                Some(vec![0xE0 | channel, 0x00, value & 0x7F]),
+                delta + u32::from(own_delta),
+            ),
+        };
+
+        if let Some(bytes) = message {
+            emit(&mut events, now, port, bytes);
+        }
+        now += u64::from(advance);
+        gate = 0;
+        delta = 0;
+
+        if reference_count != 0 {
+            reference_count -= 1;
+            if reference_count == 0 {
+                cursor = return_to;
+            }
+        }
+        continue;
+    }
+
+    Ok((events, markers))
+}
+
+pub fn song_to_smf(song: &Song) -> Result<Vec<u8>> {
+    let (events, mut markers) = play(song)?;
+    let tempo = song.tempo.last().ok_or_else(|| {
+        Error::Format("a song with no tempo record has no tempo to export".to_string())
+    })?;
+    let microseconds = tempo.microseconds_per_quarter;
+    if microseconds == 0 || microseconds > 0x00FF_FFFF {
+        return Err(Error::Format(format!(
+            "{microseconds} microseconds per quarter does not fit a MIDI tempo"
+        )));
+    }
+
+    markers.push(Message {
+        tick: 0,
+        order: 0,
+        port: 0,
+        bytes: meta(0x51, &microseconds.to_be_bytes()[1..]),
+    });
+    let mut tracks = vec![track(&mut markers)];
+
+    let mut ports: Vec<u8> = events.iter().map(|message| message.port).collect();
+    ports.sort_unstable();
+    ports.dedup();
+    if ports.is_empty() {
+        ports.push(0);
+    }
+    for port in ports {
+        let mut on_port: Vec<Message> = events
+            .iter()
+            .filter(|message| message.port == port)
+            .map(|message| Message {
+                tick: message.tick,
+                order: message.order,
+                port,
+                bytes: message.bytes.clone(),
+            })
+            .collect();
+        let mut body = meta(0x03, format!("port {port}").as_bytes());
+        body.insert(0, 0x00);
+        body.extend_from_slice(&track(&mut on_port));
+        tracks.push(body);
+    }
+
+    let mut out = Vec::new();
+    let mut header = Vec::new();
+    header.extend_from_slice(&1u16.to_be_bytes());
+    header.extend_from_slice(&(tracks.len() as u16).to_be_bytes());
+    header.extend_from_slice(&song.resolution.to_be_bytes());
+    chunk(b"MThd", &header, &mut out);
+    for body in &tracks {
+        chunk(b"MTrk", body, &mut out);
+    }
+    Ok(out)
+}
+
+pub fn export_bank(bank: &Bank, output_dir: &Path, stem: &str) -> Result<Vec<PathBuf>> {
+    std::fs::create_dir_all(output_dir)?;
+    let width = bank.songs.len().to_string().len();
+    let mut written = Vec::with_capacity(bank.songs.len());
+    for (index, song) in bank.songs.iter().enumerate() {
+        let smf = song_to_smf(song)
+            .map_err(|e| Error::Format(format!("{stem} song {index}: {e}")))?;
+        let path = output_dir.join(format!("{stem}_{index:0width$}.mid"));
+        std::fs::write(&path, smf)?;
+        written.push(path);
+    }
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::seq::Tempo;
+
+    fn song(events: Vec<Event>) -> Song {
+        Song {
+            resolution: 480,
+            tempo: vec![Tempo {
+                delta: 0,
+                microseconds_per_quarter: 500_000,
+            }],
+            events,
+            padding: 0,
+        }
+    }
+
+    fn note(key: u8, gate: u16, delta: u16) -> Event {
+        Event::Note {
+            channel: 0,
+            port: 0,
+            key,
+            velocity: 100,
+            gate,
+            delta,
+        }
+    }
+
+    fn events_of(smf: &[u8], want: usize) -> Vec<(u32, Vec<u8>)> {
+        let mut at = 14; 
+        let mut track = 0;
+        loop {
+            let size = u32::from_be_bytes([smf[at + 4], smf[at + 5], smf[at + 6], smf[at + 7]])
+                as usize;
+            let body = &smf[at + 8..at + 8 + size];
+            if track == want {
+                let mut out = Vec::new();
+                let mut cursor = 0;
+                while cursor < body.len() {
+                    let mut delta = 0u32;
+                    loop {
+                        let byte = body[cursor];
+                        cursor += 1;
+                        delta = delta << 7 | u32::from(byte & 0x7F);
+                        if byte & 0x80 == 0 {
+                            break;
+                        }
+                    }
+                    let length = match body[cursor] {
+                        0xFF => {
+                            let payload = body[cursor + 2] as usize;
+                            3 + payload
+                        }
+                        status if status & 0xF0 == 0xC0 || status & 0xF0 == 0xD0 => 2,
+                        _ => 3,
+                    };
+                    out.push((delta, body[cursor..cursor + length].to_vec()));
+                    cursor += length;
+                }
+                return out;
+            }
+            at += 8 + size;
+            track += 1;
+        }
+    }
+
+    #[test]
+    fn a_note_becomes_an_on_and_an_off_a_gate_apart() {
+        let smf = song_to_smf(&song(vec![note(60, 240, 480), Event::End])).expect("export");
+        assert_eq!(&smf[..4], b"MThd");
+        assert_eq!(&smf[8..14], &[0x00, 0x01, 0x00, 0x02, 0x01, 0xE0]);
+        let events = events_of(&smf, 1);
+        assert_eq!(events[1], (0, vec![0x90, 60, 100]));
+        assert_eq!(events[2], (240, vec![0x80, 60, 0x40]));
+    }
+
+    #[test]
+    fn the_accumulators_collapse_into_ordinary_ticks() {
+        let smf = song_to_smf(&song(vec![
+            Event::DeltaAdd { value: 0x100 },
+            Event::GateAdd { value: 0x200 },
+            note(60, 0x30, 0x18),
+            note(62, 1, 1),
+            Event::End,
+        ]))
+        .expect("export");
+        let events = events_of(&smf, 1);
+        assert_eq!(events[1], (0, vec![0x90, 60, 100]));
+        assert_eq!(events[2], (0x118, vec![0x90, 62, 100]));
+        assert_eq!(events[3], (1, vec![0x80, 62, 0x40]));
+        assert_eq!(events[4], (0x230 - 0x119, vec![0x80, 60, 0x40]));
+    }
+
+    #[test]
+    fn a_reference_expands_into_its_repeats() {
+        let events = vec![note(60, 10, 10), note(62, 10, 10), Event::End];
+        let mut with_reference = events.clone();
+        with_reference.pop();
+        with_reference.push(Event::Reference { target: 0, count: 2 });
+        with_reference.push(Event::End);
+
+        let smf = song_to_smf(&song(with_reference)).expect("export");
+        let ons: Vec<u8> = events_of(&smf, 1)
+            .into_iter()
+            .filter(|(_, bytes)| bytes[0] == 0x90)
+            .map(|(_, bytes)| bytes[1])
+            .collect();
+        assert_eq!(ons, vec![60, 62, 60, 62]);
+    }
+
+    #[test]
+    fn the_second_loop_marker_ends_the_file_instead_of_looping_forever() {
+        let smf = song_to_smf(&song(vec![
+            Event::Loop { delta: 0 },
+            note(60, 10, 10),
+            Event::Loop { delta: 0 },
+            Event::End,
+        ]))
+        .expect("export");
+        let markers: Vec<Vec<u8>> = events_of(&smf, 0)
+            .into_iter()
+            .filter(|(_, bytes)| bytes.starts_with(&[0xFF, 0x06]))
+            .map(|(_, bytes)| bytes[3..].to_vec())
+            .collect();
+        assert_eq!(markers.len(), 2);
+        assert_eq!(markers[0], b"loop start");
+        assert_eq!(markers[1], b"loop end");
+        let ons = events_of(&smf, 1)
+            .into_iter()
+            .filter(|(_, bytes)| bytes[0] == 0x90)
+            .count();
+        assert_eq!(ons, 1);
+    }
+
+    #[test]
+    fn a_bend_lands_in_the_high_seven_bits() {
+        let smf = song_to_smf(&song(vec![
+            Event::Bend {
+                channel: 2,
+                value: 0x40,
+                delta: 0,
+            },
+            Event::End,
+        ]))
+        .expect("export");
+        assert!(events_of(&smf, 1)
+            .iter()
+            .any(|(_, bytes)| bytes == &[0xE2, 0x00, 0x40]));
+    }
+
+    #[test]
+    fn a_reference_to_the_middle_of_an_event_is_refused() {
+        let error = song_to_smf(&song(vec![
+            note(60, 10, 10),
+            Event::Reference { target: 2, count: 1 },
+            Event::End,
+        ]))
+        .expect_err("misaligned reference")
+        .to_string();
+        assert!(error.contains("start of an event"), "{error}");
+    }
+
+    #[test]
+    fn a_port_that_is_used_gets_its_own_track() {
+        let smf = song_to_smf(&song(vec![
+            note(60, 10, 10),
+            Event::Control {
+                channel: 0,
+                port: 1,
+                controller: 7,
+                value: 100,
+                delta: 0,
+            },
+            Event::End,
+        ]))
+        .expect("export");
+        assert_eq!(smf[11], 3, "a tempo track and one per port");
+    }
+}

--- a/tools/saturn/assets/src/seq.rs
+++ b/tools/saturn/assets/src/seq.rs
@@ -1,0 +1,704 @@
+
+use crate::{Error, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub const FORMAT: &str = "sotn-saturn-sequence-bank";
+pub const VERSION: u32 = 1;
+
+const MIN_RESOLUTION: u16 = 24;
+const MAX_RESOLUTION: u16 = 960;
+
+const NOTE_MAX: u16 = 0x1FF;
+
+const GATE_ADDENDS: [u16; 4] = [0x200, 0x800, 0x1000, 0x2000];
+const DELTA_ADDENDS: [u16; 4] = [0x100, 0x200, 0x800, 0x1000];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Event {
+    Note {
+        channel: u8,
+        port: u8,
+        key: u8,
+        velocity: u8,
+        gate: u16,
+        delta: u16,
+    },
+    Reference { target: u16, count: u8 },
+    Loop { delta: u8 },
+    End,
+    GateAdd { value: u16 },
+    DeltaAdd { value: u16 },
+    Aftertouch {
+        channel: u8,
+        port: u8,
+        key: u8,
+        pressure: u8,
+        delta: u8,
+    },
+    Control {
+        channel: u8,
+        port: u8,
+        controller: u8,
+        value: u8,
+        delta: u8,
+    },
+    Program {
+        channel: u8,
+        port: u8,
+        program: u8,
+        delta: u8,
+    },
+    Pressure {
+        channel: u8,
+        port: u8,
+        pressure: u8,
+        delta: u8,
+    },
+    Bend { channel: u8, value: u8, delta: u8 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tempo {
+    pub delta: u32,
+    pub microseconds_per_quarter: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Song {
+    pub resolution: u16,
+    pub tempo: Vec<Tempo>,
+    pub events: Vec<Event>,
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub padding: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bank {
+    pub format: String,
+    pub version: u32,
+    pub size: usize,
+    pub songs: Vec<Song>,
+}
+
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
+fn read_u16(data: &[u8], at: usize) -> Result<u16> {
+    data.get(at..at + 2)
+        .map(|b| u16::from_be_bytes([b[0], b[1]]))
+        .ok_or_else(|| Error::Format(format!("sequence bank is truncated at 0x{at:X}")))
+}
+
+fn read_u32(data: &[u8], at: usize) -> Result<u32> {
+    data.get(at..at + 4)
+        .map(|b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+        .ok_or_else(|| Error::Format(format!("sequence bank is truncated at 0x{at:X}")))
+}
+
+fn track_offset(tracks: usize) -> usize {
+    8 + tracks * 8
+}
+
+fn tempo_offset(tracks: usize) -> usize {
+    8 + (tracks - 1) * 8
+}
+
+pub fn decode(data: &[u8]) -> Result<Bank> {
+    let count = read_u16(data, 0)? as usize;
+    if count == 0 {
+        if data.iter().any(|&b| b != 0) {
+            return Err(Error::Format(
+                "sequence bank declares no songs but is not empty".to_string(),
+            ));
+        }
+        return Ok(Bank {
+            format: FORMAT.to_string(),
+            version: VERSION,
+            size: data.len(),
+            songs: Vec::new(),
+        });
+    }
+
+    let table_end = 2 + count * 4;
+    let mut offsets = Vec::with_capacity(count);
+    for index in 0..count {
+        offsets.push(read_u32(data, 2 + index * 4)? as usize);
+    }
+    if offsets[0] != table_end {
+        return Err(Error::Format(format!(
+            "the first song starts at 0x{:X}, not directly after the {count}-song table at 0x{table_end:X}",
+            offsets[0]
+        )));
+    }
+    for pair in offsets.windows(2) {
+        if pair[1] < pair[0] {
+            return Err(Error::Format(
+                "the song table is not in ascending offset order".to_string(),
+            ));
+        }
+    }
+
+    let mut songs = Vec::with_capacity(count);
+    for (index, &start) in offsets.iter().enumerate() {
+        let end = offsets.get(index + 1).copied().unwrap_or(data.len());
+        let song = data
+            .get(start..end)
+            .ok_or_else(|| Error::Format(format!("song {index} lies outside the bank")))?;
+        songs.push(decode_song(song, index)?);
+    }
+
+    Ok(Bank {
+        format: FORMAT.to_string(),
+        version: VERSION,
+        size: data.len(),
+        songs,
+    })
+}
+
+fn decode_song(song: &[u8], index: usize) -> Result<Song> {
+    let resolution = read_u16(song, 0)?;
+    let tracks = read_u16(song, 2)? as usize;
+    let declared_track = read_u16(song, 4)? as usize;
+    let declared_tempo = read_u16(song, 6)? as usize;
+    if !(MIN_RESOLUTION..=MAX_RESOLUTION).contains(&resolution) {
+        return Err(Error::Format(format!(
+            "song {index} has resolution {resolution}, outside the driver's {MIN_RESOLUTION}..{MAX_RESOLUTION}"
+        )));
+    }
+    if tracks == 0 {
+        return Err(Error::Format(format!("song {index} declares no tracks")));
+    }
+    if declared_track != track_offset(tracks) || declared_tempo != tempo_offset(tracks) {
+        return Err(Error::Format(format!(
+            "song {index} declares {tracks} tracks with its track at 0x{declared_track:X} and \
+             tempo at 0x{declared_tempo:X}; every song on the disc puts them at 0x{:X} and 0x{:X}",
+            track_offset(tracks),
+            tempo_offset(tracks)
+        )));
+    }
+
+    let mut tempo = Vec::with_capacity(tracks);
+    for track in 0..tracks {
+        let at = 8 + track * 8;
+        tempo.push(Tempo {
+            delta: read_u32(song, at)?,
+            microseconds_per_quarter: read_u32(song, at + 4)?,
+        });
+    }
+
+    let (events, track_end) = decode_track(song, declared_track, index)?;
+    let padding = song.len() - track_end;
+    if song[track_end..].iter().any(|&b| b != 0) {
+        return Err(Error::Format(format!(
+            "song {index} has {padding} bytes after its track and they are not all zero"
+        )));
+    }
+
+    Ok(Song {
+        resolution,
+        tempo,
+        events,
+        padding,
+    })
+}
+
+fn decode_track(song: &[u8], start: usize, index: usize) -> Result<(Vec<Event>, usize)> {
+    let mut events = Vec::new();
+    let mut at = start;
+    loop {
+        let opcode = *song
+            .get(at)
+            .ok_or_else(|| Error::Format(format!("song {index}'s track has no end marker")))?;
+        at += 1;
+        let event = match opcode {
+            0x00..=0x7F => {
+                let operands = song.get(at..at + 4).ok_or_else(|| {
+                    Error::Format(format!("song {index} has a truncated note event"))
+                })?;
+                at += 4;
+                Event::Note {
+                    channel: opcode & 0x0F,
+                    port: opcode >> 4 & 1,
+                    key: operands[0],
+                    velocity: operands[1],
+                    gate: u16::from(operands[2]) | if opcode & 0x40 != 0 { 0x100 } else { 0 },
+                    delta: u16::from(operands[3]) | if opcode & 0x20 != 0 { 0x100 } else { 0 },
+                }
+            }
+            0x81 => {
+                let target = read_u16(song, at)?;
+                let count = *song.get(at + 2).ok_or_else(|| {
+                    Error::Format(format!("song {index} has a truncated reference event"))
+                })?;
+                at += 3;
+                if count == 0 {
+                    return Err(Error::Format(format!(
+                        "song {index} references a run of no events"
+                    )));
+                }
+                Event::Reference { target, count }
+            }
+            0x82 => {
+                let delta = *song.get(at).ok_or_else(|| {
+                    Error::Format(format!("song {index} has a truncated loop event"))
+                })?;
+                at += 1;
+                Event::Loop { delta }
+            }
+            0x83 => {
+                events.push(Event::End);
+                return Ok((events, at));
+            }
+            0x88..=0x8B => Event::GateAdd {
+                value: GATE_ADDENDS[(opcode - 0x88) as usize],
+            },
+            0x8C..=0x8F => Event::DeltaAdd {
+                value: DELTA_ADDENDS[(opcode - 0x8C) as usize],
+            },
+            0xA0..=0xEF => {
+                let channel = opcode & 0x0F;
+                let kind = opcode & 0xF0;
+                let operands = 1 + usize::from(matches!(kind, 0xA0 | 0xB0));
+                let bytes = song.get(at..at + operands + 1).ok_or_else(|| {
+                    Error::Format(format!("song {index} has a truncated MIDI event"))
+                })?;
+                at += operands + 1;
+                let delta = bytes[operands];
+                let port = bytes[0] >> 7;
+                let data1 = bytes[0] & 0x7F;
+                match kind {
+                    0xA0 => Event::Aftertouch {
+                        channel,
+                        port,
+                        key: data1,
+                        pressure: bytes[1],
+                        delta,
+                    },
+                    0xB0 => Event::Control {
+                        channel,
+                        port,
+                        controller: data1,
+                        value: bytes[1],
+                        delta,
+                    },
+                    0xC0 => Event::Program {
+                        channel,
+                        port,
+                        program: data1,
+                        delta,
+                    },
+                    0xD0 => Event::Pressure {
+                        channel,
+                        port,
+                        pressure: data1,
+                        delta,
+                    },
+                    _ => Event::Bend {
+                        channel,
+                        value: bytes[0],
+                        delta,
+                    },
+                }
+            }
+            _ => {
+                return Err(Error::Format(format!(
+                    "song {index} uses opcode 0x{opcode:02X} at 0x{:X}, which no song on the \
+                     retail disc uses and this decoder does not know",
+                    at - 1
+                )))
+            }
+        };
+        events.push(event);
+    }
+}
+
+fn addend(value: u16, addends: [u16; 4], base: u8, what: &str) -> Result<u8> {
+    addends
+        .iter()
+        .position(|&a| a == value)
+        .map(|i| base + i as u8)
+        .ok_or_else(|| {
+            Error::Format(format!(
+                "no opcode adds 0x{value:X} to the {what}; the encodable values are {addends:X?}"
+            ))
+        })
+}
+
+fn field(value: u8, limit: u8, what: &str) -> Result<u8> {
+    if value > limit {
+        return Err(Error::Format(format!(
+            "{what} is {value}, which does not fit in the {limit:#X} the format allows"
+        )));
+    }
+    Ok(value)
+}
+
+fn encode_event(event: &Event, out: &mut Vec<u8>) -> Result<()> {
+    match *event {
+        Event::Note {
+            channel,
+            port,
+            key,
+            velocity,
+            gate,
+            delta,
+        } => {
+            field(channel, 0x0F, "a note's channel")?;
+            field(port, 1, "a note's port")?;
+            field(key, 0x7F, "a note's key")?;
+            field(velocity, 0x7F, "a note's velocity")?;
+            if gate > NOTE_MAX || delta > NOTE_MAX {
+                return Err(Error::Format(format!(
+                    "a note event carries gate {gate} and delta {delta}; a note encodes at most \
+                     {NOTE_MAX} of each, and the rest belongs in gate_add and delta_add events"
+                )));
+            }
+            out.push(
+                channel
+                    | port << 4
+                    | if delta & 0x100 != 0 { 0x20 } else { 0 }
+                    | if gate & 0x100 != 0 { 0x40 } else { 0 },
+            );
+            out.extend_from_slice(&[key, velocity, gate as u8, delta as u8]);
+        }
+        Event::Reference { target, count } => {
+            if count == 0 {
+                return Err(Error::Format(
+                    "a reference to a run of no events cannot be encoded".to_string(),
+                ));
+            }
+            out.push(0x81);
+            out.extend_from_slice(&target.to_be_bytes());
+            out.push(count);
+        }
+        Event::Loop { delta } => out.extend_from_slice(&[0x82, delta]),
+        Event::End => out.push(0x83),
+        Event::GateAdd { value } => out.push(addend(value, GATE_ADDENDS, 0x88, "gate")?),
+        Event::DeltaAdd { value } => out.push(addend(value, DELTA_ADDENDS, 0x8C, "delta")?),
+        Event::Aftertouch {
+            channel,
+            port,
+            key,
+            pressure,
+            delta,
+        } => encode_midi(out, 0xA0, channel, port, key, Some(pressure), delta)?,
+        Event::Control {
+            channel,
+            port,
+            controller,
+            value,
+            delta,
+        } => encode_midi(out, 0xB0, channel, port, controller, Some(value), delta)?,
+        Event::Program {
+            channel,
+            port,
+            program,
+            delta,
+        } => encode_midi(out, 0xC0, channel, port, program, None, delta)?,
+        Event::Pressure {
+            channel,
+            port,
+            pressure,
+            delta,
+        } => encode_midi(out, 0xD0, channel, port, pressure, None, delta)?,
+        Event::Bend {
+            channel,
+            value,
+            delta,
+        } => {
+            field(channel, 0x0F, "a pitch bend's channel")?;
+            out.extend_from_slice(&[0xE0 | channel, value, delta]);
+        }
+    }
+    Ok(())
+}
+
+fn encode_midi(
+    out: &mut Vec<u8>,
+    kind: u8,
+    channel: u8,
+    port: u8,
+    data1: u8,
+    data2: Option<u8>,
+    delta: u8,
+) -> Result<()> {
+    field(channel, 0x0F, "a MIDI event's channel")?;
+    field(port, 1, "a MIDI event's port")?;
+    field(data1, 0x7F, "a MIDI event's first data byte")?;
+    out.push(kind | channel);
+    out.push(data1 | port << 7);
+    if let Some(data2) = data2 {
+        out.push(field(data2, 0x7F, "a MIDI event's second data byte")?);
+    }
+    out.push(delta);
+    Ok(())
+}
+
+pub fn encode(bank: &Bank) -> Result<Vec<u8>> {
+    if bank.format != FORMAT || bank.version != VERSION {
+        return Err(Error::Format(format!(
+            "not a {FORMAT} v{VERSION} bank"
+        )));
+    }
+    if bank.songs.is_empty() {
+        return Ok(vec![0; bank.size]);
+    }
+    if bank.songs.len() > u16::MAX as usize {
+        return Err(Error::Format(format!(
+            "a sequence bank holds at most {} songs, not {}",
+            u16::MAX,
+            bank.songs.len()
+        )));
+    }
+
+    let mut bodies = Vec::with_capacity(bank.songs.len());
+    for (index, song) in bank.songs.iter().enumerate() {
+        bodies.push(encode_song(song, index)?);
+    }
+
+    let mut out = Vec::with_capacity(bank.size);
+    out.extend_from_slice(&(bank.songs.len() as u16).to_be_bytes());
+    let mut offset = 2 + bank.songs.len() * 4;
+    for body in &bodies {
+        let Ok(offset32) = u32::try_from(offset) else {
+            return Err(Error::Format(
+                "a sequence bank grew past the 32-bit song offsets".to_string(),
+            ));
+        };
+        out.extend_from_slice(&offset32.to_be_bytes());
+        offset += body.len();
+    }
+    for body in &bodies {
+        out.extend_from_slice(body);
+    }
+    if out.len() != bank.size {
+        return Err(Error::Format(format!(
+            "the bank encodes to {} bytes but the area is {} -- a sound area cannot change size \
+             without rewriting 0.BIN's area map",
+            out.len(),
+            bank.size
+        )));
+    }
+    Ok(out)
+}
+
+fn encode_song(song: &Song, index: usize) -> Result<Vec<u8>> {
+    if !(MIN_RESOLUTION..=MAX_RESOLUTION).contains(&song.resolution) {
+        return Err(Error::Format(format!(
+            "song {index} has resolution {}, outside the driver's {MIN_RESOLUTION}..{MAX_RESOLUTION}",
+            song.resolution
+        )));
+    }
+    if song.tempo.is_empty() {
+        return Err(Error::Format(format!(
+            "song {index} has no tempo record, so it declares no tracks"
+        )));
+    }
+    if !matches!(song.events.last(), Some(Event::End)) {
+        return Err(Error::Format(format!(
+            "song {index} does not end with an end event"
+        )));
+    }
+    if song.events[..song.events.len() - 1]
+        .iter()
+        .any(|event| matches!(event, Event::End))
+    {
+        return Err(Error::Format(format!(
+            "song {index} has an end event before its last"
+        )));
+    }
+
+    let tracks = song.tempo.len();
+    let Ok(tracks16) = u16::try_from(tracks) else {
+        return Err(Error::Format(format!("song {index} declares too many tracks")));
+    };
+    let mut out = Vec::new();
+    out.extend_from_slice(&song.resolution.to_be_bytes());
+    out.extend_from_slice(&tracks16.to_be_bytes());
+    out.extend_from_slice(&(track_offset(tracks) as u16).to_be_bytes());
+    out.extend_from_slice(&(tempo_offset(tracks) as u16).to_be_bytes());
+    for tempo in &song.tempo {
+        out.extend_from_slice(&tempo.delta.to_be_bytes());
+        out.extend_from_slice(&tempo.microseconds_per_quarter.to_be_bytes());
+    }
+    for event in &song.events {
+        encode_event(event, &mut out).map_err(|e| Error::Format(format!("song {index}: {e}")))?;
+    }
+    out.resize(out.len() + song.padding, 0);
+    Ok(out)
+}
+
+pub fn load(path: &Path) -> Result<Bank> {
+    let text = std::fs::read_to_string(path)?;
+    let bank: Bank = serde_json::from_str(&text)?;
+    if bank.format != FORMAT || bank.version != VERSION {
+        return Err(Error::Format(format!(
+            "{} is not a {FORMAT} v{VERSION} bank",
+            path.display()
+        )));
+    }
+    Ok(bank)
+}
+
+pub fn write(bank: &Bank, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_string_pretty(bank)?;
+    json.push('\n');
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn event_count(bank: &Bank) -> usize {
+    bank.songs.iter().map(|song| song.events.len()).sum()
+}
+
+pub fn encoded_size(event: &Event) -> Result<usize> {
+    let mut out = Vec::with_capacity(5);
+    encode_event(event, &mut out)?;
+    Ok(out.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one_song() -> Vec<u8> {
+        let mut track = vec![
+            0xC0, 0x05, 0x00, 
+            0x8C, 
+            0x40, 0x3C, 0x64, 0x30, 0x18, 
+            0x83,
+        ];
+        let mut song = vec![
+            0x01, 0xE0, 
+            0x00, 0x01, 
+            0x00, 0x10, 
+            0x00, 0x08, 
+        ];
+        song.extend_from_slice(&0u32.to_be_bytes());
+        song.extend_from_slice(&500_000u32.to_be_bytes());
+        song.append(&mut track);
+        let mut bank = vec![0x00, 0x01];
+        bank.extend_from_slice(&6u32.to_be_bytes());
+        bank.append(&mut song);
+        bank
+    }
+
+    #[test]
+    fn a_song_decodes_to_the_opcodes_the_encoder_chose() {
+        let bank = decode(&one_song()).expect("decode");
+        assert_eq!(bank.size, one_song().len());
+        let song = &bank.songs[0];
+        assert_eq!(song.resolution, 480);
+        assert_eq!(
+            song.tempo,
+            vec![Tempo {
+                delta: 0,
+                microseconds_per_quarter: 500_000
+            }]
+        );
+        assert_eq!(
+            song.events,
+            vec![
+                Event::Program {
+                    channel: 0,
+                    port: 0,
+                    program: 5,
+                    delta: 0
+                },
+                Event::DeltaAdd { value: 0x100 },
+                Event::Note {
+                    channel: 0,
+                    port: 0,
+                    key: 0x3C,
+                    velocity: 0x64,
+                    gate: 0x130,
+                    delta: 0x18,
+                },
+                Event::End,
+            ]
+        );
+    }
+
+    #[test]
+    fn encoding_a_decode_reproduces_the_bytes() {
+        let data = one_song();
+        assert_eq!(encode(&decode(&data).expect("decode")).expect("encode"), data);
+    }
+
+    #[test]
+    fn a_bank_of_no_songs_is_an_empty_area() {
+        let bank = decode(&[0u8; 2048]).expect("decode");
+        assert!(bank.songs.is_empty());
+        assert_eq!(encode(&bank).expect("encode"), vec![0u8; 2048]);
+    }
+
+    #[test]
+    fn a_zero_count_over_real_data_is_refused() {
+        let mut data = vec![0u8; 64];
+        data[10] = 1;
+        assert!(decode(&data).is_err());
+    }
+
+    #[test]
+    fn an_unknown_opcode_is_refused_rather_than_skipped() {
+        let mut data = one_song();
+        let at = data.iter().position(|&b| b == 0xC0).expect("program change");
+        data[at] = 0x84;
+        let error = decode(&data).expect_err("unknown opcode").to_string();
+        assert!(error.contains("0x84"), "{error}");
+    }
+
+    #[test]
+    fn a_track_with_no_terminator_is_refused() {
+        let mut data = one_song();
+        let at = data.len() - 1;
+        data[at] = 0x88;
+        assert!(decode(&data).is_err());
+    }
+
+    #[test]
+    fn padding_that_is_not_zero_is_refused() {
+        let mut data = one_song();
+        data.push(0x01);
+        assert!(decode(&data).is_err());
+        let at = data.len() - 1;
+        data[at] = 0;
+        let bank = decode(&data).expect("decode");
+        assert_eq!(bank.songs[0].padding, 1);
+        assert_eq!(encode(&bank).expect("encode"), data);
+    }
+
+    #[test]
+    fn a_song_header_the_driver_would_not_read_is_refused() {
+        let mut data = one_song();
+        data[8] = 0x00;
+        data[9] = 0x02;
+        let error = decode(&data).expect_err("mismatched header").to_string();
+        assert!(error.contains("tracks"), "{error}");
+    }
+
+    #[test]
+    fn a_gate_too_large_for_a_note_is_refused_rather_than_truncated() {
+        let mut bank = decode(&one_song()).expect("decode");
+        let Event::Note { gate, .. } = &mut bank.songs[0].events[2] else {
+            panic!("expected a note");
+        };
+        *gate = 0x200;
+        let error = encode(&bank).expect_err("oversized gate").to_string();
+        assert!(error.contains("gate_add"), "{error}");
+    }
+
+    #[test]
+    fn a_bank_that_changed_size_is_refused() {
+        let mut bank = decode(&one_song()).expect("decode");
+        bank.songs[0].padding += 4;
+        let error = encode(&bank).expect_err("resized bank").to_string();
+        assert!(error.contains("area map"), "{error}");
+    }
+}

--- a/tools/saturn/assets/src/tone.rs
+++ b/tools/saturn/assets/src/tone.rs
@@ -1,0 +1,499 @@
+
+use crate::{sha256_hex, Error, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub const FORMAT: &str = "sotn-saturn-tone-bank";
+pub const VERSION: u32 = 1;
+pub const SAMPLES_NAME: &str = "samples.bin";
+
+const HEADER_SIZE: usize = 8;
+const LAYER_SIZE: usize = 0x20;
+const VOICE_HEADER_SIZE: usize = 4;
+const CURVE_SIZE: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurveSegment {
+    pub velocity: u8,
+    pub level: u8,
+    pub coefficient: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VelocityCurve {
+    pub coefficient: u8,
+    pub segments: [CurveSegment; 3],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Layer {
+    pub start_note: u8,
+    pub end_note: u8,
+    pub source_address: u32,
+    pub loop_start: u16,
+    pub loop_end: u16,
+    pub envelope: u32,
+    pub sound_direct: u8,
+    pub total_level: u8,
+    pub modulation: u16,
+    #[serde(default, skip_serializing_if = "is_zero_u16")]
+    pub reserved_12: u16,
+    pub lfo: u16,
+    pub effect_input: u16,
+    pub direct_pan: u8,
+    pub base_note: u8,
+    pub fine_tune: i8,
+    #[serde(default, skip_serializing_if = "is_zero_u16")]
+    pub reserved_1b: u16,
+    pub velocity_curve: u8,
+    #[serde(default, skip_serializing_if = "is_zero_u16")]
+    pub reserved_1e: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Voice {
+    pub play_mode_and_bend_range: u8,
+    pub portamento_time: u8,
+    pub volume_bias: i8,
+    pub layers: Vec<Layer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Samples {
+    pub offset: usize,
+    pub size: usize,
+    pub sha256: String,
+    pub file: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bank {
+    pub format: String,
+    pub version: u32,
+    pub size: usize,
+    pub mixer: String,
+    pub velocity_curves: Vec<VelocityCurve>,
+    pub unknown_4: String,
+    pub unknown_6: String,
+    pub voices: Vec<Voice>,
+    pub samples: Samples,
+}
+
+fn is_zero_u16(value: &u16) -> bool {
+    *value == 0
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn from_hex(text: &str, what: &str) -> Result<Vec<u8>> {
+    if !text.len().is_multiple_of(2) {
+        return Err(Error::Format(format!(
+            "{what} is {} hex digits, which is not a whole number of bytes",
+            text.len()
+        )));
+    }
+    (0..text.len())
+        .step_by(2)
+        .map(|at| {
+            u8::from_str_radix(&text[at..at + 2], 16)
+                .map_err(|_| Error::Format(format!("{what} is not hexadecimal: {text}")))
+        })
+        .collect()
+}
+
+fn read_u16(data: &[u8], at: usize) -> Result<u16> {
+    data.get(at..at + 2)
+        .map(|b| u16::from_be_bytes([b[0], b[1]]))
+        .ok_or_else(|| Error::Format(format!("tone bank is truncated at 0x{at:X}")))
+}
+
+fn read_u32(data: &[u8], at: usize) -> Result<u32> {
+    data.get(at..at + 4)
+        .map(|b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+        .ok_or_else(|| Error::Format(format!("tone bank is truncated at 0x{at:X}")))
+}
+
+fn block<'a>(data: &'a [u8], from: usize, to: usize, what: &str) -> Result<&'a [u8]> {
+    if to < from {
+        return Err(Error::Format(format!(
+            "the tone bank's {what} block ends at 0x{to:X}, before it starts at 0x{from:X}"
+        )));
+    }
+    data.get(from..to)
+        .ok_or_else(|| Error::Format(format!("the tone bank's {what} block runs past its end")))
+}
+
+pub fn decode(data: &[u8], samples_file: &str) -> Result<Bank> {
+    let mixer_offset = read_u16(data, 0)? as usize;
+    let velocity_offset = read_u16(data, 2)? as usize;
+    let unknown_4_offset = read_u16(data, 4)? as usize;
+    let unknown_6_offset = read_u16(data, 6)? as usize;
+    if mixer_offset < HEADER_SIZE || !(mixer_offset - HEADER_SIZE).is_multiple_of(2) {
+        return Err(Error::Format(format!(
+            "a voice table ending at 0x{mixer_offset:X} is not a whole number of offsets"
+        )));
+    }
+    let count = (mixer_offset - HEADER_SIZE) / 2;
+    if count == 0 {
+        return Err(Error::Format("tone bank has no voices".to_string()));
+    }
+
+    let mut voice_offsets = Vec::with_capacity(count);
+    for index in 0..count {
+        voice_offsets.push(read_u16(data, HEADER_SIZE + index * 2)? as usize);
+    }
+    let first_voice = voice_offsets[0];
+
+    let mixer = block(data, mixer_offset, velocity_offset, "mixer")?;
+    let curves = block(data, velocity_offset, unknown_4_offset, "velocity curve")?;
+    let unknown_4 = block(data, unknown_4_offset, unknown_6_offset, "unknown_4")?;
+    let unknown_6 = block(data, unknown_6_offset, first_voice, "unknown_6")?;
+    if !curves.len().is_multiple_of(CURVE_SIZE) {
+        return Err(Error::Format(format!(
+            "the velocity curve table is {} bytes, not a whole number of {CURVE_SIZE}-byte curves",
+            curves.len()
+        )));
+    }
+    let velocity_curves = curves
+        .chunks_exact(CURVE_SIZE)
+        .map(|curve| VelocityCurve {
+            coefficient: curve[0],
+            segments: std::array::from_fn(|i| CurveSegment {
+                velocity: curve[1 + i * 3],
+                level: curve[2 + i * 3],
+                coefficient: curve[3 + i * 3],
+            }),
+        })
+        .collect();
+
+    let mut voices = Vec::with_capacity(count);
+    let mut at = first_voice;
+    for (index, &offset) in voice_offsets.iter().enumerate() {
+        if offset != at {
+            return Err(Error::Format(format!(
+                "voice {index} is at 0x{offset:X}, but the voices before it end at 0x{at:X}; \
+                 every tone bank on the disc packs them end to end"
+            )));
+        }
+        let header = data
+            .get(offset..offset + VOICE_HEADER_SIZE)
+            .ok_or_else(|| Error::Format(format!("voice {index} lies outside the bank")))?;
+        let layer_count_minus_one = header[2] as i8;
+        if layer_count_minus_one < 0 {
+            return Err(Error::Format(format!("voice {index} has no layers")));
+        }
+        let layer_count = layer_count_minus_one as usize + 1;
+        let mut layers = Vec::with_capacity(layer_count);
+        for layer in 0..layer_count {
+            let base = offset + VOICE_HEADER_SIZE + layer * LAYER_SIZE;
+            if base + LAYER_SIZE > data.len() {
+                return Err(Error::Format(format!(
+                    "voice {index}'s layers run past the end of the bank"
+                )));
+            }
+            layers.push(Layer {
+                start_note: data[base],
+                end_note: data[base + 0x01],
+                source_address: read_u32(data, base + 0x02)?,
+                loop_start: read_u16(data, base + 0x06)?,
+                loop_end: read_u16(data, base + 0x08)?,
+                envelope: read_u32(data, base + 0x0A)?,
+                sound_direct: data[base + 0x0E],
+                total_level: data[base + 0x0F],
+                modulation: read_u16(data, base + 0x10)?,
+                reserved_12: read_u16(data, base + 0x12)?,
+                lfo: read_u16(data, base + 0x14)?,
+                effect_input: read_u16(data, base + 0x16)?,
+                direct_pan: data[base + 0x18],
+                base_note: data[base + 0x19],
+                fine_tune: data[base + 0x1A] as i8,
+                reserved_1b: read_u16(data, base + 0x1B)?,
+                velocity_curve: data[base + 0x1D],
+                reserved_1e: read_u16(data, base + 0x1E)?,
+            });
+        }
+        at = offset + VOICE_HEADER_SIZE + layer_count * LAYER_SIZE;
+        voices.push(Voice {
+            play_mode_and_bend_range: header[0],
+            portamento_time: header[1],
+            volume_bias: header[3] as i8,
+            layers,
+        });
+    }
+
+    let samples = data
+        .get(at..)
+        .ok_or_else(|| Error::Format("the voices run past the end of the bank".to_string()))?;
+    Ok(Bank {
+        format: FORMAT.to_string(),
+        version: VERSION,
+        size: data.len(),
+        mixer: to_hex(mixer),
+        velocity_curves,
+        unknown_4: to_hex(unknown_4),
+        unknown_6: to_hex(unknown_6),
+        voices,
+        samples: Samples {
+            offset: at,
+            size: samples.len(),
+            sha256: sha256_hex(samples),
+            file: samples_file.to_string(),
+        },
+    })
+}
+
+pub fn encode(bank: &Bank, samples: &[u8]) -> Result<Vec<u8>> {
+    if bank.format != FORMAT || bank.version != VERSION {
+        return Err(Error::Format(format!("not a {FORMAT} v{VERSION} bank")));
+    }
+    if bank.voices.is_empty() {
+        return Err(Error::Format("a tone bank has at least one voice".to_string()));
+    }
+    if samples.len() != bank.samples.size {
+        return Err(Error::Format(format!(
+            "{} is {} bytes, expected {}",
+            bank.samples.file,
+            samples.len(),
+            bank.samples.size
+        )));
+    }
+
+    let mixer = from_hex(&bank.mixer, "the mixer block")?;
+    let unknown_4 = from_hex(&bank.unknown_4, "the unknown_4 block")?;
+    let unknown_6 = from_hex(&bank.unknown_6, "the unknown_6 block")?;
+
+    let mixer_offset = HEADER_SIZE + bank.voices.len() * 2;
+    let velocity_offset = mixer_offset + mixer.len();
+    let unknown_4_offset = velocity_offset + bank.velocity_curves.len() * CURVE_SIZE;
+    let unknown_6_offset = unknown_4_offset + unknown_4.len();
+    let first_voice = unknown_6_offset + unknown_6.len();
+
+    let mut out = Vec::with_capacity(bank.size);
+    for offset in [
+        mixer_offset,
+        velocity_offset,
+        unknown_4_offset,
+        unknown_6_offset,
+    ] {
+        let Ok(offset16) = u16::try_from(offset) else {
+            return Err(Error::Format(
+                "the tone bank's structure grew past its 16-bit offsets".to_string(),
+            ));
+        };
+        out.extend_from_slice(&offset16.to_be_bytes());
+    }
+
+    let mut at = first_voice;
+    for (index, voice) in bank.voices.iter().enumerate() {
+        let Ok(offset16) = u16::try_from(at) else {
+            return Err(Error::Format(format!(
+                "voice {index} sits past the 16-bit voice offsets"
+            )));
+        };
+        out.extend_from_slice(&offset16.to_be_bytes());
+        if voice.layers.is_empty() || voice.layers.len() > 128 {
+            return Err(Error::Format(format!(
+                "voice {index} has {} layers; a voice holds 1 to 128",
+                voice.layers.len()
+            )));
+        }
+        at += VOICE_HEADER_SIZE + voice.layers.len() * LAYER_SIZE;
+    }
+
+    out.extend_from_slice(&mixer);
+    for curve in &bank.velocity_curves {
+        out.push(curve.coefficient);
+        for segment in &curve.segments {
+            out.extend_from_slice(&[segment.velocity, segment.level, segment.coefficient]);
+        }
+    }
+    out.extend_from_slice(&unknown_4);
+    out.extend_from_slice(&unknown_6);
+
+    for voice in &bank.voices {
+        out.extend_from_slice(&[
+            voice.play_mode_and_bend_range,
+            voice.portamento_time,
+            (voice.layers.len() - 1) as u8,
+            voice.volume_bias as u8,
+        ]);
+        for layer in &voice.layers {
+            let mut record = [0u8; LAYER_SIZE];
+            record[0x00] = layer.start_note;
+            record[0x01] = layer.end_note;
+            record[0x02..0x06].copy_from_slice(&layer.source_address.to_be_bytes());
+            record[0x06..0x08].copy_from_slice(&layer.loop_start.to_be_bytes());
+            record[0x08..0x0A].copy_from_slice(&layer.loop_end.to_be_bytes());
+            record[0x0A..0x0E].copy_from_slice(&layer.envelope.to_be_bytes());
+            record[0x0E] = layer.sound_direct;
+            record[0x0F] = layer.total_level;
+            record[0x10..0x12].copy_from_slice(&layer.modulation.to_be_bytes());
+            record[0x12..0x14].copy_from_slice(&layer.reserved_12.to_be_bytes());
+            record[0x14..0x16].copy_from_slice(&layer.lfo.to_be_bytes());
+            record[0x16..0x18].copy_from_slice(&layer.effect_input.to_be_bytes());
+            record[0x18] = layer.direct_pan;
+            record[0x19] = layer.base_note;
+            record[0x1A] = layer.fine_tune as u8;
+            record[0x1B..0x1D].copy_from_slice(&layer.reserved_1b.to_be_bytes());
+            record[0x1D] = layer.velocity_curve;
+            record[0x1E..0x20].copy_from_slice(&layer.reserved_1e.to_be_bytes());
+            out.extend_from_slice(&record);
+        }
+    }
+
+    if out.len() != bank.samples.offset {
+        return Err(Error::Format(format!(
+            "the structure encodes to 0x{:X} bytes but the samples start at 0x{:X}",
+            out.len(),
+            bank.samples.offset
+        )));
+    }
+    out.extend_from_slice(samples);
+    if out.len() != bank.size {
+        return Err(Error::Format(format!(
+            "the bank encodes to {} bytes but the area is {} -- a sound area cannot change size \
+             without rewriting 0.BIN's area map",
+            out.len(),
+            bank.size
+        )));
+    }
+    Ok(out)
+}
+
+pub fn load(path: &Path) -> Result<Bank> {
+    let text = std::fs::read_to_string(path)?;
+    let bank: Bank = serde_json::from_str(&text)?;
+    if bank.format != FORMAT || bank.version != VERSION {
+        return Err(Error::Format(format!(
+            "{} is not a {FORMAT} v{VERSION} bank",
+            path.display()
+        )));
+    }
+    Ok(bank)
+}
+
+pub fn write(bank: &Bank, path: &Path, samples: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut json = serde_json::to_string_pretty(bank)?;
+    json.push('\n');
+    std::fs::write(path, json)?;
+    let samples_path = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(&bank.samples.file);
+    std::fs::write(samples_path, samples)?;
+    Ok(())
+}
+
+pub fn layer_count(bank: &Bank) -> usize {
+    bank.voices.iter().map(|voice| voice.layers.len()).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one_bank() -> Vec<u8> {
+        let mixer = [0u8; 4];
+        let curve = [0x00, 0x08, 0x00, 0x46, 0x0A, 0x15, 0x5E, 0x13, 0x3F, 0x70];
+        let unknown_4 = [0x23u8, 0x00];
+        let unknown_6 = [0x00u8, 0x24];
+        let mixer_offset = HEADER_SIZE + 2 * 2;
+        let velocity_offset = mixer_offset + mixer.len();
+        let unknown_4_offset = velocity_offset + curve.len();
+        let unknown_6_offset = unknown_4_offset + unknown_4.len();
+        let first_voice = unknown_6_offset + unknown_6.len();
+        let voice_size = VOICE_HEADER_SIZE + LAYER_SIZE;
+
+        let mut out = Vec::new();
+        for offset in [
+            mixer_offset,
+            velocity_offset,
+            unknown_4_offset,
+            unknown_6_offset,
+        ] {
+            out.extend_from_slice(&(offset as u16).to_be_bytes());
+        }
+        out.extend_from_slice(&(first_voice as u16).to_be_bytes());
+        out.extend_from_slice(&((first_voice + voice_size) as u16).to_be_bytes());
+        out.extend_from_slice(&mixer);
+        out.extend_from_slice(&curve);
+        out.extend_from_slice(&unknown_4);
+        out.extend_from_slice(&unknown_6);
+        for voice in 0..2u8 {
+            out.extend_from_slice(&[0x02, 0x00, 0x00, 0x10]);
+            let mut layer = [0u8; LAYER_SIZE];
+            layer[0x00] = voice * 60;
+            layer[0x01] = voice * 60 + 59;
+            layer[0x02..0x06].copy_from_slice(&(0x0004_0000u32 + u32::from(voice)).to_be_bytes());
+            layer[0x08..0x0A].copy_from_slice(&0x0100u16.to_be_bytes());
+            layer[0x19] = 60;
+            layer[0x1A] = 0xFF; 
+            out.extend_from_slice(&layer);
+        }
+        out.extend_from_slice(&[0xAA; 8]);
+        out
+    }
+
+    #[test]
+    fn a_bank_decodes_to_named_voices_and_layers() {
+        let data = one_bank();
+        let bank = decode(&data, SAMPLES_NAME).expect("decode");
+        assert_eq!(bank.voices.len(), 2);
+        assert_eq!(layer_count(&bank), 2);
+        assert_eq!(bank.velocity_curves.len(), 1);
+        assert_eq!(bank.velocity_curves[0].segments[1].level, 0x15);
+        assert_eq!(bank.voices[1].layers[0].start_note, 60);
+        assert_eq!(bank.voices[1].layers[0].fine_tune, -1);
+        assert_eq!(bank.voices[1].layers[0].source_address, 0x0004_0001);
+        assert_eq!(bank.samples.size, 8);
+        assert_eq!(bank.samples.offset, data.len() - 8);
+    }
+
+    #[test]
+    fn encoding_a_decode_reproduces_the_bytes() {
+        let data = one_bank();
+        let bank = decode(&data, SAMPLES_NAME).expect("decode");
+        let samples = &data[bank.samples.offset..];
+        assert_eq!(encode(&bank, samples).expect("encode"), data);
+    }
+
+    #[test]
+    fn a_voice_table_that_is_not_end_to_end_is_refused() {
+        let mut data = one_bank();
+        let second = read_u16(&data, HEADER_SIZE + 2).expect("offset") + 1;
+        data[HEADER_SIZE + 2..HEADER_SIZE + 4].copy_from_slice(&second.to_be_bytes());
+        let error = decode(&data, SAMPLES_NAME).expect_err("gap").to_string();
+        assert!(error.contains("end to end"), "{error}");
+    }
+
+    #[test]
+    fn a_voice_with_no_layers_is_refused() {
+        let mut data = one_bank();
+        let first = read_u16(&data, HEADER_SIZE).expect("offset") as usize;
+        data[first + 2] = 0xFF; 
+        assert!(decode(&data, SAMPLES_NAME).is_err());
+    }
+
+    #[test]
+    fn samples_of_the_wrong_length_are_refused() {
+        let data = one_bank();
+        let bank = decode(&data, SAMPLES_NAME).expect("decode");
+        assert!(encode(&bank, &[0xAA; 7]).is_err());
+    }
+
+    #[test]
+    fn a_reserved_byte_that_is_set_still_round_trips() {
+        let mut data = one_bank();
+        let first = read_u16(&data, HEADER_SIZE).expect("offset") as usize;
+        data[first + VOICE_HEADER_SIZE + 0x12] = 0x5A;
+        let bank = decode(&data, SAMPLES_NAME).expect("decode");
+        assert_eq!(bank.voices[0].layers[0].reserved_12, 0x5A00);
+        let samples = data[bank.samples.offset..].to_vec();
+        assert_eq!(encode(&bank, &samples).expect("encode"), data);
+    }
+}

--- a/tools/saturn/assets/tests/retail_crt.rs
+++ b/tools/saturn/assets/tests/retail_crt.rs
@@ -1,5 +1,5 @@
 
-use saturn_assets::crt;
+use saturn_assets::{crt, midi, seq};
 use std::path::{Path, PathBuf};
 
 fn repo_root() -> PathBuf {
@@ -51,21 +51,21 @@ fn every_package_round_trips_byte_for_byte() {
     let mut areas = 0;
     let mut sequences = 0;
     let mut songs = 0;
+    let mut layers = 0;
     for (name, path) in &packages {
         let out = scratch(name);
         match crt::extract(&game, path, &out) {
             Ok(manifest) => {
                 areas += manifest.areas.len();
-                sequences += manifest
-                    .areas
-                    .iter()
-                    .filter(|area| area.contents == crt::Contents::Sequence)
-                    .count();
-                songs += manifest
-                    .areas
-                    .iter()
-                    .map(|area| area.songs.len())
-                    .sum::<usize>();
+                for area in &manifest.areas {
+                    match area.contents {
+                        crt::Contents::Sequence => {
+                            sequences += 1;
+                            songs += area.entries;
+                        }
+                        crt::Contents::Tone => layers += area.entries,
+                    }
+                }
                 let total: usize = manifest.areas.iter().map(|area| area.size).sum();
                 if total != manifest.source.crt_size {
                     failures.push(format!(
@@ -74,6 +74,9 @@ fn every_package_round_trips_byte_for_byte() {
                     ));
                 }
                 if let Err(e) = crt::verify(&out.join(crt::MANIFEST_NAME), path) {
+                    failures.push(format!("{name}: {e}"));
+                }
+                if let Err(e) = crt::verify_banks(&out.join(crt::MANIFEST_NAME)) {
                     failures.push(format!("{name}: {e}"));
                 }
             }
@@ -89,11 +92,104 @@ fn every_package_round_trips_byte_for_byte() {
         packages.len(),
         failures.join("\n  ")
     );
+    assert_eq!(areas, 161, "sound areas across the disc");
+    assert_eq!(sequences, 106, "sequence banks");
+    assert_eq!(songs, 6137, "songs");
+    assert_eq!(layers, 795, "tone layers");
     eprintln!(
-        "{} packages round-tripped byte-exactly: {areas} sound areas, \
-         {songs} songs across the {sequences} areas that probe as sequence banks",
+        "{} packages round-tripped byte-exactly, areas and banks both: {areas} sound areas, \
+         {songs} songs across {sequences} sequence banks, {layers} layers across the rest",
         packages.len()
     );
+}
+
+#[test]
+fn every_song_exports_as_a_standard_midi_file() {
+    let packages = packages();
+    if packages.is_empty() {
+        eprintln!("skipping: no SD_*.CRT files present");
+        return;
+    }
+    let game = disc().join("0.BIN");
+
+    let mut songs = 0;
+    let mut notes = 0;
+    let mut failures = Vec::new();
+    for (name, path) in &packages {
+        let out = scratch(&format!("midi-{name}"));
+        let manifest = crt::extract(&game, path, &out).expect("extract");
+        for area in &manifest.areas {
+            if area.contents != crt::Contents::Sequence {
+                continue;
+            }
+            let bank = seq::load(&out.join(&area.decoded)).expect("load seq.json");
+            for (index, song) in bank.songs.iter().enumerate() {
+                songs += 1;
+                match midi::song_to_smf(song) {
+                    Ok(smf) => {
+                        if &smf[..4] != b"MThd" {
+                            failures.push(format!("{name} area 0x{:02X} song {index}: not an SMF", area.id));
+                            continue;
+                        }
+                        let (on, off) = count_notes(&smf);
+                        notes += on;
+                        if on != off {
+                            failures.push(format!(
+                                "{name} area 0x{:02X} song {index}: {on} note-ons, {off} note-offs",
+                                area.id
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        failures.push(format!("{name} area 0x{:02X} song {index}: {e}", area.id))
+                    }
+                }
+            }
+        }
+        std::fs::remove_dir_all(&out).ok();
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} songs failed to export:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+    assert_eq!(songs, 6137);
+    eprintln!("{songs} songs exported as MIDI, {notes} notes in total");
+}
+
+fn count_notes(smf: &[u8]) -> (usize, usize) {
+    let mut at = 14;
+    let (mut on, mut off) = (0, 0);
+    while at + 8 <= smf.len() {
+        let size =
+            u32::from_be_bytes([smf[at + 4], smf[at + 5], smf[at + 6], smf[at + 7]]) as usize;
+        let body = &smf[at + 8..at + 8 + size];
+        let mut cursor = 0;
+        while cursor < body.len() {
+            while body[cursor] & 0x80 != 0 {
+                cursor += 1; 
+            }
+            cursor += 1;
+            let status = body[cursor];
+            cursor += match status {
+                0xFF => {
+                    let length = body[cursor + 2] as usize;
+                    3 + length
+                }
+                _ if status & 0xF0 == 0xC0 || status & 0xF0 == 0xD0 => 2,
+                _ => 3,
+            };
+            match status & 0xF0 {
+                0x90 => on += 1,
+                0x80 => off += 1,
+                _ => {}
+            }
+        }
+        at += 8 + size;
+    }
+    (on, off)
 }
 
 #[test]


### PR DESCRIPTION
This decodes the midi-like data and tone bank information in CRT files. e.g.

```
    {
      "play_mode_and_bend_range": 2,
      "portamento_time": 0,
      "volume_bias": 0,
      "layers": [
        {
          "start_note": 0,
          "end_note": 127,
          "source_address": 1255192,
          "loop_start": 0,
          "loop_end": 1096,
          "envelope": 2031647,
          "sound_direct": 0,
          "total_level": 0,
          "modulation": 0,
          "lfo": 0,
          "effect_input": 0,
          "direct_pan": 224,
          "base_note": 88,
          "fine_tune": 0,
          "velocity_curve": 0
        }
      ]
    }
```

and 
```
        {
          "op": "note",
          "channel": 0,
          "port": 0,
          "key": 64,
          "velocity": 65,
          "gate": 11,
          "delta": 1
        },
        {
          "op": "gate_add",
          "value": 512
        },
        {
          "op": "note",
          "channel": 1,
          "port": 0,
          "key": 64,
          "velocity": 65,
          "gate": 11,
          "delta": 0
        },
```