### PR TITLE
Fix Palette png extraction

### DIFF
--- a/patch_assets.sh
+++ b/patch_assets.sh
@@ -1,0 +1,3 @@
+
+cp ~/sotn_banhammer/banhammer.png assets/st/no2/D_8019260C.png
+cp ~/sotn_banhammer/banhammer_pal.png assets/st/no2/D_80194A08/D_80194A08_6.png

--- a/patch_assets.sh
+++ b/patch_assets.sh
@@ -1,3 +1,0 @@
-
-cp ~/sotn_banhammer/banhammer.png assets/st/no2/D_8019260C.png
-cp ~/sotn_banhammer/banhammer_pal.png assets/st/no2/D_80194A08/D_80194A08_6.png

--- a/tools/sotn-assets/util/png/pngencode.go
+++ b/tools/sotn-assets/util/png/pngencode.go
@@ -59,12 +59,16 @@ func Encode(w io.Writer, data []byte, width, height int, palette []color.RGBA) e
 			return fmt.Errorf("data length (%d) < width*height (%d)", len(data), width*height/2)
 		}
 		// convert 4-bit nibbles to 8-bit data
-		convert := make([]byte, len(data)*2)
-		for i := 0; i < len(data); i++ {
-			convert[i*2+0] = data[i] & 15
-			convert[i*2+1] = data[i] >> 4
+		// But don't do it if the PNG we're encoding is a full 8 bit palette.
+		// Detect that by checking if we just have a 1x16 image.
+		if !(width == 16 && height == 1) {
+			convert := make([]byte, len(data)*2)
+			for i := 0; i < len(data); i++ {
+				convert[i*2+0] = data[i] & 15
+				convert[i*2+1] = data[i] >> 4
+			}
+			data = convert
 		}
-		data = convert
 	} else {
 		if len(data) < width*height {
 			return fmt.Errorf("data length (%d) < width*height (%d)", len(data), width*height)


### PR DESCRIPTION
I discovered this while playing with assets.

The majority of PNG files we want to export are using 16-bit indexed color, where every byte corresponds to two pixels. Therefore there is a routine in the PNG encoding script which breaks them up.

However, this routine was also running when extracting palettes, leading to the following issue:
<img width="1600" height="800" alt="palette_error" src="https://github.com/user-attachments/assets/c10a8fc3-4db5-45e6-af67-3a4a35b6333a" />


I have added a statement to test if the PNG we are dealing with appears to be a palette file (simply testing if it is a 1x16 image) and if so, it skips the step of unpacking the pixels and treats the pixels as full pixels. This fixes everything.

The "data" for a palette is simply the integers 0 to 15, but when this was running on a palette, it was getting converted to say 0 0 1 0 2 0 3 0 4 0 5 0 6 0 7 0 8 0 9 0 10 0 11 0 12 0 13 0 14 0 15 0 - so there was way too much zero padding.

I have confirmed that this fixes palette extraction. However, I can not guarantee that it did not break anything else. Overall this seems like a safe fix.
