### PR TITLE
Get build time back on track

### DIFF
--- a/tools/sotn-assets/build.go
+++ b/tools/sotn-assets/build.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/deps"
+	"github.com/xeeynamo/sotn-decomp/tools/sotn-assets/util"
 )
 
 // allVersions are built by `./sotn.sh build` with no arguments.
@@ -114,11 +115,7 @@ func genNinjaIfNeeded(versionStr string, versions []string) error {
 func copyBuildToExpectedFolder(version string) error {
 	buildPath := filepath.Join("build", version)
 	expectedPath := filepath.Join("expected", "build", version)
-	_ = os.RemoveAll(expectedPath)
-	if err := os.CopyFS(expectedPath, os.DirFS(buildPath)); err != nil {
-		return err
-	}
-	return nil
+	return util.MirrorDir(buildPath, expectedPath)
 }
 
 func parseBuildArgs(args []string) ([]string, error) {

--- a/tools/sotn-assets/deps/build_deps.go
+++ b/tools/sotn-assets/deps/build_deps.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -109,23 +110,37 @@ func ensureSotnAssets() error {
 	if err != nil {
 		return fmt.Errorf("resolve own executable: %w", err)
 	}
-	selfInfo, err := os.Stat(self)
-	if err != nil {
-		return fmt.Errorf("stat own executable: %w", err)
-	}
-	if destInfo, err := os.Stat("bin/sotn-assets"); err == nil {
-		if selfInfo.ModTime().Equal(destInfo.ModTime()) {
-			return nil
-		}
-	}
-	if err := os.MkdirAll("bin", 0755); err != nil {
-		return err
-	}
 	src, err := os.ReadFile(self)
 	if err != nil {
 		return fmt.Errorf("read own executable: %w", err)
 	}
+	if same, err := sameContent("bin/sotn-assets", src); err != nil {
+		return err
+	} else if same {
+		return nil
+	}
+	if err := os.MkdirAll("bin", 0755); err != nil {
+		return err
+	}
 	return os.WriteFile("bin/sotn-assets", src, 0755)
+}
+
+func sameContent(path string, want []byte) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != int64(len(want)) {
+		return false, nil
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return bytes.Equal(got, want), nil
 }
 
 func ensurePythonDeps() error {

--- a/tools/sotn-assets/util/atomicwriter_test.go
+++ b/tools/sotn-assets/util/atomicwriter_test.go
@@ -1,0 +1,150 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeAtomically(t *testing.T, path, content string) {
+	t.Helper()
+	w, err := CreateAtomicWriter(path)
+	if err != nil {
+		t.Fatalf("CreateAtomicWriter: %v", err)
+	}
+	if _, err := w.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func mtimeOf(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.ModTime()
+}
+
+func TestAtomicWriterCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "asset.bin")
+	writeAtomically(t, path, "hello")
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("content = %q, want %q", got, "hello")
+	}
+}
+
+func TestAtomicWriterKeepsMtimeWhenContentIsUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "asset.bin")
+	writeAtomically(t, path, "unchanged payload")
+
+	// Backdate the file so any rewrite is unmistakable.
+	old := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	writeAtomically(t, path, "unchanged payload")
+
+	if got := mtimeOf(t, path); !got.Equal(old) {
+		t.Fatalf("mtime changed for identical content: %v -> %v", old, got)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "unchanged payload" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestAtomicWriterRewritesWhenContentDiffers(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name  string
+		first string
+		next  string
+	}{
+		{"same length", "aaaa", "aaab"},
+		{"longer", "aaaa", "aaaaa"},
+		{"shorter", "aaaa", "aaa"},
+		{"emptied", "aaaa", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			writeAtomically(t, path, tc.first)
+			old := time.Now().Add(-time.Hour).Truncate(time.Second)
+			if err := os.Chtimes(path, old, old); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+
+			writeAtomically(t, path, tc.next)
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if string(got) != tc.next {
+				t.Fatalf("content = %q, want %q", got, tc.next)
+			}
+			if mtimeOf(t, path).Equal(old) {
+				t.Fatal("mtime was not updated even though content changed")
+			}
+		})
+	}
+}
+
+func TestAtomicWriterHandlesLargeFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.bin")
+	payload := make([]byte, 64*1024*3+7)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	writeAtomically(t, path, string(payload))
+	old := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	writeAtomically(t, path, string(payload))
+	if got := mtimeOf(t, path); !got.Equal(old) {
+		t.Fatalf("large identical file was rewritten: %v -> %v", old, got)
+	}
+
+	// A difference in the final partial chunk must still be detected.
+	payload[len(payload)-1] ^= 0xff
+	writeAtomically(t, path, string(payload))
+	if mtimeOf(t, path).Equal(old) {
+		t.Fatal("difference in the trailing chunk was missed")
+	}
+}
+
+func TestAtomicWriterLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "asset.bin")
+	writeAtomically(t, path, "payload")
+	writeAtomically(t, path, "payload") // identical, takes the skip path
+	writeAtomically(t, path, "other")   // different, takes the rename path
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "asset.bin" {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Fatalf("temp files left behind: %v", names)
+	}
+}

