### PR TITLE
PlayStation Format Angle Transformer & ILLEGAL Lint

### DIFF
--- a/src/boss/bo0/e_secrets.c
+++ b/src/boss/bo0/e_secrets.c
@@ -487,7 +487,7 @@ void func_us_801AC894(Entity* self) {
         InitializeEntity(g_EInitEnvironment);
         self->animCurFrame = 0;
         self->drawFlags |= ENTITY_ROTATE;
-        self->rotate = ROT(270.0);
+        self->rotate = ROT(270);
         if (g_CastleFlags[NO2_SECRET_CEILING_OPEN]) {
             for (i = 0; i < 8; i++) {
                 tileIdx = D_us_80180E14[i];

--- a/src/boss/bo1/e_explosion_flame.c
+++ b/src/boss/bo1/e_explosion_flame.c
@@ -146,7 +146,7 @@ void EntityExplosionFlame(Entity* self) {
             angle = self->rotate;
             self->velocityX = rcos(angle) << 4;
             self->velocityY = rsin(angle) << 4;
-            self->rotate -= 0x400;
+            self->rotate -= ROT(90);
             self->step_s++;
         }
         MoveEntity();
@@ -160,7 +160,7 @@ void EntityExplosionFlame(Entity* self) {
             angle = self->rotate;
             self->velocityX = (rcos(angle) * 7) << 2;
             self->velocityY = (rsin(angle) * 7) << 2;
-            self->rotate += 0x400;
+            self->rotate += ROT(90);
             self->blendMode = BLEND_ADD | BLEND_TRANSP;
             self->drawFlags =
                 ENTITY_OPACITY | ENTITY_ROTATE | ENTITY_SCALEY | ENTITY_SCALEX;

--- a/src/boss/bo1/e_granfaloon.c
+++ b/src/boss/bo1/e_granfaloon.c
@@ -369,7 +369,7 @@ void EntityGranfaloon(Entity* self) {
         case 2:
             MoveEntity();
             self->velocityY = FIX(0.5);
-            self->rotate -= 0x40;
+            self->rotate -= ROT(5.625);
             if (!(self->ext.granfaloon.timer & 3)) {
                 self->opacity -= 1;
             }
@@ -724,7 +724,7 @@ void func_us_801A2D90(Entity* self) {
         self->ext.granfaloon.timer = (Random() & 0x1F) + 0x10;
     case 1:
         MoveEntity();
-        self->rotate += 0x40;
+        self->rotate += ROT(5.625);
         if (self->velocityY < FIX(3.0)) {
             self->velocityY += 0x1400;
         }
@@ -1234,7 +1234,7 @@ void EntityZombieFalling(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY += FIX(0.0625);
-        self->rotate += 0x18;
+        self->rotate += ROT(2.109375);
         if (self->flags & FLAG_DEAD) {
             self->velocityY = 0;
             self->hitboxState = 0;

--- a/src/boss/bo2/e_minotaur.h
+++ b/src/boss/bo2/e_minotaur.h
@@ -67,7 +67,7 @@ void EntityMinotaurAttackHitbox(Entity* self) {
             /* fall through */
         case 1:
             MoveEntity();
-            self->rotate += 0x100;
+            self->rotate += ROT(22.5);
             self->velocityY += FIX(0.0625);
             if (!(g_Timer & 0xF)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
@@ -96,7 +96,7 @@ void EntityMinotaurAttackHitbox(Entity* self) {
             /* fall through */
         case 1:
             MoveEntity();
-            self->rotate += 0x100;
+            self->rotate += ROT(22.5);
             self->velocityY += FIX(0.25);
             parent = self - 1;
             delta = parent->posY.i.hi - self->posY.i.hi;

--- a/src/boss/bo4/doors.c
+++ b/src/boss/bo4/doors.c
@@ -199,7 +199,7 @@ void EntityUnkId17(Entity* self) {
         self->scaleX = D_us_801805C0[self->params & 0xF];
         self->scaleY = self->scaleX;
         if ((self->params & 0xF) % 2) {
-            self->rotate = -0x400;
+            self->rotate = ROT(-90);
         } else {
             self->rotate = 0;
         }
@@ -338,7 +338,7 @@ void EntityUnkId1C(Entity* self) {
     case 0:
         InitializeEntity(EInitUnk17);
         self->drawFlags |= ENTITY_ROTATE;
-        self->rotate = -0x400;
+        self->rotate = ROT(-90);
         if (self->params & 1) {
             self->animCurFrame = 0x64;
             self->velocityX = FIX(-0.5);

--- a/src/boss/bo4/unk_46E7C.c
+++ b/src/boss/bo4/unk_46E7C.c
@@ -4085,15 +4085,15 @@ void EntityHitByIce(Entity* self) {
         }
         if (DOPPLEGANGER.velocityY != 0) {
             if (DOPPLEGANGER.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (DOPPLEGANGER.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         self->step++;
@@ -5555,13 +5555,13 @@ void EntitySubwpnKnife(Entity* self) {
             angle2 = 0xD2;
             angle3 = 0x800 + 0xD2;
             angle4 = -0xD2;
-            self->rotate -= 0x80;
+            self->rotate -= ROT(11.25);
         } else {
             angle2 = 0x800 - 0xD2;
             angle1 = 0xD2;
             angle4 = 0x800 + 0xD2;
             angle3 = -0xD2;
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
         }
         angle1 += self->rotate;
         angle2 += self->rotate;

--- a/src/boss/bo5/unk_2159C.c
+++ b/src/boss/bo5/unk_2159C.c
@@ -55,9 +55,9 @@ void func_us_801A3E78(Entity* self) {
         }
         self->velocityY -= FIX(0.0625);
         if (self->params) {
-            self->rotate -= 0x40;
+            self->rotate -= ROT(5.625);
         } else {
-            self->rotate += 0x40;
+            self->rotate += ROT(5.625);
         }
         self->scaleX -= 0xA;
         self->opacity -= 6;

--- a/src/boss/bo5_psp/unk_FE10.c
+++ b/src/boss/bo5_psp/unk_FE10.c
@@ -49,9 +49,9 @@ void func_us_801A3E78(Entity* self) {
         }
         self->velocityY -= FIX(0.0625);
         if (self->params) {
-            self->rotate -= 0x40;
+            self->rotate -= ROT(5.625);
         } else {
-            self->rotate += 0x40;
+            self->rotate += ROT(5.625);
         }
         self->scaleX -= 0xA;
         self->opacity -= 6;

--- a/src/boss/rbo5/doors.c
+++ b/src/boss/rbo5/doors.c
@@ -222,7 +222,7 @@ void EntityUnkId17(Entity* self) {
         self->scaleX = D_us_801805D8[self->params & 0xF];
         self->scaleY = self->scaleX;
         if ((self->params & 0xF) % 2) {
-            self->rotate = -0x400;
+            self->rotate = ROT(-90);
         } else {
             self->rotate = 0;
         }
@@ -360,7 +360,7 @@ void EntityUnkId1C(Entity* self) {
     switch (self->step) {
     case 0:
         InitializeEntity(EInitUnk17);
-        self->rotate = -0x400;
+        self->rotate = ROT(-90);
         self->drawFlags |= ENTITY_ROTATE;
         if (self->params & 1) {
             self->animCurFrame = 0x64;

--- a/src/boss/rbo5/unk_4648C.c
+++ b/src/boss/rbo5/unk_4648C.c
@@ -3308,15 +3308,15 @@ void EntityHitByIce(Entity* self) {
         }
         if (DOPPLEGANGER.velocityY != 0) {
             if (DOPPLEGANGER.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (DOPPLEGANGER.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         self->step++;
@@ -4737,13 +4737,13 @@ void EntitySubwpnKnife(Entity* self) {
             angle2 = 0xD2;
             angle3 = 0x800 + 0xD2;
             angle4 = -0xD2;
-            self->rotate -= 0x80;
+            self->rotate -= ROT(11.25);
         } else {
             angle2 = 0x800 - 0xD2;
             angle1 = 0xD2;
             angle4 = 0x800 + 0xD2;
             angle3 = -0xD2;
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
         }
         angle1 += self->rotate;
         angle2 += self->rotate;

--- a/src/boss/rbo8/unk_15868.c
+++ b/src/boss/rbo8/unk_15868.c
@@ -158,7 +158,7 @@ void func_us_8019921C(Entity* self) {
         /* fall through */
     case 1:
         MoveEntity();
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
         self->velocityY += FIX(0.125);
         if (self->facingLeft) {
             self->velocityX = FIX(0.5);

--- a/src/boss/rbo8_psp/unk_EF80.c
+++ b/src/boss/rbo8_psp/unk_EF80.c
@@ -159,7 +159,7 @@ void func_us_8019921C(Entity* self) {
         /* fall through */
     case 1:
         MoveEntity();
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
         self->velocityY += FIX(0.125);
         if (self->facingLeft) {
             self->velocityX = FIX(0.5);

--- a/src/dra/7E4BC.c
+++ b/src/dra/7E4BC.c
@@ -796,15 +796,15 @@ void EntityHitByIce(Entity* self) {
         }
         if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (PLAYER.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         PlaySfx(SFX_MAGIC_SWITCH);

--- a/src/dra/84B88.c
+++ b/src/dra/84B88.c
@@ -152,13 +152,13 @@ void EntitySubwpnKnife(Entity* self) {
             angle2 = 0xD2;
             angle3 = 0x800 + 0xD2;
             angle4 = -0xD2;
-            self->rotate -= 0x80;
+            self->rotate -= ROT(11.25);
         } else {
             angle2 = 0x800 - 0xD2;
             angle1 = 0xD2;
             angle4 = 0x800 + 0xD2;
             angle3 = -0xD2;
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
         }
         angle1 += self->rotate;
         angle2 += self->rotate;
@@ -1307,7 +1307,7 @@ void EntityHellfireBigFireball(Entity* entity) {
     case 1:
         if (entity->pose >= 23) {
             if (!(g_GameTimer & 3)) {
-                entity->rotate += 0x400;
+                entity->rotate += ROT(90);
             }
             if (entity->velocityX < 0) {
                 entity->velocityX -= FIX(0.09375);

--- a/src/dra/8D3E8.c
+++ b/src/dra/8D3E8.c
@@ -1344,7 +1344,7 @@ void func_80130264(Entity* self) {
     switch (PLAYER.step_s) {
     case 1:
         if (D_800B0914 == 1) {
-            self->rotate -= 0x180;
+            self->rotate -= ROT(33.75);
         }
         break;
     case 2:
@@ -1452,7 +1452,7 @@ void func_80130618(Entity* self) {
     switch (PLAYER.step_s) {
     case 1:
         if (D_800B0914 == 1) {
-            self->rotate -= 0x100;
+            self->rotate -= ROT(22.5);
             self->posY.i.hi += 8;
         }
         if (D_80138430 < 0x601) {
@@ -1507,7 +1507,7 @@ void func_80130618(Entity* self) {
     case 4:
         if (D_800B0914 == 0) {
             self->posY.i.hi++;
-            self->rotate -= 0x180;
+            self->rotate -= ROT(33.75);
         }
         break;
     case 5:

--- a/src/maria/pl_blueprints.c
+++ b/src/maria/pl_blueprints.c
@@ -1146,21 +1146,21 @@ void MarEntityApplyMariaPowerAnim(Entity* self) {
     }
     prim = &g_PrimBuf[self->primIndex];
     prim->x0 =
-        posX + (((rcos(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y0 =
-        posY - (((rsin(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x1 =
-        posX + (((rcos(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y1 =
-        posY - (((rsin(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x2 =
-        posX + (((rcos(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y2 =
-        posY - (((rsin(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x3 =
-        posX + (((rcos(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y3 =
-        posY - (((rsin(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
 }
 
 void func_maria_801623E0(Entity* self) {
@@ -2087,22 +2087,22 @@ void MarEntityHitByIce(Entity* self) {
         }
         if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (PLAYER.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         if (PLAYER.step == PL_S_DEAD) {
             if (PLAYER.facingLeft) {
-                self->rotate = 0x180;
+                self->rotate = ROT(33.75);
             } else {
-                self->rotate = -0x180;
+                self->rotate = ROT(-33.75);
             }
             self->ext.hitbyice.unk80 = 1;
             self->ext.hitbyice.unk82 = 0x3C;
@@ -2117,23 +2117,23 @@ void MarEntityHitByIce(Entity* self) {
         if (PLAYER.step == PL_S_DEAD) {
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x21) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x280;
+                    self->rotate = ROT(56.25);
                 } else {
-                    self->rotate = -0x280;
+                    self->rotate = ROT(-56.25);
                 }
             }
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x22) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x380;
+                    self->rotate = ROT(78.75);
                 } else {
-                    self->rotate = -0x380;
+                    self->rotate = ROT(-78.75);
                 }
             }
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x20) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x180;
+                    self->rotate = ROT(33.75);
                 } else {
-                    self->rotate = -0x180;
+                    self->rotate = ROT(-33.75);
                 }
             }
         }

--- a/src/maria/pl_subweapons.c
+++ b/src/maria/pl_subweapons.c
@@ -764,15 +764,15 @@ void EntityMariaDragonCrash(Entity* self) {
             angle = NormalizeAngle(
                 ratan2(y - self->posY.i.hi, x - self->posX.i.hi));
             if (self->rotate < angle) {
-                if (angle - self->rotate < 0x800) {
-                    self->rotate += 0x40;
+                if (angle - self->rotate < ROT(180)) {
+                    self->rotate += ROT(5.625);
                 } else {
-                    self->rotate -= 0x40;
+                    self->rotate -= ROT(5.625);
                 }
             } else if (self->rotate - angle < 0x800) {
-                self->rotate -= 0x40;
+                self->rotate -= ROT(5.625);
             } else {
-                self->rotate += 0x40;
+                self->rotate += ROT(5.625);
             }
             SetGeomOffset(0, 0);
             func_psp_089285A0(self->rotate, &m);
@@ -1672,7 +1672,7 @@ void EntityMariaTurtleCrash(Entity* self) {
             self->drawFlags |= ENTITY_SCALEX | ENTITY_SCALEY | ENTITY_ROTATE;
             self->scaleX -= 0x20;
             self->scaleY -= 0x20;
-            self->rotate += 0xF78;
+            self->rotate += ROT(348.046875);
             return;
         }
         self->ext.mariaTurtleCrash.timer2 = 0x80;

--- a/src/ric/pl_blueprints.c
+++ b/src/ric/pl_blueprints.c
@@ -1412,21 +1412,21 @@ void RicEntityApplyMariaPowerAnim(Entity* self) {
     }
     prim = &g_PrimBuf[self->primIndex];
     prim->x0 =
-        posX + (((rcos(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y0 =
-        posY - (((rsin(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x1 =
-        posX + (((rcos(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y1 =
-        posY - (((rsin(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x2 =
-        posX + (((rcos(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y2 =
-        posY - (((rsin(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x3 =
-        posX + (((rcos(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y3 =
-        posY - (((rsin(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
 }
 
 void func_801623E0(Entity* self) {
@@ -2421,22 +2421,22 @@ void RicEntityHitByIce(Entity* self) {
         }
         if (PLAYER.velocityY != 0) {
             if (PLAYER.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (PLAYER.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         if (PLAYER.step == PL_S_DEAD) {
             if (PLAYER.facingLeft) {
-                self->rotate = 0x180;
+                self->rotate = ROT(33.75);
             } else {
-                self->rotate = -0x180;
+                self->rotate = ROT(-33.75);
             }
             self->ext.hitbyice.unk80 = 1;
             self->ext.hitbyice.unk82 = 0x3C;
@@ -2451,23 +2451,23 @@ void RicEntityHitByIce(Entity* self) {
         if (PLAYER.step == PL_S_DEAD) {
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x21) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x280;
+                    self->rotate = ROT(56.25);
                 } else {
-                    self->rotate = -0x280;
+                    self->rotate = ROT(-56.25);
                 }
             }
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x22) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x380;
+                    self->rotate = ROT(78.75);
                 } else {
-                    self->rotate = -0x380;
+                    self->rotate = ROT(-78.75);
                 }
             }
             if ((PLAYER.animCurFrame & 0x7FFF) == 0x20) {
                 if (PLAYER.facingLeft) {
-                    self->rotate = 0x180;
+                    self->rotate = ROT(33.75);
                 } else {
-                    self->rotate = -0x180;
+                    self->rotate = ROT(-33.75);
                 }
             }
         }

--- a/src/ric/pl_subweapon_cross.c
+++ b/src/ric/pl_subweapon_cross.c
@@ -229,7 +229,7 @@ void RicEntitySubwpnCross(Entity* self) {
         self->zPriority = PLAYER.zPriority;
         RicSetSpeedX(FIX(3.5625));
         self->drawFlags = ENTITY_ROTATE;
-        self->rotate = 0xC00;
+        self->rotate = ROT(270);
         self->ext.crossBoomerang.subweaponId = PL_W_CROSS;
         RicSetSubweaponParams(self);
         self->hitboxWidth = 8;
@@ -246,7 +246,7 @@ void RicEntitySubwpnCross(Entity* self) {
         // First phase. We spin at 0x80 angle units per frame.
         // Velocity gets decremented by 1/16 per frame until we slow
         // down to less than 0.75.
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         self->posX.val += self->velocityX;
         if (self->facingLeft) {
             xAccel = FIX(-1.0 / 16);
@@ -261,7 +261,7 @@ void RicEntitySubwpnCross(Entity* self) {
     case 3:
         // Second phase. Once we are slow, we spin twice as fast, and then
         // wait until our speed gets higher once again (turned around).
-        self->rotate -= 0x100;
+        self->rotate -= ROT(22.5);
         self->posX.val += self->velocityX;
         if (self->facingLeft) {
             xAccel = FIX(-1.0 / 16);
@@ -306,7 +306,7 @@ void RicEntitySubwpnCross(Entity* self) {
             return;
         }
         // Otherwise, we keep trucking. spin at the slower rate again.
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         self->posX.val += self->velocityX;
         break;
     case 7:
@@ -424,18 +424,18 @@ void RicEntitySubwpnCrossTrail(Entity* self) {
         self->facingLeft = PLAYER.facingLeft;
         self->zPriority = PLAYER.zPriority;
         self->drawFlags = ENTITY_ROTATE;
-        self->rotate = 0xC00;
+        self->rotate = ROT(270);
         self->step++;
         break;
     case 1:
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         if (self->ext.crossBoomerang.parent->step == 7) {
             self->step++;
             self->ext.crossBoomerang.timer = (self->params + 1) * 4;
         }
         break;
     case 2:
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         if (--self->ext.crossBoomerang.timer == 0) {
             DestroyEntity(self);
             return;

--- a/src/ric/pl_subweapon_holywater.c
+++ b/src/ric/pl_subweapon_holywater.c
@@ -149,11 +149,11 @@ void RicEntityCrashHydroStorm(Entity* self) {
             // both rcos and rsin could be pre-calcualted values
             // PSP and PSX are logically equivalent
 #if defined(VERSION_PSP)
-            line->velocityX.val = (rcos(0xB80) * 16) * 12;
+            line->velocityX.val = (rcos(ROT(258.75)) * 16) * 12;
 #else
-            line->velocityX.val = -(rcos(0xB80) * -16) * 12;
+            line->velocityX.val = -(rcos(ROT(258.75)) * -16) * 12;
 #endif
-            line->velocityY.val = -(rsin(0xB80) * 16) * 12;
+            line->velocityY.val = -(rsin(ROT(258.75)) * 16) * 12;
             line->timer = 0;
             line->delay = (rand() & 0xF) + 12;
             if (rand() & 1) {

--- a/src/ric/pl_subweapons.c
+++ b/src/ric/pl_subweapons.c
@@ -590,13 +590,13 @@ void RicEntitySubwpnKnife(Entity* self) {
             angle2 = 0xD2;
             angle3 = 0x800 + 0xD2;
             angle4 = -0xD2;
-            self->rotate -= 0x80;
+            self->rotate -= ROT(11.25);
         } else {
             angle2 = 0x800 - 0xD2;
             angle1 = 0xD2;
             angle4 = 0x800 + 0xD2;
             angle3 = -0xD2;
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
         }
         angle1 += self->rotate;
         angle2 += self->rotate;

--- a/src/servant/tt_003/demon.c
+++ b/src/servant/tt_003/demon.c
@@ -443,11 +443,11 @@ void func_us_80173D14(Entity* self) {
         }
         self->flags = FLAG_KEEP_ALIVE_OFFCAMERA | FLAG_HAS_PRIMS;
         if (self->facingLeft) {
-            s = rsin(0xE00);
-            c = rcos(0xE00);
+            s = rsin(ROT(315));
+            c = rcos(ROT(315));
         } else {
-            s = rsin(0xA00);
-            c = rcos(0xA00);
+            s = rsin(ROT(225));
+            c = rcos(ROT(225));
         }
         prim = &g_PrimBuf[self->primIndex];
         for (i = 0; i < 3; i++) {

--- a/src/st/cat/e_lossoth.c
+++ b/src/st/cat/e_lossoth.c
@@ -584,7 +584,7 @@ void EntityLossothFireball(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY += FIX(0.125);
-        self->rotate -= 0xC0;
+        self->rotate -= ROT(16.875);
         if (!(g_Timer & 3)) {
             // Spawn embers as the fireballs move
             newEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);

--- a/src/st/cen_psp/e_maria_blueprints.c
+++ b/src/st/cen_psp/e_maria_blueprints.c
@@ -1142,21 +1142,21 @@ void MarEntityApplyMariaPowerAnim(Entity* self) {
     }
     prim = &g_PrimBuf[self->primIndex];
     prim->x0 =
-        posX + (((rcos(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y0 =
-        posY - (((rsin(0x600) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(135)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x1 =
-        posX + (((rcos(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y1 =
-        posY - (((rsin(0x200) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(45)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x2 =
-        posX + (((rcos(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y2 =
-        posY - (((rsin(0xA00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(225)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->x3 =
-        posX + (((rcos(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posX + (((rcos(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
     prim->y3 =
-        posY - (((rsin(0xE00) >> 4) * self->ext.ricMariaPower.size) >> 8);
+        posY - (((rsin(ROT(315)) >> 4) * self->ext.ricMariaPower.size) >> 8);
 }
 
 void func_maria_801623E0(Entity* self) {
@@ -2085,22 +2085,22 @@ void MarEntityHitByIce(Entity* self) {
         }
         if (MARIA.velocityY != 0) {
             if (MARIA.facingLeft) {
-                self->rotate = 0x100;
+                self->rotate = ROT(22.5);
             } else {
-                self->rotate = -0x100;
+                self->rotate = ROT(-22.5);
             }
         } else {
             if (MARIA.velocityX > 0) {
-                self->rotate = 0x80;
+                self->rotate = ROT(11.25);
             } else {
-                self->rotate = 0xF80;
+                self->rotate = ROT(348.75);
             }
         }
         if (MARIA.step == PL_S_DEAD) {
             if (MARIA.facingLeft) {
-                self->rotate = 0x180;
+                self->rotate = ROT(33.75);
             } else {
-                self->rotate = -0x180;
+                self->rotate = ROT(-33.75);
             }
             self->ext.hitbyice.unk80 = 1;
             self->ext.hitbyice.unk82 = 0x3C;
@@ -2115,23 +2115,23 @@ void MarEntityHitByIce(Entity* self) {
         if (MARIA.step == PL_S_DEAD) {
             if ((MARIA.animCurFrame & 0x7FFF) == 0x21) {
                 if (MARIA.facingLeft) {
-                    self->rotate = 0x280;
+                    self->rotate = ROT(56.25);
                 } else {
-                    self->rotate = -0x280;
+                    self->rotate = ROT(-56.25);
                 }
             }
             if ((MARIA.animCurFrame & 0x7FFF) == 0x22) {
                 if (MARIA.facingLeft) {
-                    self->rotate = 0x380;
+                    self->rotate = ROT(78.75);
                 } else {
-                    self->rotate = -0x380;
+                    self->rotate = ROT(-78.75);
                 }
             }
             if ((MARIA.animCurFrame & 0x7FFF) == 0x20) {
                 if (MARIA.facingLeft) {
-                    self->rotate = 0x180;
+                    self->rotate = ROT(33.75);
                 } else {
-                    self->rotate = -0x180;
+                    self->rotate = ROT(-33.75);
                 }
             }
         }

--- a/src/st/cen_psp/e_maria_dragon.c
+++ b/src/st/cen_psp/e_maria_dragon.c
@@ -249,15 +249,15 @@ void EntityMariaDragonCrash(Entity* self) {
             angle = NormalizeAngle(
                 ratan2(y - self->posY.i.hi, x - self->posX.i.hi));
             if (self->rotate < angle) {
-                if (angle - self->rotate < 0x800) {
-                    self->rotate += 0x40;
+                if (angle - self->rotate < ROT(180)) {
+                    self->rotate += ROT(5.625);
                 } else {
-                    self->rotate -= 0x40;
+                    self->rotate -= ROT(5.625);
                 }
             } else if (self->rotate - angle < 0x800) {
-                self->rotate -= 0x40;
+                self->rotate -= ROT(5.625);
             } else {
-                self->rotate += 0x40;
+                self->rotate += ROT(5.625);
             }
             SetGeomOffset(0, 0);
             func_psp_089285A0(self->rotate, &m);

--- a/src/st/cen_psp/e_maria_subweapons.c
+++ b/src/st/cen_psp/e_maria_subweapons.c
@@ -663,7 +663,7 @@ void EntityMariaTurtleCrash(Entity* self) {
             self->drawFlags |= ENTITY_SCALEX | ENTITY_SCALEY | ENTITY_ROTATE;
             self->scaleX -= 0x20;
             self->scaleY -= 0x20;
-            self->rotate += 0xF78;
+            self->rotate += ROT(348.046875);
             break;
         }
 

--- a/src/st/chi/en_falling_stairs.c
+++ b/src/st/chi/en_falling_stairs.c
@@ -229,7 +229,7 @@ void EntityFallingStairs(Entity* self) {
         switch (self->step_s) {
         case ROTATE_CLOCKWISE:
             MoveEntity();
-            self->rotate += 0x12;
+            self->rotate += ROT(1.58203125);
             self->velocityY += FIX(0.25);
             scrolledY = self->posY.i.hi + g_Tilemap.scrollY.i.hi;
             if (self->ext.fallingStairs.prim7C != NULL) {
@@ -468,7 +468,7 @@ void EntityFallingStep(Entity* self) {
 
     case FALLING:
         MoveEntity();
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
         self->velocityY += FIX(0.25);
         posX = self->posX.i.hi;
         posY = self->posY.i.hi + 9;

--- a/src/st/e_azaghal.h
+++ b/src/st/e_azaghal.h
@@ -359,7 +359,7 @@ static void func_us_801B33F4(void) {
     RotMatrix(&sVec, &matrix);
 
     if (g_CurrentEntity->facingLeft) {
-        RotMatrixY(0x800, &matrix);
+        RotMatrixY(ROT(180), &matrix);
     }
 
     vector.vx = 0;

--- a/src/st/e_blood_skeleton.h
+++ b/src/st/e_blood_skeleton.h
@@ -122,9 +122,9 @@ void EntityBloodSkeleton(Entity* self) {
             if ((g_Timer % 3) == 0) {
                 self->ext.bloodSkeleton.timer++;
                 if (self->ext.bloodSkeleton.timer % 2) {
-                    self->rotate = 0x10;
+                    self->rotate = ROT(1.40625);
                 } else {
-                    self->rotate = -0x10;
+                    self->rotate = ROT(-1.40625);
                 }
             }
 

--- a/src/st/e_bone_archer.h
+++ b/src/st/e_bone_archer.h
@@ -431,9 +431,9 @@ void EntityBoneArcherArrow(Entity* self) {
         MoveEntity();
         self->velocityY += FIX(0.125);
         if (self->params == 1) {
-            self->rotate -= 0x20;
+            self->rotate -= ROT(2.8125);
         } else {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
         break;
     }

--- a/src/st/e_breakable_wall_debris.h
+++ b/src/st/e_breakable_wall_debris.h
@@ -26,9 +26,9 @@ void EntityBreakableWallDebris(Entity* self) {
 
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
         self->velocityY += FIX(0.125);
 

--- a/src/st/e_cavern_door.h
+++ b/src/st/e_cavern_door.h
@@ -25,7 +25,7 @@ void EntityCavernDoorLever(Entity* self) {
         InitializeEntity(CAVERN_DOOR_EINIT);
         self->animCurFrame = 18;
         self->drawFlags |= ENTITY_ROTATE;
-        self->rotate = -0x200;
+        self->rotate = ROT(-45);
         platform = self + 1;
         CreateEntityFromEntity(E_ID(CAVERN_DOOR_PLATFORM), self, platform);
         if (g_CastleFlags[NO4_TO_NP3_SHORTCUT]) {

--- a/src/st/e_gaibon_large_projectile.h
+++ b/src/st/e_gaibon_large_projectile.h
@@ -28,7 +28,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
             self->drawFlags = ENTITY_ROTATE;
             self->velocityX = (rcos(self->rotate) * FIX(3.5)) >> 0xC;
             self->velocityY = (rsin(self->rotate) * FIX(3.5)) >> 0xC;
-            self->rotate -= 0x400;
+            self->rotate -= ROT(90);
             self->palette = PAL_FLAG(PAL_UNK_1B6);
         } else {
             self->animSet = ANIMSET_DRA(14);

--- a/src/st/e_gurkha.h
+++ b/src/st/e_gurkha.h
@@ -638,7 +638,7 @@ void EntityGurkhaWeapon(Entity* self) {
 
     case 3:
         MoveEntity();
-        self->rotate -= 0x100;
+        self->rotate -= ROT(22.5);
         self->ext.GH_Props.rotate = self->rotate;
         self->ext.GH_Props.rotVel = -0xC0;
         angle = self->rotate;

--- a/src/st/e_harpy.h
+++ b/src/st/e_harpy.h
@@ -502,6 +502,6 @@ void EntityHarpyFeather(Entity* self) {
         self->velocityY = speed * rsin(angle);
     }
     MoveEntity();
-    self->rotate += 0x20;
+    self->rotate += ROT(2.8125);
     self->velocityY += FIX(1.0 / 8);
 }

--- a/src/st/e_imp.h
+++ b/src/st/e_imp.h
@@ -378,7 +378,7 @@ void EntityImp(Entity* self) {
             /* fallthrough */
         case 1:
             AnimateEntity(&anim_imp, self);
-            self->rotate += 0x40;
+            self->rotate += ROT(5.625);
             MoveEntity();
             self->velocityY += FIX(0.03125);
             if (!--self->ext.imp.timer) {

--- a/src/st/e_imp_death_particle.h
+++ b/src/st/e_imp_death_particle.h
@@ -45,10 +45,10 @@ void EntityImpDeathParticle(Entity* self) {
             self->velocityY += FIX(0.03125);
         }
 #if defined(VERSION_PSP)
-        angle = self->rotate += 0x80;
+        angle = self->rotate += ROT(11.25);
         self->velocityX = (rcos(angle) << 15) >> 12;
 #else
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         self->velocityX = (rcos(self->rotate) << 15) >> 12;
 #endif
         break;

--- a/src/st/e_jack_o_bones.h
+++ b/src/st/e_jack_o_bones.h
@@ -272,7 +272,7 @@ void EntityJackOBonesJack(Entity* self) {
     }
     MoveEntity();
     self->velocityY += FIX(0.1875);
-    self->rotate -= 0x40;
+    self->rotate -= ROT(5.625);
     xVar = self->posX.i.hi;
     yVar = self->posY.i.hi + 5;
     g_api.CheckCollision(xVar, yVar, &sp10, 0);

--- a/src/st/e_jewel_sword_puzzle.h
+++ b/src/st/e_jewel_sword_puzzle.h
@@ -358,7 +358,7 @@ void EntityFallingRock2(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY += FIX(0.25);
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
         collX = self->posX.i.hi;
         collY = self->posY.i.hi;
         collY += rockYOffsets[animFrame];

--- a/src/st/e_merman2.h
+++ b/src/st/e_merman2.h
@@ -242,7 +242,7 @@ void EntityMerman2(Entity* self) {
             if (self->velocityY > ~0xBFFF) {
                 prim->drawMode = DRAW_HIDE;
                 self->animCurFrame = 18;
-                self->rotate -= 0x80;
+                self->rotate -= ROT(11.25);
                 self->hitboxHeight = 8;
             } else {
                 // These should probably be written some other way
@@ -457,8 +457,8 @@ void EntityMerman2(Entity* self) {
                 self->velocityX = 0;
             }
             MoveEntity();
-            self->rotate += 0xC0;
-            if (self->rotate > 0x1000) {
+            self->rotate += ROT(16.875);
+            if (self->rotate > ROT(360)) {
                 self->posY.i.hi -= 10;
                 self->drawFlags &=
                     ENTITY_BLINK | ENTITY_MASK_B | ENTITY_MASK_G |

--- a/src/st/e_plate_lord_2.h
+++ b/src/st/e_plate_lord_2.h
@@ -546,7 +546,7 @@ void func_us_801D542C(Entity* self) {
             RotMatrixX(rotB.vx, &m);
             RotMatrixZ(self->ext.plateLordUnknown.unk8C, &m);
             if (!self->facingLeft) {
-                RotMatrixY(0x800, &m);
+                RotMatrixY(ROT(180), &m);
             }
             trans.vx = 0;
             trans.vy = 0;

--- a/src/st/e_skeleton.h
+++ b/src/st/e_skeleton.h
@@ -271,7 +271,7 @@ void EntitySkeletonThrownBone(Entity* self) { // Bone Projectile from Skeleton
             return;
         }
 
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         self->velocityY += 0x2400;
         MoveEntity();
 

--- a/src/st/e_stairway.h
+++ b/src/st/e_stairway.h
@@ -205,7 +205,7 @@ void EntityFallingRock(Entity* self) {
     case 1:
         MoveEntity();
         self->velocityY += FIX(0.125);
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
         x = self->posX.i.hi;
         y = self->posY.i.hi + 8;
         g_api.CheckCollision(x, y, &collider, 0);

--- a/src/st/e_subweapon_container.h
+++ b/src/st/e_subweapon_container.h
@@ -183,15 +183,15 @@ void EntitySubWpnContGlass(Entity* self) {
         self->velocityY += FIX(0.125);
         if (self->velocityX != 0) {
             if (self->facingLeft) {
-                self->rotate += 0x10;
+                self->rotate += ROT(1.40625);
             } else {
-                self->rotate -= 0x10;
+                self->rotate -= ROT(1.40625);
             }
         } else {
             if (self->facingLeft) {
-                self->rotate -= 0x10;
+                self->rotate -= ROT(1.40625);
             } else {
-                self->rotate += 0x10;
+                self->rotate += ROT(1.40625);
             }
         }
         break;
@@ -316,7 +316,7 @@ void EntitySubwpnInContainer(Entity* self) {
 #endif
         // Handles floating up and down within the liquid
         self->velocityY = rsin(self->rotate) * 2;
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
 
         parentContainer = self - 1;
         // Once the parent is broken (no longer idle) this entity becomes

--- a/src/st/e_tombstone.h
+++ b/src/st/e_tombstone.h
@@ -39,7 +39,7 @@ void EntityTombstone(Entity* self) {
         } else if (GetDistanceToPlayerX() < 0x40) {
             self->facingLeft = (GetSideToPlayer() & 1) ^ 1;
             self->ext.tombstone.timer = 0x18;
-            self->rotate = 0xFC0;
+            self->rotate = ROT(354.375);
             PlaySfxPositional(SFX_TOMBSTONE_MOVE);
             SetStep(3);
         }
@@ -57,10 +57,10 @@ void EntityTombstone(Entity* self) {
                 self->step_s++;
                 return;
             } else if (self->ext.tombstone.timer & 4) {
-                self->rotate += 0x20;
+                self->rotate += ROT(2.8125);
                 return;
             } else {
-                self->rotate -= 0x20;
+                self->rotate -= ROT(2.8125);
                 return;
             }
             return;

--- a/src/st/e_wereskeleton.h
+++ b/src/st/e_wereskeleton.h
@@ -299,7 +299,7 @@ void EntityWereskeleton(Entity* self) {
     case 13:
         MoveEntity();
         self->velocityY += FIX(0.25);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (self->ext.wereskeleton.unk7C++ > 4) {
             tempEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
             if (tempEntity != NULL) {

--- a/src/st/entity_axe_knight.h
+++ b/src/st/entity_axe_knight.h
@@ -481,9 +481,9 @@ void EntityAxeKnight(Entity* self) {
 
 void EntityAxeKnightRotateAxe(void) {
     if (g_CurrentEntity->params) {
-        g_CurrentEntity->rotate += 0x80;
+        g_CurrentEntity->rotate += ROT(11.25);
     } else {
-        g_CurrentEntity->rotate -= 0x80;
+        g_CurrentEntity->rotate -= ROT(11.25);
     }
 
     g_CurrentEntity->rotate &= 0xFFF;

--- a/src/st/no0/4E2E0.c
+++ b/src/st/no0/4E2E0.c
@@ -17,7 +17,7 @@ void func_us_801CE2E0(Entity* self) {
 
     if (self->step != 0) {
         UnkAnimFunc(anim_unk, self, 5);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         player = &PLAYER;
         if (self->ext.et_801CE2E0.unk88 & 0x40) {
             self->velocityY = FIX(-0.5);

--- a/src/st/no1/unk_39184.c
+++ b/src/st/no1/unk_39184.c
@@ -383,7 +383,7 @@ void func_us_801B9BE4(Entity* self) {
             if (!--self->ext.et_801B9BE4.unk80) {
                 self->step_s--;
             }
-            if (self->rotate >= 0x20) {
+            if (self->rotate >= ROT(2.8125)) {
                 self->hitboxState = 0;
                 tempEntity = AllocEntity(&g_Entities[224], &g_Entities[256]);
                 if (tempEntity != NULL) {
@@ -401,7 +401,7 @@ void func_us_801B9BE4(Entity* self) {
         break;
 
     case 2:
-        self->rotate = 0x20;
+        self->rotate = ROT(2.8125);
         xOffset = FLT_TO_I(rsin(self->rotate) * 18);
         yOffset = -FLT_TO_I(rcos(self->rotate) * 18);
         tempEntity = self - 1;

--- a/src/st/no2/e_secrets.c
+++ b/src/st/no2/e_secrets.c
@@ -487,7 +487,7 @@ void func_us_801B68EC(Entity* self) {
         InitializeEntity(g_EInitEnvironment);
         self->animCurFrame = 0;
         self->drawFlags |= ENTITY_ROTATE;
-        self->rotate = 0xC00;
+        self->rotate = ROT(270);
         if (g_CastleFlags[NO2_SECRET_CEILING_OPEN]) {
             for (i = 0; i < 8; i++) {
                 tileIdx = D_us_80180E14[i];

--- a/src/st/no3/e_death.c
+++ b/src/st/no3/e_death.c
@@ -353,7 +353,7 @@ void EntityDeath(Entity* self) {
         if (AnimateEntity(deathAnim14, self) == 0) {
             SetStep(2);
             self->drawFlags = ENTITY_ROTATE;
-            self->rotate = 0x1000;
+            self->rotate = ROT(360);
             self->posY.i.hi += 16;
             self->animCurFrame = 0x3A;
             self->ext.death.posX = self->posX.i.hi;
@@ -362,7 +362,7 @@ void EntityDeath(Entity* self) {
         break;
 
     case 2:
-        self->rotate -= 0x40;
+        self->rotate -= ROT(5.625);
         if (!self->rotate) {
             SetStep(3);
             self->drawFlags = ENTITY_DEFAULT;

--- a/src/st/no3/e_room_fg.c
+++ b/src/st/no3/e_room_fg.c
@@ -32,7 +32,7 @@ void EntityRoomForeground(Entity* self) {
         }
         if (self->params > 4) {
             self->drawFlags |= ENTITY_ROTATE;
-            self->rotate = 0x800;
+            self->rotate = ROT(180);
         }
     }
     AnimateEntity(objInit->animFrames, self);

--- a/src/st/no4/e_ferryman.c
+++ b/src/st/no4/e_ferryman.c
@@ -325,9 +325,9 @@ void EntityFerrymanController(Entity* self) {
                     tempEntity->params = 0;
                 }
                 self->ext.ferrymanBoat.splashTimer = 3;
-                self->rotate += 0x30;
+                self->rotate += ROT(4.21875);
                 self->step_s++;
-            } else if (self->rotate > -0x400) {
+            } else if (self->rotate > ROT(-90)) {
                 self->rotate -= 8;
             }
             break;
@@ -357,7 +357,7 @@ void EntityFerrymanController(Entity* self) {
                 self->velocityY -= FIX(0.625);
                 self->step_s++;
             }
-            self->rotate += 0x30;
+            self->rotate += ROT(4.21875);
             break;
         case 2:
             self->velocityY -= FIX(0.625);
@@ -692,7 +692,7 @@ void EntityBoatElevatorChains(Entity* self) {
                 prim = prim->next;
                 i++;
             }
-            self->rotate = 0x200;
+            self->rotate = ROT(45);
         } else {
             self->step = 0;
             return;
@@ -702,10 +702,10 @@ void EntityBoatElevatorChains(Entity* self) {
     if (self->ext.boatElevator_child.unk7C) {
         if (self->ext.boatElevator_child.unk7C < 0) {
             self->ext.boatElevator_child.unk7E++;
-            self->rotate += 0x10;
+            self->rotate += ROT(1.40625);
         } else {
             self->ext.boatElevator_child.unk7E--;
-            self->rotate -= 0x10;
+            self->rotate -= ROT(1.40625);
         }
     }
     self->ext.boatElevator_child.unk7E &= 0xF;

--- a/src/st/no4/e_secrets.c
+++ b/src/st/no4/e_secrets.c
@@ -238,9 +238,9 @@ void EntityBreakableWallDebris(Entity* self) {
         // fallthrough
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
         self->velocityY += FIX(0.125);
         posX = self->posX.i.hi;

--- a/src/st/no4/first_c_file.c
+++ b/src/st/no4/first_c_file.c
@@ -2259,9 +2259,9 @@ void func_us_801C5020(Entity* self) {
     }
 
     if (self->params) {
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
     } else {
-        self->rotate -= 0x20;
+        self->rotate -= ROT(2.8125);
     }
 
     self->posY.val += FIX(0.5);

--- a/src/st/np3/e_room_fg.c
+++ b/src/st/np3/e_room_fg.c
@@ -32,7 +32,7 @@ void EntityRoomForeground(Entity* self) {
         }
         if (self->params > 4) {
             self->drawFlags |= ENTITY_ROTATE;
-            self->rotate = 0x800;
+            self->rotate = ROT(180);
         }
     }
     AnimateEntity(objInit->animFrames, self);

--- a/src/st/np3/gaibon.c
+++ b/src/st/np3/gaibon.c
@@ -713,7 +713,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
         self->scaleX = 0xC0;
         self->velocityX = (rcos(self->rotate) * FIX(2.5)) >> 0xC;
         self->velocityY = (rsin(self->rotate) * FIX(2.5)) >> 0xC;
-        self->rotate -= 0x400;
+        self->rotate -= ROT(90);
         self->palette = PAL_FLAG(PAL_UNK_1B6);
 
     case 1:

--- a/src/st/np3/slogra.c
+++ b/src/st/np3/slogra.c
@@ -484,7 +484,7 @@ void EntitySlograSpear(Entity* self) {
         case 1:
             MoveEntity();
             self->velocityY += FIX(0.15625);
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
             if (!(self->rotate & 0xFFF)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
             }

--- a/src/st/nz0/e_left_secret_room_wall.c
+++ b/src/st/nz0/e_left_secret_room_wall.c
@@ -208,9 +208,9 @@ void EntitySecretWallDebris(Entity* self) {
         }
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
 
         self->velocityY += FIX(0.125);

--- a/src/st/nz0/gaibon.c
+++ b/src/st/nz0/gaibon.c
@@ -675,7 +675,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
         self->scaleX = 0xC0;
         self->velocityX = (rcos(self->rotate) * FIX(2.5)) >> 0xC;
         self->velocityY = (rsin(self->rotate) * FIX(2.5)) >> 0xC;
-        self->rotate -= 0x400;
+        self->rotate -= ROT(90);
         self->palette = PAL_FLAG(PAL_UNK_1B6);
 
     case 1:
@@ -705,7 +705,7 @@ void EntityLargeGaibonProjectile(Entity* self) {
             self->drawFlags = ENTITY_ROTATE;
             self->velocityX = (rcos(self->rotate) * FIX(3.5)) >> 0xC;
             self->velocityY = (rsin(self->rotate) * FIX(3.5)) >> 0xC;
-            self->rotate -= 0x400;
+            self->rotate -= ROT(90);
             self->palette = PAL_FLAG(PAL_UNK_1B6);
         } else {
             self->animSet = ANIMSET_DRA(14);

--- a/src/st/nz0/slogra.c
+++ b/src/st/nz0/slogra.c
@@ -526,7 +526,7 @@ void EntitySlograSpear(Entity* self) {
         case 1:
             MoveEntity();
             self->velocityY += FIX(0.15625);
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
             if (!(self->rotate & 0xFFF)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
             }

--- a/src/st/nz1/e_gear_vertical.c
+++ b/src/st/nz1/e_gear_vertical.c
@@ -19,7 +19,7 @@ void EntityGearVertical(Entity* self) {
         InitializeEntity(g_EInitEnvironment);
         self->zPriority = 0x6C;
         self->drawFlags = ENTITY_ROTATE;
-        self->rotate = 0x400;
+        self->rotate = ROT(90);
         // fallthrough
 
     case 1:

--- a/src/st/nz1/e_secrets.c
+++ b/src/st/nz1/e_secrets.c
@@ -237,9 +237,9 @@ void EntitySecretWallDebris(Entity* self) {
         /* fallthrough */
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
         self->velocityY += FIX(0.125);
         x = self->posX.i.hi;

--- a/src/st/rchi/e_gaibon.c
+++ b/src/st/rchi/e_gaibon.c
@@ -27,7 +27,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
         self->scaleX = 0xC0;
         self->velocityX = (rcos(self->rotate) * FIX(2.5)) >> 0xC;
         self->velocityY = (rsin(self->rotate) * FIX(2.5)) >> 0xC;
-        self->rotate -= 0x400;
+        self->rotate -= ROT(90);
         self->palette = PAL_FLAG(PAL_UNK_1B6);
 
     case 1:

--- a/src/st/rchi/e_slogra.c
+++ b/src/st/rchi/e_slogra.c
@@ -54,7 +54,7 @@ void EntitySlograSpear(Entity* self) {
         case 1:
             MoveEntity();
             self->velocityY += FIX(0.15625);
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
             if (!(self->rotate & 0xFFF)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
             }

--- a/src/st/rchi_psp/e_gaibon.c
+++ b/src/st/rchi_psp/e_gaibon.c
@@ -30,7 +30,7 @@ void EntitySmallGaibonProjectile(Entity* self) {
         self->scaleX = 0xC0;
         self->velocityX = (rcos(self->rotate) * FIX(2.5)) >> 0xC;
         self->velocityY = (rsin(self->rotate) * FIX(2.5)) >> 0xC;
-        self->rotate -= 0x400;
+        self->rotate -= ROT(90);
         self->palette = PAL_FLAG(PAL_UNK_1B6);
 
     case 1:

--- a/src/st/rchi_psp/e_slogra.c
+++ b/src/st/rchi_psp/e_slogra.c
@@ -57,7 +57,7 @@ void EntitySlograSpear(Entity* self) {
         case 1:
             MoveEntity();
             self->velocityY += FIX(0.15625);
-            self->rotate += 0x80;
+            self->rotate += ROT(11.25);
             if (!(self->rotate & 0xFFF)) {
                 PlaySfxPositional(SFX_ARROW_SHOT_A);
             }

--- a/src/st/rno1_psp/unk_10910.c
+++ b/src/st/rno1_psp/unk_10910.c
@@ -60,7 +60,7 @@ void func_us_80198A18_from_rbo4(Entity* self) {
         InitializeEntity(&D_us_80180778);
         self->drawFlags |= ENTITY_ROTATE;
         if ((self->params & 0xF) % 2) {
-            self->rotate = -0x400;
+            self->rotate = ROT(-90);
         } else {
             self->rotate = 0;
         }

--- a/src/st/rno3/e_dodo.c
+++ b/src/st/rno3/e_dodo.c
@@ -101,9 +101,9 @@ void EntityDodoBird(Entity* self) {
             self->velocityX = rsin(self->ext.dodo.timer) * 0x10;
             self->ext.dodo.timer += 0x20;
             if (self->velocityX > 0) {
-                self->rotate -= 0x40;
+                self->rotate -= ROT(5.625);
             } else {
-                self->rotate += 0x40;
+                self->rotate += ROT(5.625);
             }
         }
         break;
@@ -117,7 +117,7 @@ void EntityDodoBird(Entity* self) {
             /* fallthrough */
         case 1:
             AnimateEntity(dodo_freakout, self);
-            self->rotate -= 0x80;
+            self->rotate -= ROT(11.25);
             // Every 4 frames, spawn 5 more feathers.
             // Timer starts at 16, so this will hit 4 times.
             // Total of 20 feathers.

--- a/src/st/rno3/e_dragon_rider.c
+++ b/src/st/rno3/e_dragon_rider.c
@@ -79,7 +79,7 @@ void EntityDragonRider(Entity* self) {
             self->facingLeft = self->ext.orob.movingLeft;
         }
         if (self->rotate) {
-            self->rotate -= 0x10;
+            self->rotate -= ROT(1.40625);
         }
         xVar = self->posX.i.hi;
         yVar = self->posY.i.hi + 12;
@@ -109,7 +109,7 @@ void EntityDragonRider(Entity* self) {
                 self->poseTimer = 0;
                 self->pose = 0;
             } else {
-                self->rotate = 0x200;
+                self->rotate = ROT(45);
             }
             if (self->ext.orob.movingLeft) {
                 self->velocityX = FIX(1.5);

--- a/src/st/rno3/e_orobourous.c
+++ b/src/st/rno3/e_orobourous.c
@@ -95,7 +95,7 @@ void EntityOrobourous(Entity* self) {
             self->facingLeft = self->ext.orob.movingLeft;
         }
         if (self->rotate) {
-            self->rotate -= 0x10;
+            self->rotate -= ROT(1.40625);
         }
         xVar = self->posX.i.hi;
         yVar = self->posY.i.hi + 12;
@@ -125,7 +125,7 @@ void EntityOrobourous(Entity* self) {
                 self->poseTimer = 0;
                 self->pose = 0;
             } else {
-                self->rotate = 0x200;
+                self->rotate = ROT(45);
             }
             if (self->ext.orob.movingLeft) {
                 self->velocityX = FIX(1.5);
@@ -429,8 +429,8 @@ void EntityOrobRider(Entity* self) {
         }
         if (other->velocityY > 0) {
             self->animCurFrame = 13;
-            if (self->rotate > -0x240) {
-                self->rotate -= 0x18;
+            if (self->rotate > ROT(-50.625)) {
+                self->rotate -= ROT(2.109375);
             }
         } else {
             self->animCurFrame = 0;

--- a/src/st/rno3/e_room_fg.c
+++ b/src/st/rno3/e_room_fg.c
@@ -34,7 +34,7 @@ void EntityRoomForeground(Entity* self) {
         }
         if (self->params > 4) {
             self->drawFlags |= ENTITY_ROTATE;
-            self->rotate = 0x800;
+            self->rotate = ROT(180);
         }
     }
     AnimateEntity(objInit->animFrames, self);

--- a/src/st/rno4/e_breakable_wall.c
+++ b/src/st/rno4/e_breakable_wall.c
@@ -28,9 +28,9 @@ void EntityBreakableWallDebris(Entity* self) {
     case 1:
         MoveEntity();
 #ifdef VERSION_PSP
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
 #else
         {

--- a/src/st/rnz0/e_breakable.c
+++ b/src/st/rnz0/e_breakable.c
@@ -63,7 +63,7 @@ void EntityBreakableNZ0(Entity* self) {
         self->animSet = g_eBreakableanimSets[breakableType];
         if (!breakableType) {
             self->drawFlags = ENTITY_ROTATE;
-            self->rotate = 0x800;
+            self->rotate = ROT(180);
         }
         if (breakableType == 2) {
             self->unk5A = 0x4B;

--- a/src/st/rnz0/e_left_secret_room_wall.c
+++ b/src/st/rnz0/e_left_secret_room_wall.c
@@ -214,9 +214,9 @@ void EntitySecretWallDebris(Entity* self) {
         }
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
 
         self->velocityY += FIX(0.125);

--- a/src/st/rnz1/e_darkwing_bat.c
+++ b/src/st/rnz1/e_darkwing_bat.c
@@ -560,7 +560,7 @@ void EntityDarkwingBat(Entity* self) {
             self->ext.darkwing.unk86 = 1;
             self->drawFlags = ENTITY_ROTATE;
             // Strange value, potentially a mistake that should be 180 degrees
-            self->rotate = 0x180;
+            self->rotate = ROT(33.75);
             if (self->facingLeft) {
                 self->velocityX = FIX(-0.1875);
             } else {
@@ -626,7 +626,7 @@ void EntityDarkwingBat(Entity* self) {
             self->ext.darkwing.unk86 = 1;
             self->ext.darkwing.unk87 = 0;
             self->drawFlags = ENTITY_ROTATE;
-            self->rotate = 0x180;
+            self->rotate = ROT(33.75);
             if (self->facingLeft) {
                 self->velocityX = FIX(-0.1875);
             } else {
@@ -769,7 +769,7 @@ void EntityDarkwingWindDust(Entity* self) {
         self->velocityX += FIX(0.125);
     }
     self->velocityY = FIX(-1.5);
-    self->rotate -= 0x40;
+    self->rotate -= ROT(5.625);
     if (!(self->poseTimer & 1)) {
         self->animCurFrame += 1;
     }

--- a/src/st/rnz1/e_dw_batwings.c
+++ b/src/st/rnz1/e_dw_batwings.c
@@ -113,7 +113,7 @@ static Primitive* func_us_801AB380(
     RotMatrixZ(rotVec.vz, &m);
     mainBat = g_CurrentEntity - 1;
     if (mainBat->facingLeft) {
-        RotMatrixY(0x800, &m);
+        RotMatrixY(ROT(180), &m);
     }
     xOffset = arg0->unk30;
     yOffset = arg0->unk32;

--- a/src/st/rnz1/e_gear_vertical.c
+++ b/src/st/rnz1/e_gear_vertical.c
@@ -19,7 +19,7 @@ void EntityGearVertical(Entity* self) {
         InitializeEntity(g_EInitEnvironment);
         self->zPriority = 0x6C;
         self->drawFlags = ENTITY_ROTATE;
-        self->rotate = 0x400;
+        self->rotate = ROT(90);
         // fallthrough
 
     case 1:

--- a/src/st/rnz1/e_secrets.c
+++ b/src/st/rnz1/e_secrets.c
@@ -240,9 +240,9 @@ void EntitySecretWallDebris(Entity* self) {
         /* fallthrough */
     case 1:
         MoveEntity();
-        self->rotate += 0x20;
+        self->rotate += ROT(2.8125);
         if (self->params) {
-            self->rotate += 0x20;
+            self->rotate += ROT(2.8125);
         }
         self->velocityY += FIX(0.125);
         x = self->posX.i.hi;

--- a/src/st/rwrp/warp.c
+++ b/src/st/rwrp/warp.c
@@ -434,7 +434,7 @@ void EntityWarpSmallRocks(Entity* entity) {
         }
         break;
     case 4:
-        angle = entity->rotate += 0x20;
+        angle = entity->rotate += ROT(2.8125);
         entity->velocityY = rsin(angle) * 4;
         if (D_80180648 == 0) {
             entity->ext.warpRoom.unk88 = 0x10;

--- a/src/st/st0/2A8DC.c
+++ b/src/st/st0/2A8DC.c
@@ -85,7 +85,7 @@ void EntitySecretButton(Entity* self) {
 
         case 1:
             MoveEntity();
-            self->rotate += 0x40;
+            self->rotate += ROT(5.625);
             if (UnkCollisionFunc3(D_801808F8) & 1) {
                 self->step_s++;
                 break;
@@ -186,7 +186,7 @@ void EntitySecretStairs(Entity* self) {
             break;
         }
         self->drawFlags |= ENTITY_ROTATE;
-        self->rotate = -0x200;
+        self->rotate = ROT(-45);
         break;
 
     case 1:
@@ -197,7 +197,7 @@ void EntitySecretStairs(Entity* self) {
         break;
 
     case 2:
-        self->rotate += 0x10;
+        self->rotate += ROT(1.40625);
         if (!self->rotate) {
             self->drawFlags = ENTITY_DEFAULT;
             self->step++;

--- a/src/st/st0/2C564.c
+++ b/src/st/st0/2C564.c
@@ -1107,7 +1107,7 @@ void EntityDraculaGlass(Entity* entity) {
         }
     case 1:
         MoveEntity();
-        entity->rotate += 0x20;
+        entity->rotate += ROT(2.8125);
         entity->velocityY += FIX(0.125);
         if (entity->posY.i.hi > 204) {
             g_api.PlaySfx(SFX_DRA_GLASS_BREAK); // "What is a man?!"

--- a/src/st/st0/2DAC8.c
+++ b/src/st/st0/2DAC8.c
@@ -839,7 +839,7 @@ void EntityDraculaMegaFireball(Entity* self) {
             self->drawFlags |= ENTITY_ROTATE | ENTITY_SCALEY | ENTITY_SCALEX;
             self->scaleX = self->scaleY = 0x80;
             angle = self->rotate;
-            self->rotate = 0x1C0;
+            self->rotate = ROT(39.375);
             self->rotate -= angle;
             if (self->facingLeft) {
                 self->velocityX = rcos(angle) * 0x60;

--- a/src/st/top/e_secret_stairs.c
+++ b/src/st/top/e_secret_stairs.c
@@ -100,7 +100,7 @@ void EntityStairSwitch(Entity* self) {
 
         case 1:
             MoveEntity();
-            self->rotate += 0x40;
+            self->rotate += ROT(5.625);
             if (UnkCollisionFunc3(D_us_80180CAC) & 1) {
                 self->step_s++;
             } else {

--- a/src/st/wrp/warp.c
+++ b/src/st/wrp/warp.c
@@ -375,7 +375,7 @@ void EntityWarpSmallRocks(Entity* entity) {
         break;
 
     case 4:
-        angle = entity->rotate += 0x20;
+        angle = entity->rotate += ROT(2.8125);
         entity->velocityY = rsin(angle) * 4;
         if (D_80180648 == 0) {
             entity->ext.warpRoom.unk88 = 0x10;

--- a/src/weapon/w_008.c
+++ b/src/weapon/w_008.c
@@ -194,7 +194,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_009.c
+++ b/src/weapon/w_009.c
@@ -131,7 +131,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_010.c
+++ b/src/weapon/w_010.c
@@ -163,7 +163,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }
@@ -568,11 +568,11 @@ void func_ptr_80170024(Entity* self) {
         if (!((self->facingLeft ^ upperParams) & 1)) {
             self->ext.shield.unk9E = -0x100;
             self->ext.shield.unk9C = 0x800;
-            self->rotate = 0x200;
+            self->rotate = ROT(45);
         } else {
             self->ext.shield.unk9E = 0x100;
             self->ext.shield.unk9C = 0;
-            self->rotate = 0x600;
+            self->rotate = ROT(135);
         }
         self->ext.shield.equipId = self->ext.shield.parent->ext.shield.equipId;
         SetWeaponProperties(self, 0);

--- a/src/weapon/w_011.c
+++ b/src/weapon/w_011.c
@@ -134,7 +134,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_013.c
+++ b/src/weapon/w_013.c
@@ -132,7 +132,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->hitboxWidth = 12;
         self->hitboxHeight = 12;
         self->drawFlags |= DRAW_COLORS;
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
         self->velocityY += FIX(1.0 / 16);
@@ -159,7 +159,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->ext.heavenSword.unk7E++;
         return;
     case 3:
-        self->rotate -= 0x80;
+        self->rotate -= ROT(11.25);
         var_s1 = self->ext.heavenSword.unk84;
         self->ext.heavenSword.unk84 += 0x20;
         xVar = abs((PLAYER.posX.i.hi + PLAYER.hitboxOffX) - self->posX.i.hi);
@@ -291,7 +291,7 @@ static void func_ptr_80170008(Entity* self) {
         self->step++;
         return;
     case 1:
-        self->rotate += 0x100;
+        self->rotate += ROT(22.5);
         angle = self->ext.heavenSword.angle;
         self->ext.heavenSword.angle += -0x20;
         self->ext.heavenSword2.unk84 += 0x10;

--- a/src/weapon/w_014.c
+++ b/src/weapon/w_014.c
@@ -66,7 +66,7 @@ void EntityWeaponAttack(Entity* self) {
         DestroyEntityWeapon(true);
         self->hitboxHeight = 4;
         self->hitboxWidth = 4;
-        self->rotate = -0x700;
+        self->rotate = ROT(-157.5);
         self->drawFlags |= ENTITY_ROTATE;
 
         prim = &g_PrimBuf[self->primIndex];
@@ -112,7 +112,7 @@ void EntityWeaponAttack(Entity* self) {
         self->step++;
         break;
     case 1:
-        self->rotate += 0x70;
+        self->rotate += ROT(9.84375);
         if (self->rotate > 0) {
             self->rotate = 0;
         }

--- a/src/weapon/w_016.c
+++ b/src/weapon/w_016.c
@@ -168,7 +168,7 @@ void func_ptr_80170008(Entity* self) {
         self->ext.weapon_016.unk80 = 0x48;
         self->ext.weapon_016.unk7E = 0xA;
         self->ext.weapon_016.unk84 = 0;
-        self->rotate = 0x400;
+        self->rotate = ROT(90);
         SetWeaponProperties(self, 0);
         DestroyEntityWeapon(true);
         self->hitboxHeight = 0xC;
@@ -182,7 +182,7 @@ void func_ptr_80170008(Entity* self) {
         break;
     case 1:
         self->ext.weapon_016.unk7C += self->ext.weapon_016.unk7E;
-        self->rotate -= 0x100;
+        self->rotate -= ROT(22.5);
         angle = self->ext.weapon_016.unk7C;
         self->velocityX = rcos(angle) * self->ext.weapon_016.unk80;
         self->velocityY = -rsin(angle) * self->ext.weapon_016.unk80;

--- a/src/weapon/w_019.c
+++ b/src/weapon/w_019.c
@@ -96,7 +96,7 @@ void EntityWeaponAttack(Entity* self) {
     case 3:
         self->scaleX += 0x10;
         self->scaleY = self->scaleX;
-        self->rotate += 0x40;
+        self->rotate += ROT(5.625);
         if (self->opacity >= 5) {
             self->opacity += 0xFE;
         }

--- a/src/weapon/w_023.c
+++ b/src/weapon/w_023.c
@@ -149,7 +149,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_024.c
+++ b/src/weapon/w_024.c
@@ -133,7 +133,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_025.c
+++ b/src/weapon/w_025.c
@@ -140,7 +140,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_026.c
+++ b/src/weapon/w_026.c
@@ -136,7 +136,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_027.c
+++ b/src/weapon/w_027.c
@@ -152,7 +152,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.weapon.lifetime < 16) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_028.c
+++ b/src/weapon/w_028.c
@@ -129,7 +129,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.weapon.lifetime < 16) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_030.c
+++ b/src/weapon/w_030.c
@@ -942,7 +942,7 @@ s32 func_ptr_80170010(Entity* self) {
                 self->ext.weapon.vol = 0x7F;
             }
         }
-        self->rotate += 0x100;
+        self->rotate += ROT(22.5);
         self->scaleX += 2;
         if (self->scaleX > 0x100) {
             self->scaleX = 0x100;
@@ -962,7 +962,7 @@ s32 func_ptr_80170010(Entity* self) {
     case 2:
         self->posX.val += self->velocityX;
         if (!(g_GameTimer & 3)) {
-            self->rotate += 0x400;
+            self->rotate += ROT(90);
         }
         if (!(g_GameTimer & 1) && (rand() & 1)) {
             g_api.CreateEntFactoryFromEntity(self, FACTORY(0x24, 1), 0);

--- a/src/weapon/w_034.c
+++ b/src/weapon/w_034.c
@@ -203,7 +203,7 @@ static s32 func_ptr_80170004(Entity* self) {
         self->step++;
         break;
     case 1:
-        self->rotate += 0x200;
+        self->rotate += ROT(45);
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
         self->velocityX += self->ext.sword.unk7C;
@@ -216,7 +216,7 @@ static s32 func_ptr_80170004(Entity* self) {
         }
         break;
     case 2:
-        self->rotate += 0x200;
+        self->rotate += ROT(45);
         var_s1 = self->ext.sword.unk84;
         self->ext.sword.unk84 += 0x10;
         xDist = abs((PLAYER.posX.i.hi + PLAYER.hitboxOffX) - self->posX.i.hi);

--- a/src/weapon/w_042.c
+++ b/src/weapon/w_042.c
@@ -251,7 +251,7 @@ static void func_ptr_80170008(Entity* self) {
         self->step++;
         break;
     case 1:
-        self->rotate -= 0x60;
+        self->rotate -= ROT(8.4375);
         self->posX.val += self->velocityX;
         self->posY.val += self->velocityY;
         self->velocityY += FIX(0.15625);

--- a/src/weapon/w_044.c
+++ b/src/weapon/w_044.c
@@ -320,18 +320,18 @@ void EntityWeaponAttack(Entity* self) {
     sine = 0x80;
     lastBlockYShift = 0x68;
     if (doLastblock) {
-        prim->x0 = +(((rcos(0x600) >> 8) * self->scaleX) >> 8) + sine;
+        prim->x0 = +(((rcos(ROT(135)) >> 8) * self->scaleX) >> 8) + sine;
         prim->y0 =
-            -(((rsin(0x600) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
-        prim->x1 = +(((rcos(0x200) >> 8) * self->scaleX) >> 8) + sine;
+            -(((rsin(ROT(135)) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
+        prim->x1 = +(((rcos(ROT(45)) >> 8) * self->scaleX) >> 8) + sine;
         prim->y1 =
-            -(((rsin(0x200) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
-        prim->x2 = +(((rcos(0xA00) >> 8) * self->scaleX) >> 8) + sine;
+            -(((rsin(ROT(45)) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
+        prim->x2 = +(((rcos(ROT(225)) >> 8) * self->scaleX) >> 8) + sine;
         prim->y2 =
-            -(((rsin(0xA00) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
-        prim->x3 = +(((rcos(0xE00) >> 8) * self->scaleX) >> 8) + sine;
+            -(((rsin(ROT(225)) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
+        prim->x3 = +(((rcos(ROT(315)) >> 8) * self->scaleX) >> 8) + sine;
         prim->y3 =
-            -(((rsin(0xE00) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
+            -(((rsin(ROT(315)) >> 8) * self->scaleX) >> 8) + lastBlockYShift;
         prim->r0 = prim->g0 = prim->b0 = prim->r1 = prim->g1 = prim->b1 =
             prim->r2 = prim->g2 = prim->b2 = prim->r3 = prim->g3 = prim->b3 =
                 self->scaleY;

--- a/src/weapon/w_052.c
+++ b/src/weapon/w_052.c
@@ -301,7 +301,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/src/weapon/w_058.c
+++ b/src/weapon/w_058.c
@@ -133,7 +133,7 @@ static void EntityWeaponAttack(Entity* self) {
         self->posY.val += self->velocityY;
         self->posX.val += self->velocityX;
         self->velocityY += FIX(20.0 / 128);
-        self->rotate += 0x80;
+        self->rotate += ROT(11.25);
         if (--self->ext.timer.t < 0x10) {
             self->drawFlags |= ENTITY_BLINK;
         }

--- a/tools/lints/sotn-lint/src/main.rs
+++ b/tools/lints/sotn-lint/src/main.rs
@@ -21,6 +21,7 @@ mod palette_indices;
 mod player_status;
 mod primitive_type;
 mod relics;
+mod rot;
 mod sfx;
 mod vram_flag;
 
@@ -43,6 +44,7 @@ use player_status::PlayerStatusTransformer;
 use primitive_type::PrimitiveTypeTransformer;
 use rayon::prelude::*;
 use relics::RelicsTransformer;
+use rot::RotationTransformer;
 use sfx::SfxLineTransformer;
 use vram_flag::PlayerVramFlagTransformer;
 
@@ -106,6 +108,7 @@ const SKIPPED_DIRS: [&str; 2] = ["mednafen", "saturn"];
 fn process_directory(dir_path: &str) -> bool {
     let fixed_transformer = FixedTransformer;
     let relics_transformer = RelicsTransformer;
+    let rotation_transformer = RotationTransformer;
     let draw_mode_transformer = DrawModeTransformer::new();
     let blend_mode_transformer = BlendModeTransformer::new();
     let flags_transformer = FlagsTransformer::new();
@@ -118,6 +121,7 @@ fn process_directory(dir_path: &str) -> bool {
     let transformers: Vec<Box<dyn LineTransformer>> = vec![
         Box::new(fixed_transformer),
         Box::new(relics_transformer),
+        Box::new(rotation_transformer),
         Box::new(ColliderEffectsTransformer::new()),
         Box::new(draw_mode_transformer),
         Box::new(blend_mode_transformer),
@@ -141,6 +145,10 @@ fn process_directory(dir_path: &str) -> bool {
         Box::new(RegexLinter::new(
             "CreateEntity With Int",
             r"Create[^(]*Entity[^(]*\((?:(?:0x[0-9A-F]+)|(?:[0-9]+)),",
+        )),
+        Box::new(RegexLinter::new(
+            "ILLEGAL Entity Extension",
+            r"ext\.ILLEGAL",
         )),
     ];
 

--- a/tools/lints/sotn-lint/src/rot.rs
+++ b/tools/lints/sotn-lint/src/rot.rs
@@ -1,0 +1,154 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::line_transformer::LineTransformer;
+
+pub struct RotationTransformer;
+
+impl LineTransformer for RotationTransformer {
+    fn transform_line(&self, line: &str) -> String {
+        transform_line_rotation(line)
+    }
+}
+
+fn rotation(x: f64, group: &str, terminal: char) -> String {
+    let formatted_str = format!("{:.20}", x);
+    let trimmed_str = formatted_str
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string();
+    format!("{group}ROT({trimmed_str}){terminal}")
+}
+
+struct Pattern {
+    regex: Regex,
+    terminal: char,
+}
+
+fn gen_patterns(patterns: &mut Vec<Pattern>) {
+    // MATRIX and ratan2 not supported
+    // n.b.! GsBG, GsSPRITE, GsRVIEWUNIT use a different format for rotation
+    let regs = [
+        (r"(OBJECT->NAME\s*=\s*)(-?0x[0-9a-fA-F]+);", ';'), // =
+        (r"(OBJECT->NAME\s*\+=\s*)(-?0x[0-9a-fA-F]+);", ';'), // +=
+        (r"(OBJECT->NAME\s*-=\s*)(-?0x[0-9a-fA-F]+);", ';'), // -=
+        (r"(OBJECT->NAME\s*>\s*)(-?0x[0-9a-fA-F]+)\)", ')'), // >
+        (r"(OBJECT->NAME\s*>=\s*)(-?0x[0-9a-fA-F]+)\)", ')'), // >=
+        (r"(OBJECT->NAME\s*<\s*)(-?0x[0-9a-fA-F]+)\)", ')'), // <
+        (r"(OBJECT->NAME\s*<=\s*)(-?0x[0-9a-fA-F]+)\)", ')'), // <=
+        (
+            r"(^.*(?:catan|ccos|csin|rcos|rsin|rtan)\()(-?0x[0-9a-fA-F]+)\)",
+            ')',
+        ), // rsin/rcos/rtan
+        (r"(^.*RotMatrix[XYZ]\()(-?0x[0-9a-fA-F]+),", ','), // RotMatrixX/Y/Z
+    ];
+
+    let objs = ["entity", "g_CurrentEntity", "self"];
+
+    let names = ["rotate"];
+
+    for obj in objs.iter() {
+        for name in names.iter() {
+            for (regex_str, c) in regs.iter() {
+                let temp = regex_str.replace("OBJECT", obj).replace("NAME", name);
+                let regex = Regex::new(&temp).unwrap();
+                let terminal = *c;
+                patterns.push(Pattern { regex, terminal });
+            }
+        }
+    }
+}
+
+fn hex_string_to_float(hex_str: &str) -> Option<f64> {
+    let cleaned_str = hex_str.trim_start_matches("-0x").trim_start_matches("0x");
+    if let Ok(hex_value) = i64::from_str_radix(cleaned_str, 16) {
+        let result = 360.0 * (hex_value as f64 / 4096.0);
+        if hex_str.starts_with('-') {
+            Some(-result)
+        } else {
+            Some(result)
+        }
+    } else {
+        None
+    }
+}
+
+fn transform_line_rotation(line: &str) -> String {
+    for pattern in PATTERNS.iter() {
+        if let Some(thing) = pattern.regex.captures(line) {
+            if let Some(hex_str) = thing.get(2) {
+                if let Some(conv) = hex_string_to_float(hex_str.into()) {
+                    if let Some(group_str) = thing.get(1) {
+                        let rotation_value = rotation(conv, group_str.as_str(), pattern.terminal);
+                        return pattern.regex.replace(line, &rotation_value).to_string();
+                    }
+                }
+            }
+        }
+    }
+    line.to_string()
+}
+
+fn get_regexes() -> Vec<Pattern> {
+    let mut patterns = Vec::new();
+    gen_patterns(&mut patterns);
+    patterns
+}
+
+lazy_static! {
+    static ref PATTERNS: Vec<Pattern> = get_regexes();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_negative() {
+        let input_line = "entity->rotate = -0x800;";
+        let expected_line = "entity->rotate = ROT(-180);";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+
+    #[test]
+    fn test_positive() {
+        let input_line = "entity->rotate = 0x800;";
+        let expected_line = "entity->rotate = ROT(180);";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+
+    #[test]
+    fn test_complex_line() {
+        // don't format
+        let input_line = "entity->rotate += 0x800 - (Random() << 8);";
+        let expected_line = "entity->rotate += 0x800 - (Random() << 8);";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+
+    #[test]
+    fn test_trailing_zero() {
+        let input_line = "if (self->rotate < -0x180) {";
+        let expected_line = "if (self->rotate < ROT(-33.75)) {";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+
+    #[test]
+    fn test_rsin() {
+        let input_line = "foo = rsin(0x1000) * …";
+        let expected_line = "foo = rsin(ROT(360)) * …";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+
+    #[test]
+    fn test_rotmatrix() {
+        let input_line = "m = *RotMatrixX(0x57D, &m);";
+        let expected_line = "m = *RotMatrixX(ROT(123.486328125), &m);";
+        let result = transform_line_rotation(input_line);
+        assert_eq!(result, expected_line);
+    }
+}


### PR DESCRIPTION
Adds a transformer for `Entity.rotation` and constant arguments to several SDK functions (`rsin`, `rcos`, etc.) that take PlayStation format angles (4096 = 360°).

Adds a failing linter for the `ILLEGAL` Entity extension.