### PR TITLE
Use incbin for generated tilemaps

### DIFF
--- a/tools/sotn-assets/assets/layer/layer.go
+++ b/tools/sotn-assets/assets/layer/layer.go
@@ -303,13 +303,28 @@ func buildGenericU16(fileName string, symbol string, outputDir string) error {
 	if err != nil {
 		return err
 	}
+	u16Count := len(data) / 2
 
 	var sb strings.Builder
 	sb.WriteString("// clang-format off\n")
+	sb.WriteString("#if defined(VERSION_PSP) || defined(VERSION_PC)\n")
 	sb.WriteString(fmt.Sprintf("u16 %s[] = {\n", symbol))
-	u16Data := (*[1 << 30]uint16)(unsafe.Pointer(&data[0]))[:len(data)/2]
-	util.WriteWordsAsHex(&sb, u16Data)
+	if u16Count > 0 {
+		u16Data := unsafe.Slice((*uint16)(unsafe.Pointer(&data[0])), u16Count)
+		util.WriteWordsAsHex(&sb, u16Data)
+	}
 	sb.WriteString("};\n")
+	sb.WriteString("#else\n")
+	sb.WriteString("__asm__(\n")
+	sb.WriteString("\".section .data\\n\"\n")
+	sb.WriteString("\".align 2\\n\"\n")
+	sb.WriteString(fmt.Sprintf("\".globl %s\\n\"\n", symbol))
+	sb.WriteString(fmt.Sprintf("\"%s:\\n\"\n", symbol))
+	sb.WriteString(fmt.Sprintf("\".incbin \\\"%s\\\", 0, %d\\n\"\n",
+		filepath.ToSlash(fileName), u16Count*2))
+	sb.WriteString(");\n")
+	sb.WriteString(fmt.Sprintf("extern u16 %s[];\n", symbol))
+	sb.WriteString("#endif\n")
 
 	return util.WriteFile(filepath.Join(outputDir, fmt.Sprintf("gen/%s.h", symbol)), []byte(sb.String()))
 }


### PR DESCRIPTION
Partial mitigation for #2616 as a first experiment. Brings down the build time from 32.2s to 25.1s (22% faster).

the `__asm__` directive `.incbin` is only used for PS1 builds. PSP MWCC doesn't support `__asm__`, and PC builds have to think of too many compiler variants. The PS1 was the most affected in build speed anyway, where the major bottleneck is maspsx scanning giant generated byte arrays.

I think it's a fine and self-contained enough change. If successful I am thinking to do `cmpgfx` next, which is a much more involved change.