### PR TITLE
pc: support loading stage overlays by name

### DIFF
--- a/src/dra/dra.h
+++ b/src/dra/dra.h
@@ -582,7 +582,7 @@ extern u16 g_JosephsCloakColors[4];
 extern GfxBank** g_GfxSharedBank[];
 extern s16** D_800A3B70[18];
 extern u_long* D_800A3BB8[];
-extern Lba g_StagesLba[80];
+extern Lba g_StagesLba[];
 
 extern SubweaponDef g_SubwpnDefs[13];
 // These are different on PSP since they have text that needs translating.

--- a/src/pc/main.c
+++ b/src/pc/main.c
@@ -3,52 +3,35 @@
 #include "pc.h"
 #include "spawn_point.h"
 #include <assert.h>
-#include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-static const char* allowed_stages[] = {
-    "no0",      "no1",      "lib",       "cat",      "no2",     "chi",
-    "dai",      "np3",      "cen",       "no4",      "are",     "top",
-    "nz0",      "nz1",      "wrp",       "no1_alt",  "no0_alt", "",
-    "dre",      "nz0_demo", "nz1_demo",  "lib_demo", "bo7",     "mar",
-    "bo6",      "bo5",      "bo4",       "bo3",      "bo2",     "bo1",
-    "bo0",      "st0",      "rno0",      "rno1",     "rlib",    "rcat",
-    "rno2",     "rchi",     "rdai",      "rno3",     "rcen",    "rno4",
-    "rare",     "rtop",     "rnz0",      "rnz1",     "rwrp",    "",
-    "",         "",         "",          "",         "",        "rnz1_demo",
-    "rbo8",     "rbo7",     "rbo6",      "rbo5",     "rbo4",    "rbo3",
-    "rbo2",     "rbo1",     "rbo0",      "",         "mad",     "no3",
-    "iwa_load", "iga_load", "hagi_load", "sel",      "te1",     "te2",
-    "te3",      "te4",      "te5",       "top_alt"};
 static const char* allowed_players[] = {"alu", "ric", "mar"};
 static const char* allowed_tests[] = {"sndlib"};
 #define PARSE_PARAM(param, allowed) parseStrParam(param, allowed, LEN(allowed))
 static int parseIntParam(const char* param) {
-    long i = strtol(param, NULL, 10);
-    if (i != LONG_MIN && i != LONG_MAX && i >= 0) {
+    char* end;
+    long i = strtol(param, &end, 10);
+    if (end != param && *end == '\0' && i != LONG_MIN && i != LONG_MAX &&
+        i >= 0) {
         return (int)i;
     }
     return -1;
 }
 static int parseStrParam(
     const char* param, const char* allowedValues[], int n) {
-    long i;
-    if (isdigit(param[0])) {
-        i = strtol(param, NULL, 10);
-        if (i != LONG_MIN && i != LONG_MAX && i >= 0) {
-            return (int)i;
+    int i = parseIntParam(param);
+    if (i >= 0) {
+        return i;
+    }
+    for (i = 0; i < n; i++) {
+        if (allowedValues[i] == NULL || allowedValues[i][0] == '\0') {
+            continue;
         }
-    } else {
-        for (i = 0; i < n; i++) {
-            if (allowedValues[i][0] == '\0') {
-                continue;
-            }
-            if (!strcmp(param, allowedValues[i])) {
-                return i;
-            }
+        if (!strcmp(param, allowedValues[i])) {
+            return i;
         }
     }
     return -1;
@@ -74,14 +57,17 @@ static void printHelp(void) {
 }
 static void printAllowedParams(const char* allowedValues[], int n) {
     int i;
+    bool first = true;
+
     printf("allowed params are: ");
-    for (i = 0; i < n - 1; i++) {
-        if (allowedValues[i][0] == '\0') {
+    for (i = 0; i < n; i++) {
+        if (allowedValues[i] == NULL || allowedValues[i][0] == '\0') {
             continue;
         }
-        printf("%s, ", allowedValues[i]);
+        printf("%s%s", first ? "" : ", ", allowedValues[i]);
+        first = false;
     }
-    printf("%s\n", allowedValues[i - 1]);
+    printf("\n");
 }
 static bool parseArgs(
     struct InitGameParams* outParams, int argc, char* argv[]) {
@@ -89,6 +75,7 @@ static bool parseArgs(
     outParams->diskPath = NULL;
     outParams->testMode = NO_TEST;
     outParams->stage = -1;
+    outParams->stageName = NULL;
     outParams->player = -1;
     outParams->demo = -1;
     outParams->scale = 1;
@@ -106,11 +93,10 @@ static bool parseArgs(
         if (strcmp(argv[i], "--disk") == 0 && i + 1 < argc) {
             outParams->diskPath = argv[++i];
         } else if (strcmp(argv[i], "--stage") == 0 && i + 1 < argc) {
-            outParams->stage = PARSE_PARAM(argv[++i], allowed_stages);
+            const char* stage = argv[++i];
+            outParams->stage = parseIntParam(stage);
             if (outParams->stage < 0) {
-                printf("stage '%s' is invalid or not recognized\n", argv[i]);
-                printAllowedParams(allowed_stages, LEN(allowed_stages));
-                return false;
+                outParams->stageName = stage;
             }
         } else if (strcmp(argv[i], "--player") == 0 && i + 1 < argc) {
             outParams->player = PARSE_PARAM(argv[++i], allowed_players);

--- a/src/pc/pc.h
+++ b/src/pc/pc.h
@@ -33,6 +33,7 @@ struct InitGameParams {
     const char* diskPath;
     enum TestMode testMode;
     int stage;
+    const char* stageName;
     int player;
     int demo;
     int scale;

--- a/src/pc/sim_pc.c
+++ b/src/pc/sim_pc.c
@@ -386,13 +386,46 @@ static bool isFirstBoot() {
     return g_StageId == STAGE_SEL && g_GameState == Game_Init;
 }
 
+typedef struct {
+    const char* name;
+    s32 stageId;
+} StageNameAlias;
+
+static s32 FindStageIdByName(const char* name) {
+    static const StageNameAlias aliases[] = {
+        {"no1_alt", STAGE_NO1_ALT},     {"no0_alt", STAGE_NO0_ALT},
+        {"nz0_demo", STAGE_NZ0_DEMO},   {"nz1_demo", STAGE_NZ1_DEMO},
+        {"lib_demo", STAGE_LIB_DEMO},   {"rnz1_demo", STAGE_RNZ1_DEMO},
+        {"iwa_load", STAGE_IWA_LOAD},   {"iga_load", STAGE_IGA_LOAD},
+        {"hagi_load", STAGE_HAGI_LOAD}, {"top_alt", STAGE_TOP_ALT},
+    };
+    char upperName[16];
+    s32 i;
+
+    for (i = 0; i < LEN(aliases); i++) {
+        if (!strcmp(name, aliases[i].name)) {
+            return aliases[i].stageId;
+        }
+    }
+    for (i = 0; name[i] != '\0' && i < LEN(upperName) - 1; i++) {
+        upperName[i] = (char)toupper((unsigned char)name[i]);
+    }
+    upperName[i] = '\0';
+    for (i = 0; i <= STAGE_TOP_ALT; i++) {
+        if (!strcmp(upperName, g_StagesLba[i].ovlName)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
 static bool IsBossOvl(const char* ovlName) {
     return (ovlName[0] == 'B' && ovlName[1] == 'O') ||
            (ovlName[0] == 'R' && ovlName[1] == 'B' && ovlName[2] == 'O') ||
            !strcmp(ovlName, "MAR");
 }
 
-static void LoadStagePrg(const char* name) {
+static bool LoadStagePrg(const char* name) {
     char ovlName[16];
     unsigned i;
     for (i = 0; name[i] && i < LEN(ovlName) - 1; i++) {
@@ -401,7 +434,9 @@ static void LoadStagePrg(const char* name) {
     ovlName[i] = '\0';
     if (!LoadStageOverlay(ovlName, &g_api.o)) {
         ERRORF("stage '%s' was not loaded", ovlName);
+        return false;
     }
+    return true;
 }
 
 s32 LoadFileSim(s32 fileId, SimFileType type) {
@@ -512,14 +547,26 @@ s32 LoadFileSim(s32 fileId, SimFileType type) {
                 DemoInit(2);
                 SetGameState(Game_NowLoading);
                 g_GameStep = 1;
-            } else if (g_GameParams.stage >= 0) {
+            } else if (
+                g_GameParams.stageName != NULL || g_GameParams.stage >= 0) {
+                if (g_GameParams.stageName != NULL && g_GameParams.stage < 0) {
+                    g_GameParams.stage =
+                        FindStageIdByName(g_GameParams.stageName);
+                    if (g_GameParams.stage < 0) {
+                        g_GameParams.stage = g_StageId;
+                    }
+                }
                 g_StageId = g_GameParams.stage;
                 SetGameState(Game_NowLoading);
                 g_GameStep = 1;
             }
         }
-        LoadStagePrg(g_StagesLba[g_StageId].ovlName);
-        return 0;
+        if (g_GameParams.stageName != NULL &&
+            FindStageIdByName(g_GameParams.stageName) < 0 &&
+            g_StageId == g_GameParams.stage) {
+            return LoadStagePrg(g_GameParams.stageName) ? 0 : -1;
+        }
+        return LoadStagePrg(g_StagesLba[g_StageId].ovlName) ? 0 : -1;
     case SimFileType_Vh:
         g_SimFile = &sim;
         if (fileId & 0x8000) {


### PR DESCRIPTION
The purpose here is getting rid of allowed_stages so that the stage list can be extended. This also allows loading a custom stage without editing any of the supporting parts of DRA like the LBA table.