--- a/tools/sotn-assets/util/mirror.go
+++ b/tools/sotn-assets/util/mirror.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// MirrorDir makes dst an exact copy of src while touching as little as
+// possible: files whose size and mtime already match src are left alone, and
+// anything in dst with no counterpart in src is removed.
+func MirrorDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", src)
+	}
+
+	wanted := map[string]bool{}
+	err = filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel != "." {
+			wanted[rel] = true
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			// The build tree holds only directories and regular files.
+			return fmt.Errorf("%s is neither a regular file nor a directory", path)
+		}
+		// Skip anything already mirrored, comparing size and mtime the way
+		// rsync does instead of re-reading the contents.
+		if cur, err := os.Stat(target); err == nil &&
+			cur.Mode().IsRegular() &&
+			cur.Size() == info.Size() &&
+			cur.ModTime().Equal(info.ModTime()) {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, data, info.Mode()); err != nil {
+			return err
+		}
+		// Carry the source mtime over so the next run can skip this file.
+		return os.Chtimes(target, info.ModTime(), info.ModTime())
+	})
+	if err != nil {
+		return fmt.Errorf("mirror %s to %s: %w", src, dst, err)
+	}
+
+	// Delete anything in dst that src no longer has.
+	var stale []string
+	err = filepath.WalkDir(dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		rel, err := filepath.Rel(dst, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." || wanted[rel] {
+			return nil
+		}
+		stale = append(stale, path)
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("scan %s for stale entries: %w", dst, err)
+	}
+	for _, path := range stale {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove stale %s: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/tools/sotn-assets/util/mirror_test.go
+++ b/tools/sotn-assets/util/mirror_test.go
@@ -1,0 +1,228 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustWrite(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// treeOf lists every entry under root as "relpath" for directories and
+// "relpath=content" for files, so two trees can be compared directly.
+func treeOf(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if info.IsDir() {
+			out = append(out, rel+"/")
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out = append(out, rel+"="+string(data))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestMirrorDirCreatesAnExactCopy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	mustWrite(t, filepath.Join(src, "a.bin"), "aaa", 0644)
+	mustWrite(t, filepath.Join(src, "sub", "b.bin"), "bbb", 0644)
+	mustWrite(t, filepath.Join(src, "sub", "deep", "c.bin"), "ccc", 0755)
+
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatalf("MirrorDir: %v", err)
+	}
+
+	got, want := treeOf(t, dst), treeOf(t, src)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("tree mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}
+
+// The whole point of the mirror: a second run over an unchanged tree must not
+// rewrite anything.
+func TestMirrorDirLeavesUnchangedFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	mustWrite(t, filepath.Join(src, "a.bin"), "aaa", 0644)
+	mustWrite(t, filepath.Join(src, "sub", "b.bin"), "bbb", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatalf("first MirrorDir: %v", err)
+	}
+
+	targets := []string{
+		filepath.Join(dst, "a.bin"),
+		filepath.Join(dst, "sub", "b.bin"),
+	}
+	before := map[string]time.Time{}
+	for _, p := range targets {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[p] = info.ModTime()
+	}
+
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatalf("second MirrorDir: %v", err)
+	}
+
+	for _, p := range targets {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !info.ModTime().Equal(before[p]) {
+			t.Fatalf("%s was rewritten despite being up to date", p)
+		}
+	}
+}
+
+func TestMirrorDirUpdatesChangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	mustWrite(t, filepath.Join(src, "a.bin"), "original", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(src, "a.bin"), "updated", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "a.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "updated" {
+		t.Fatalf("content = %q, want %q", got, "updated")
+	}
+}
+
+// Same size but different bytes: caught by the mtime half of the check.
+func TestMirrorDirDetectsSameSizeDifferentContent(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	srcFile := filepath.Join(src, "a.bin")
+	mustWrite(t, srcFile, "aaaa", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, srcFile, "aaab", 0644)
+	// Rewrites can land inside the same filesystem timestamp tick, so make the
+	// mtime difference explicit.
+	newer := time.Now().Add(time.Hour)
+	if err := os.Chtimes(srcFile, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "a.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "aaab" {
+		t.Fatalf("content = %q, want %q", got, "aaab")
+	}
+}
+
+func TestMirrorDirRemovesStaleEntries(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	mustWrite(t, filepath.Join(src, "keep.bin"), "keep", 0644)
+	mustWrite(t, filepath.Join(src, "gone.bin"), "gone", 0644)
+	mustWrite(t, filepath.Join(src, "olddir", "nested", "x.bin"), "x", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(filepath.Join(src, "gone.bin")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(src, "olddir")); err != nil {
+		t.Fatal(err)
+	}
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, want := treeOf(t, dst), treeOf(t, src)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("stale entries survived:\ngot  %v\nwant %v", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "olddir")); !os.IsNotExist(err) {
+		t.Fatal("stale directory olddir was not removed")
+	}
+}
+
+func TestMirrorDirPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	mustWrite(t, filepath.Join(src, "tool"), "#!/bin/sh\n", 0755)
+	mustWrite(t, filepath.Join(src, "data"), "data", 0644)
+	if err := MirrorDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, want := range map[string]os.FileMode{"tool": 0755, "data": 0644} {
+		info, err := os.Stat(filepath.Join(dst, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != want {
+			t.Fatalf("%s mode = %v, want %v", name, info.Mode().Perm(), want)
+		}
+	}
+}
+
+func TestMirrorDirRejectsMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	if err := MirrorDir(filepath.Join(dir, "absent"), filepath.Join(dir, "dst")); err == nil {
+		t.Fatal("expected an error for a missing source directory")
+	}
+}

--- a/tools/sotn-assets/util/utils.go
+++ b/tools/sotn-assets/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"image/color"
@@ -316,6 +317,16 @@ func CreateAtomicWriter(name string) (StringWriteCloser, error) {
 
 func (a AtomicWriter) Close() error {
 	a.f.Close()
+
+	same, err := sameFileContent(a.f.Name(), a.name)
+	if err != nil {
+		os.Remove(a.f.Name())
+		return fmt.Errorf("failed to compare temp file with destination %q: %v\n", a.name, err)
+	}
+	if same {
+		return os.Remove(a.f.Name())
+	}
+
 	if err := os.Rename(a.f.Name(), a.name); err != nil {
 		// in the common case, a.f will already be renamed
 		// in case it isn't remove the temp file
@@ -324,6 +335,58 @@ func (a AtomicWriter) Close() error {
 	}
 
 	return nil
+}
+
+// sameFileContent reports whether two files hold identical bytes. A missing
+// destination, which is the first-extraction case, is not an error and simply
+// counts as different.
+func sameFileContent(tempPath, destPath string) (bool, error) {
+	tempInfo, err := os.Stat(tempPath)
+	if err != nil {
+		return false, err
+	}
+	destInfo, err := os.Stat(destPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !destInfo.Mode().IsRegular() || tempInfo.Size() != destInfo.Size() {
+		return false, nil
+	}
+
+	tempFile, err := os.Open(tempPath)
+	if err != nil {
+		return false, err
+	}
+	defer tempFile.Close()
+	destFile, err := os.Open(destPath)
+	if err != nil {
+		return false, err
+	}
+	defer destFile.Close()
+
+	const chunk = 64 * 1024
+	tempBuf := make([]byte, chunk)
+	destBuf := make([]byte, chunk)
+	for {
+		n, tempErr := io.ReadFull(tempFile, tempBuf)
+		m, destErr := io.ReadFull(destFile, destBuf)
+		if n != m || !bytes.Equal(tempBuf[:n], destBuf[:m]) {
+			return false, nil
+		}
+		if tempErr != nil || destErr != nil {
+			// Sizes matched up front, so both readers hit the end together.
+			if isEOF(tempErr) && isEOF(destErr) {
+				return true, nil
+			}
+			if tempErr != nil && !isEOF(tempErr) {
+				return false, tempErr
+			}
+			return false, destErr
+		}
+	}
 }
 
 func (a AtomicWriter) Write(p []byte) (int, error) {
@@ -336,4 +399,8 @@ func (a AtomicWriter) WriteString(s string) (int, error) {
 
 func (a AtomicWriter) Name() string {
 	return a.f.Name()
+}
+
+func isEOF(err error) bool {
+	return err == io.EOF || err == io.ErrUnexpectedEOF
 }


### PR DESCRIPTION
I was getting tired of the abysmal build times. With this, the execution time of a `make` after a successful build goes down from 57s to 0.6s . There were a bunch of bugs on how the build chain was detecting dirty files.