### PR TITLE
pc: centralize runtime data file lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,29 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+set(SOTN_RUNTIME_DATA_DIR "${CMAKE_BINARY_DIR}/data")
+set(SOTN_RUNTIME_OVERRIDE_DIR "" CACHE PATH
+    "Optional directory containing PC runtime asset overrides")
+set(SOTN_US_DISK_DIR "${CMAKE_SOURCE_DIR}/disks/us")
+file(GLOB_RECURSE SOTN_US_DISK_FILES CONFIGURE_DEPENDS
+    LIST_DIRECTORIES false
+    "${SOTN_US_DISK_DIR}/*")
+set(SOTN_RUNTIME_DATA_FILES)
+foreach(source_file IN LISTS SOTN_US_DISK_FILES)
+    file(RELATIVE_PATH relative_file "${SOTN_US_DISK_DIR}" "${source_file}")
+    set(runtime_file "${SOTN_RUNTIME_DATA_DIR}/${relative_file}")
+    get_filename_component(runtime_directory "${runtime_file}" DIRECTORY)
+    add_custom_command(
+        OUTPUT "${runtime_file}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${runtime_directory}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${source_file}" "${runtime_file}"
+        DEPENDS "${source_file}"
+        VERBATIM)
+    list(APPEND SOTN_RUNTIME_DATA_FILES "${runtime_file}")
+endforeach()
+add_custom_target(sotn_runtime_data DEPENDS ${SOTN_RUNTIME_DATA_FILES})
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     set(CMAKE_BUILD_TYPE Debug)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
@@ -1221,6 +1244,7 @@ add_subdirectory(tools/psyz/psyz)
 add_executable(${PROJECT_NAME}
     ${SOURCE_FILES_PC}
     ${SOURCE_FILES_CORE})
+add_dependencies(${PROJECT_NAME} sotn_runtime_data)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     include
@@ -1235,7 +1259,13 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC
     HARD_LINK
     _internal_version_us
     __psyz
+    SOTN_RUNTIME_DATA_DIR="${SOTN_RUNTIME_DATA_DIR}"
 )
+
+if(SOTN_RUNTIME_OVERRIDE_DIR)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        SOTN_RUNTIME_OVERRIDE_DIR="${SOTN_RUNTIME_OVERRIDE_DIR}")
+endif()
 
 target_include_directories(psyz PUBLIC tools/psyz/psyz/include)
 target_compile_definitions(psyz PRIVATE __psyz)

--- a/src/dra/demo.c
+++ b/src/dra/demo.c
@@ -224,8 +224,8 @@ void DemoOpenFile(s32 arg0) {
 
 #ifdef VERSION_PC
     memset(DEMO_KEY_PTR, 0, DEMO_MAX_LEN);
-    FileReadToBuf("BIN/DEMOKEY.BIN", DEMO_KEY_PTR,
-                  g_DemoKeyIdx * DEMO_MAX_LEN, DEMO_MAX_LEN);
+    FileReadToBuf("BIN/DEMOKEY.BIN", DEMO_KEY_PTR, g_DemoKeyIdx * DEMO_MAX_LEN,
+                  DEMO_MAX_LEN);
     return;
 #endif
     if (arg0 == 0) {

--- a/src/dra/demo.c
+++ b/src/dra/demo.c
@@ -224,7 +224,7 @@ void DemoOpenFile(s32 arg0) {
 
 #ifdef VERSION_PC
     memset(DEMO_KEY_PTR, 0, DEMO_MAX_LEN);
-    FileReadToBuf("disks/us/BIN/DEMOKEY.BIN", DEMO_KEY_PTR,
+    FileReadToBuf("BIN/DEMOKEY.BIN", DEMO_KEY_PTR,
                   g_DemoKeyIdx * DEMO_MAX_LEN, DEMO_MAX_LEN);
     return;
 #endif

--- a/src/pc/io.c
+++ b/src/pc/io.c
@@ -3,6 +3,20 @@
 #include <stdlib.h>
 #include "pc.h"
 
+static FILE* OpenRuntimeFile(
+    const char* path, char* resolved, size_t resolvedSize) {
+#ifdef SOTN_RUNTIME_OVERRIDE_DIR
+    snprintf(
+        resolved, resolvedSize, "%s/%s", SOTN_RUNTIME_OVERRIDE_DIR, path);
+    FILE* file = fopen(resolved, "rb");
+    if (file != NULL) {
+        return file;
+    }
+#endif
+    snprintf(resolved, resolvedSize, "%s/%s", SOTN_RUNTIME_DATA_DIR, path);
+    return fopen(resolved, "rb");
+}
+
 struct FileAsStringCbParams {
     bool (*callback)(const struct FileAsString*);
     void* param;
@@ -72,10 +86,11 @@ static bool _FileUseContentCb(const struct FileOpenRead* f) {
 // true if successful.
 bool FileOpenRead(
     bool (*cb)(const struct FileOpenRead*), const char* filename, void* param) {
-    INFOF("open '%s'", filename);
-    FILE* f = fopen(filename, "rb");
+    char resolved[1024];
+    FILE* f = OpenRuntimeFile(filename, resolved, sizeof(resolved));
+    INFOF("open '%s'", resolved);
     if (f == NULL) {
-        ERRORF("unable to open '%s'", filename);
+        ERRORF("unable to open '%s'", resolved);
         return false;
     }
     fseek(f, 0, SEEK_END);
@@ -83,7 +98,7 @@ bool FileOpenRead(
     fseek(f, 0, SEEK_SET);
 
     struct FileOpenRead s = {
-        .filename = filename,
+        .filename = resolved,
         .file = f,
         .length = len,
         .param = param,
@@ -96,10 +111,11 @@ bool FileOpenRead(
 // Read the content of a binary file into the specified buffer by maxlen bytes.
 // The number of read bytes is returned; a negative value represents a failure.
 int FileReadToBuf(const char* filename, void* dst, int offset, size_t maxlen) {
-    INFOF("open '%s'", filename);
-    FILE* f = fopen(filename, "rb");
+    char resolved[1024];
+    FILE* f = OpenRuntimeFile(filename, resolved, sizeof(resolved));
+    INFOF("open '%s'", resolved);
     if (f == NULL) {
-        ERRORF("unable to open '%s'", filename);
+        ERRORF("unable to open '%s'", resolved);
         return -1;
     }
     fseek(f, offset, SEEK_SET);

--- a/src/pc/io.c
+++ b/src/pc/io.c
@@ -6,8 +6,7 @@
 static FILE* OpenRuntimeFile(
     const char* path, char* resolved, size_t resolvedSize) {
 #ifdef SOTN_RUNTIME_OVERRIDE_DIR
-    snprintf(
-        resolved, resolvedSize, "%s/%s", SOTN_RUNTIME_OVERRIDE_DIR, path);
+    snprintf(resolved, resolvedSize, "%s/%s", SOTN_RUNTIME_OVERRIDE_DIR, path);
     FILE* file = fopen(resolved, "rb");
     if (file != NULL) {
         return file;

--- a/src/pc/servant_pc.c
+++ b/src/pc/servant_pc.c
@@ -30,8 +30,7 @@ void HandleServantChr() {
         return;
     }
     char smolbuf[48];
-    snprintf(smolbuf, sizeof(smolbuf), "SERVANT/FT_00%d.BIN",
-             g_Servant - 1);
+    snprintf(smolbuf, sizeof(smolbuf), "SERVANT/FT_00%d.BIN", g_Servant - 1);
     u8 temp[0x6000];
     FileReadToBuf(smolbuf, &temp, 0, 0x6000);
     LoadTPage(&temp, 0, 0, 0x2C0, 0x100, 0x100, 0x80);

--- a/src/pc/servant_pc.c
+++ b/src/pc/servant_pc.c
@@ -30,7 +30,7 @@ void HandleServantChr() {
         return;
     }
     char smolbuf[48];
-    snprintf(smolbuf, sizeof(smolbuf), "disks/us/SERVANT/FT_00%d.BIN",
+    snprintf(smolbuf, sizeof(smolbuf), "SERVANT/FT_00%d.BIN",
              g_Servant - 1);
     u8 temp[0x6000];
     FileReadToBuf(smolbuf, &temp, 0, 0x6000);

--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -460,13 +460,13 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
         // inside a single combined BIN/F_GO.BIN on disk
         case 8: // game over bitmap foreground
             if (FileReadToBuf(
-                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x00000, 0x8000) < 0) {
+                    "BIN/F_GO.BIN", D_80280000, 0x00000, 0x8000) < 0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDD0, D_80280000);
             return 0;
         case 9: // game over bitmap background
-            if (FileReadToBuf("disks/us/BIN/F_GO.BIN", D_80280000, 0x08000,
+            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x08000,
                               0x10000) < 0) {
                 return -1;
             }
@@ -474,7 +474,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
             return 0;
         case 10: // game over palette foreground
             if (FileReadToBuf(
-                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x18000, 0x2000) < 0) {
+                    "BIN/F_GO.BIN", D_80280000, 0x18000, 0x2000) < 0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDB8, D_80280000);
@@ -482,7 +482,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
             return 0;
         case 11: // game over palette background
             if (FileReadToBuf(
-                    "disks/us/BIN/F_GO.BIN", D_80280000, 0x1A000, 0x2000) < 0) {
+                    "BIN/F_GO.BIN", D_80280000, 0x1A000, 0x2000) < 0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDA8, D_80280000);
@@ -532,7 +532,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
             sim.size = D_800A036C[actualFileId].size;
             sim.addr = D_800A036C[actualFileId].addr;
             sim.kind = SIM_VH;
-            snprintf(buf, sizeof(buf), "disks/us/%s", sim.path);
+            snprintf(buf, sizeof(buf), "%s", sim.path);
             if (FileReadToBuf(buf, sim.addr, 0, sim.size) < 0) {
                 return -1;
             }
@@ -607,7 +607,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
             sim.size = D_800A036C[actualFileId].size;
             sim.addr = D_800A036C[actualFileId].addr;
             sim.kind = SIM_VB;
-            snprintf(buf, sizeof(buf), "disks/us/%s", sim.path);
+            snprintf(buf, sizeof(buf), "%s", sim.path);
             if (FileReadToBuf(buf, sim.addr, 0, sim.size) < 0) {
                 return -1;
             }
@@ -677,7 +677,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
     case SimFileType_Monster:
         static const int MonsterChrLen = 0x5800;
         D_800A04EC = 0;
-        if (FileReadToBuf("disks/us/BIN/MONSTER.BIN", SIM_PTR,
+        if (FileReadToBuf("BIN/MONSTER.BIN", SIM_PTR,
                           fileId * MonsterChrLen, MonsterChrLen) < 0) {
             return -1;
         }
@@ -689,7 +689,7 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
         return -1;
     }
 
-    snprintf(buf, sizeof(buf), "disks/us/%s", sim.path);
+    snprintf(buf, sizeof(buf), "%s", sim.path);
     DEBUGF("about to load %s", buf);
     if (!FileUseContent(LoadFilePc, buf, &sim)) {
         ERRORF("failed to load '%s'", buf);

--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -459,30 +459,30 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
         // gof.bin, gob.bin, c_gof.bin, c_gob.bin are packed back-to-back
         // inside a single combined BIN/F_GO.BIN on disk
         case 8: // game over bitmap foreground
-            if (FileReadToBuf(
-                    "BIN/F_GO.BIN", D_80280000, 0x00000, 0x8000) < 0) {
+            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x00000, 0x8000) <
+                0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDD0, D_80280000);
             return 0;
         case 9: // game over bitmap background
-            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x08000,
-                              0x10000) < 0) {
+            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x08000, 0x10000) <
+                0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDD8, D_80280000);
             return 0;
         case 10: // game over palette foreground
-            if (FileReadToBuf(
-                    "BIN/F_GO.BIN", D_80280000, 0x18000, 0x2000) < 0) {
+            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x18000, 0x2000) <
+                0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDB8, D_80280000);
             StoreImage(&g_Vram.D_800ACDB8, g_Clut[2]);
             return 0;
         case 11: // game over palette background
-            if (FileReadToBuf(
-                    "BIN/F_GO.BIN", D_80280000, 0x1A000, 0x2000) < 0) {
+            if (FileReadToBuf("BIN/F_GO.BIN", D_80280000, 0x1A000, 0x2000) <
+                0) {
                 return -1;
             }
             LoadImage(&g_Vram.D_800ACDA8, D_80280000);
@@ -677,8 +677,8 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
     case SimFileType_Monster:
         static const int MonsterChrLen = 0x5800;
         D_800A04EC = 0;
-        if (FileReadToBuf("BIN/MONSTER.BIN", SIM_PTR,
-                          fileId * MonsterChrLen, MonsterChrLen) < 0) {
+        if (FileReadToBuf("BIN/MONSTER.BIN", SIM_PTR, fileId * MonsterChrLen,
+                          MonsterChrLen) < 0) {
             return -1;
         }
         LoadFileSimToMem(SIM_MONSTER);

--- a/src/pc/weapon_pc.c
+++ b/src/pc/weapon_pc.c
@@ -67,7 +67,7 @@ void HandleWeaponChr(unsigned handId, unsigned weaponId) {
     const int EntryLen = 0x3000 + PixLen;
     char path[32];
 
-    snprintf(path, sizeof(path), "disks/us/BIN/WEAPON%d.BIN", handId);
+    snprintf(path, sizeof(path), "BIN/WEAPON%d.BIN", handId);
     switch (handId) {
     case 0:
         FileReadToBuf(path, g_Pix[0], weaponId * EntryLen, PixLen);


### PR DESCRIPTION
This is scaffolding for Saturn stage support. We copy disks/us into the build folder since we have to modify it to add the new doors. We make PC use root-relative paths like BIN/F_GO.BIN. It also allows setting an override directory with SOTN_RUNTIME_OVERRIDE_DIR